### PR TITLE
chore(release): bump version to 1.2.0

### DIFF
--- a/.changeset/free-hats-press.md
+++ b/.changeset/free-hats-press.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-nextfriday": minor
+---
+
+A new ESLint rule `enforce-readonly-component-props` that enforces the use of `Readonly<>` wrapper for React component props when using named types or interfaces. This rule helps prevent accidental mutations of props and makes the immutable nature of React props explicit in the type system.

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ export default [
       "nextfriday/jsx-pascal-case": "error",
       "nextfriday/prefer-interface-over-inline-types": "error",
       "nextfriday/react-props-destructure": "error",
+      "nextfriday/enforce-readonly-component-props": "error",
     },
   },
 ];
@@ -117,6 +118,7 @@ module.exports = {
 | [prefer-interface-over-inline-types](docs/rules/PREFER_INTERFACE_OVER_INLINE_TYPES.md) | Enforce interface declarations over inline types for React props | ❌      |
 | [prefer-react-import-types](docs/rules/PREFER_REACT_IMPORT_TYPES.md)                   | Enforce direct imports from 'react' instead of React.X           | ✅      |
 | [react-props-destructure](docs/rules/REACT_PROPS_DESTRUCTURE.md)                       | Enforce destructuring props inside React component body          | ❌      |
+| [enforce-readonly-component-props](docs/rules/ENFORCE_READONLY_COMPONENT_PROPS.md)     | Enforce Readonly wrapper for React component props               | ✅      |
 
 ## Configurations
 
@@ -148,6 +150,7 @@ Includes all base rules plus React-specific rules:
 - `nextfriday/jsx-pascal-case`: `"error"`
 - `nextfriday/prefer-interface-over-inline-types`: `"error"`
 - `nextfriday/react-props-destructure`: `"error"`
+- `nextfriday/enforce-readonly-component-props`: `"error"`
 
 #### `react/recommended`
 
@@ -163,6 +166,7 @@ Includes all rules suitable for Next.js projects:
 - `nextfriday/jsx-pascal-case`: `"error"`
 - `nextfriday/prefer-interface-over-inline-types`: `"error"`
 - `nextfriday/react-props-destructure`: `"error"`
+- `nextfriday/enforce-readonly-component-props`: `"error"`
 
 #### `nextjs/recommended`
 

--- a/docs/rules/ENFORCE_READONLY_COMPONENT_PROPS.md
+++ b/docs/rules/ENFORCE_READONLY_COMPONENT_PROPS.md
@@ -1,0 +1,104 @@
+# enforce-readonly-component-props
+
+Enforce `Readonly<>` wrapper for React component props when using named types or interfaces.
+
+## Rule Details
+
+This rule enforces that React component props using named types (interfaces or type aliases) must be wrapped with `Readonly<>` for immutability. This helps prevent accidental mutations of props and makes the immutable nature of React props explicit in the type system.
+
+## Examples
+
+### ❌ Incorrect
+
+```tsx
+interface Props {
+  children: ReactNode;
+}
+const Component = (props: Props) => <div>{props.children}</div>;
+```
+
+```tsx
+type ComponentProps = {
+  title: string;
+  onClick: () => void;
+};
+const Component = (props: ComponentProps) => <div>{props.title}</div>;
+```
+
+```tsx
+interface LayoutProps {
+  children: ReactNode;
+  title?: string;
+}
+function Layout(props: LayoutProps) {
+  return <div>{props.children}</div>;
+}
+```
+
+### ✅ Correct
+
+```tsx
+interface Props {
+  children: ReactNode;
+}
+const Component = (props: Readonly<Props>) => <div>{props.children}</div>;
+```
+
+```tsx
+type ComponentProps = {
+  title: string;
+  onClick: () => void;
+};
+const Component = (props: Readonly<ComponentProps>) => <div>{props.title}</div>;
+```
+
+```tsx
+interface LayoutProps {
+  children: ReactNode;
+  title?: string;
+}
+function Layout(props: Readonly<LayoutProps>) {
+  return <div>{props.children}</div>;
+}
+```
+
+```tsx
+// Inline types are handled by prefer-interface-over-inline-types rule
+const Component = (props: { children: ReactNode }) => <div>{props.children}</div>;
+```
+
+```tsx
+// Non-React functions are ignored
+interface HelperProps {
+  value: number;
+}
+const helper = (props: HelperProps) => {
+  return props.value * 2;
+};
+```
+
+## When Not To Use
+
+This rule should not be used if:
+
+- You prefer inline types for component props (use `prefer-interface-over-inline-types` instead)
+- You don't want to enforce immutability patterns in your React components
+- You're working with a codebase that doesn't use TypeScript strict mode
+
+## Fixable
+
+This rule is fixable using ESLint's `--fix` option. The fixer will automatically wrap named types with `Readonly<>`.
+
+## Related Rules
+
+- [`prefer-interface-over-inline-types`](./PREFER_INTERFACE_OVER_INLINE_TYPES.md) - Enforces interface declarations over inline types
+- [`react-props-destructure`](./REACT_PROPS_DESTRUCTURE.md) - Enforces destructuring props inside component body
+
+## Configuration
+
+This rule is included in the following configurations:
+
+- `react` (warn)
+- `react/recommended` (error)
+- `nextjs` (warn)
+- `nextjs/recommended` (error)

--- a/src/__tests__/configs.test.ts
+++ b/src/__tests__/configs.test.ts
@@ -53,6 +53,7 @@ describe("ESLint Plugin Configs", () => {
       expect(reactRules).toHaveProperty("nextfriday/jsx-pascal-case", "warn");
       expect(reactRules).toHaveProperty("nextfriday/prefer-interface-over-inline-types", "warn");
       expect(reactRules).toHaveProperty("nextfriday/react-props-destructure", "warn");
+      expect(reactRules).toHaveProperty("nextfriday/enforce-readonly-component-props", "warn");
       expect(reactRules).toHaveProperty("nextfriday/prefer-destructuring-params", "warn");
       expect(reactRules).toHaveProperty("nextfriday/no-explicit-return-type", "warn");
       expect(reactRules).toHaveProperty("nextfriday/prefer-import-type", "warn");
@@ -80,6 +81,7 @@ describe("ESLint Plugin Configs", () => {
       expect(nextjsRules).toHaveProperty("nextfriday/jsx-pascal-case", "warn");
       expect(nextjsRules).toHaveProperty("nextfriday/prefer-interface-over-inline-types", "warn");
       expect(nextjsRules).toHaveProperty("nextfriday/react-props-destructure", "warn");
+      expect(nextjsRules).toHaveProperty("nextfriday/enforce-readonly-component-props", "warn");
       expect(nextjsRules).toHaveProperty("nextfriday/prefer-destructuring-params", "warn");
       expect(nextjsRules).toHaveProperty("nextfriday/no-explicit-return-type", "warn");
       expect(nextjsRules).toHaveProperty("nextfriday/prefer-import-type", "warn");

--- a/src/__tests__/rules.test.ts
+++ b/src/__tests__/rules.test.ts
@@ -64,8 +64,8 @@ describe("ESLint Plugin Rules", () => {
     expect(typeof rules["md-filename-case-restriction"].create).toBe("function");
   });
 
-  it("should have exactly 10 rules", () => {
-    expect(Object.keys(rules)).toHaveLength(10);
+  it("should have exactly 11 rules", () => {
+    expect(Object.keys(rules)).toHaveLength(11);
   });
 
   it("should have correct rule names", () => {
@@ -80,6 +80,7 @@ describe("ESLint Plugin Rules", () => {
     expect(ruleNames).toContain("prefer-interface-over-inline-types");
     expect(ruleNames).toContain("prefer-react-import-types");
     expect(ruleNames).toContain("react-props-destructure");
+    expect(ruleNames).toContain("enforce-readonly-component-props");
   });
 
   it("should have prefer-interface-over-inline-types rule", () => {
@@ -104,5 +105,13 @@ describe("ESLint Plugin Rules", () => {
     expect(rules["react-props-destructure"]).toHaveProperty("meta");
     expect(rules["react-props-destructure"]).toHaveProperty("create");
     expect(typeof rules["react-props-destructure"].create).toBe("function");
+  });
+
+  it("should have enforce-readonly-component-props rule", () => {
+    expect(rules).toHaveProperty("enforce-readonly-component-props");
+    expect(typeof rules["enforce-readonly-component-props"]).toBe("object");
+    expect(rules["enforce-readonly-component-props"]).toHaveProperty("meta");
+    expect(rules["enforce-readonly-component-props"]).toHaveProperty("create");
+    expect(typeof rules["enforce-readonly-component-props"].create).toBe("function");
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import packageJson from "../package.json" assert { type: "json" };
 
+import enforceReadonlyComponentProps from "./rules/enforce-readonly-component-props";
 import fileKebabCase from "./rules/file-kebab-case";
 import jsxPascalCase from "./rules/jsx-pascal-case";
 import mdFilenameCaseRestriction from "./rules/md-filename-case-restriction";
@@ -19,6 +20,7 @@ const meta = {
 } as const;
 
 const rules = {
+  "enforce-readonly-component-props": enforceReadonlyComponentProps,
   "file-kebab-case": fileKebabCase,
   "jsx-pascal-case": jsxPascalCase,
   "md-filename-case-restriction": mdFilenameCaseRestriction,
@@ -60,12 +62,14 @@ const jsxRules = {
   "nextfriday/jsx-pascal-case": "warn",
   "nextfriday/prefer-interface-over-inline-types": "warn",
   "nextfriday/react-props-destructure": "warn",
+  "nextfriday/enforce-readonly-component-props": "warn",
 } as const;
 
 const jsxRecommendedRules = {
   "nextfriday/jsx-pascal-case": "error",
   "nextfriday/prefer-interface-over-inline-types": "error",
   "nextfriday/react-props-destructure": "error",
+  "nextfriday/enforce-readonly-component-props": "error",
 } as const;
 
 const createConfig = (configRules: Record<string, string>) => ({

--- a/src/rules/__tests__/enforce-readonly-component-props.test.ts
+++ b/src/rules/__tests__/enforce-readonly-component-props.test.ts
@@ -1,0 +1,195 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import { afterAll, describe, it } from "@jest/globals";
+
+import enforceReadonlyComponentProps from "../enforce-readonly-component-props";
+
+RuleTester.afterAll = afterAll;
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parserOptions: {
+      ecmaVersion: 2020,
+      sourceType: "module",
+      ecmaFeatures: {
+        jsx: true,
+      },
+    },
+  },
+});
+
+describe("enforce-readonly-component-props", () => {
+  it("should be defined", () => {
+    expect(enforceReadonlyComponentProps).toBeDefined();
+  });
+
+  ruleTester.run("enforce-readonly-component-props", enforceReadonlyComponentProps, {
+    valid: [
+      {
+        code: `
+          interface Props {
+            children: ReactNode;
+          }
+          const Component = (props: Readonly<Props>) => <div>{props.children}</div>;
+        `,
+      },
+      {
+        code: `
+          type ComponentProps = {
+            title: string;
+            onClick: () => void;
+          };
+          const Component = (props: Readonly<ComponentProps>) => <div>{props.title}</div>;
+        `,
+      },
+      {
+        code: `
+          const Component = (props: { children: ReactNode }) => <div>{props.children}</div>;
+        `,
+      },
+      {
+        code: `
+          interface HelperProps {
+            value: number;
+            name: string;
+          }
+          const helper = (props: HelperProps) => {
+            return props.value + props.name.length;
+          };
+        `,
+      },
+      {
+        code: `
+          const Component = () => <div>Hello</div>;
+        `,
+      },
+      {
+        code: `
+          interface Props {
+            title: string;
+          }
+          const Component = (props: Props, ref: any) => <div>{props.title}</div>;
+        `,
+      },
+      {
+        code: `
+          const Component = (text: string) => <div>{text}</div>;
+        `,
+      },
+    ],
+    invalid: [
+      {
+        code: `
+          interface Props {
+            children: ReactNode;
+          }
+          const Component = (props: Props) => <div>{props.children}</div>;
+        `,
+        output: `
+          interface Props {
+            children: ReactNode;
+          }
+          const Component = (props: Readonly<Props>) => <div>{props.children}</div>;
+        `,
+        errors: [
+          {
+            messageId: "useReadonly",
+          },
+        ],
+      },
+      {
+        code: `
+          type ComponentProps = {
+            title: string;
+            onClick: () => void;
+          };
+          const Component = (props: ComponentProps) => <div>{props.title}</div>;
+        `,
+        output: `
+          type ComponentProps = {
+            title: string;
+            onClick: () => void;
+          };
+          const Component = (props: Readonly<ComponentProps>) => <div>{props.title}</div>;
+        `,
+        errors: [
+          {
+            messageId: "useReadonly",
+          },
+        ],
+      },
+      {
+        code: `
+          interface Props {
+            data: string;
+          }
+          function Component(props: Props) {
+            return <div>{props.data}</div>;
+          }
+        `,
+        output: `
+          interface Props {
+            data: string;
+          }
+          function Component(props: Readonly<Props>) {
+            return <div>{props.data}</div>;
+          }
+        `,
+        errors: [
+          {
+            messageId: "useReadonly",
+          },
+        ],
+      },
+      {
+        code: `
+          type Props = {
+            config: string;
+          };
+          const Component = function(props: Props) {
+            return <div>{props.config}</div>;
+          };
+        `,
+        output: `
+          type Props = {
+            config: string;
+          };
+          const Component = function(props: Readonly<Props>) {
+            return <div>{props.config}</div>;
+          };
+        `,
+        errors: [
+          {
+            messageId: "useReadonly",
+          },
+        ],
+      },
+      {
+        code: `
+          interface LayoutProps {
+            children: ReactNode;
+            title?: string;
+          }
+          const Layout = (props: LayoutProps) => {
+            return props.title ? <div><h1>{props.title}</h1>{props.children}</div> : <div>{props.children}</div>;
+          };
+        `,
+        output: `
+          interface LayoutProps {
+            children: ReactNode;
+            title?: string;
+          }
+          const Layout = (props: Readonly<LayoutProps>) => {
+            return props.title ? <div><h1>{props.title}</h1>{props.children}</div> : <div>{props.children}</div>;
+          };
+        `,
+        errors: [
+          {
+            messageId: "useReadonly",
+          },
+        ],
+      },
+    ],
+  });
+});

--- a/src/rules/enforce-readonly-component-props.ts
+++ b/src/rules/enforce-readonly-component-props.ts
@@ -1,0 +1,116 @@
+import { AST_NODE_TYPES, ESLintUtils } from "@typescript-eslint/utils";
+
+import type { TSESTree } from "@typescript-eslint/utils";
+
+const createRule = ESLintUtils.RuleCreator(
+  (name) => `https://github.com/next-friday/eslint-plugin-nextfriday/blob/main/docs/rules/${name}.md`,
+);
+
+const enforceReadonlyComponentProps = createRule({
+  name: "enforce-readonly-component-props",
+  meta: {
+    type: "suggestion",
+    docs: {
+      description: "Enforce Readonly wrapper for React component props when using named types or interfaces",
+    },
+    fixable: "code",
+    schema: [],
+    messages: {
+      useReadonly: "Component props should be wrapped with Readonly<> for immutability",
+    },
+  },
+  defaultOptions: [],
+  create(context) {
+    function hasJSXInConditional(node: TSESTree.ConditionalExpression): boolean {
+      return (
+        node.consequent.type === AST_NODE_TYPES.JSXElement ||
+        node.consequent.type === AST_NODE_TYPES.JSXFragment ||
+        node.alternate.type === AST_NODE_TYPES.JSXElement ||
+        node.alternate.type === AST_NODE_TYPES.JSXFragment
+      );
+    }
+
+    function hasJSXInLogical(node: TSESTree.LogicalExpression): boolean {
+      return node.right.type === AST_NODE_TYPES.JSXElement || node.right.type === AST_NODE_TYPES.JSXFragment;
+    }
+
+    function hasJSXReturn(block: TSESTree.BlockStatement): boolean {
+      return block.body.some((stmt) => {
+        if (stmt.type === AST_NODE_TYPES.ReturnStatement && stmt.argument) {
+          return (
+            stmt.argument.type === AST_NODE_TYPES.JSXElement ||
+            stmt.argument.type === AST_NODE_TYPES.JSXFragment ||
+            (stmt.argument.type === AST_NODE_TYPES.ConditionalExpression && hasJSXInConditional(stmt.argument)) ||
+            (stmt.argument.type === AST_NODE_TYPES.LogicalExpression && hasJSXInLogical(stmt.argument))
+          );
+        }
+        return false;
+      });
+    }
+
+    function isReactComponent(
+      node: TSESTree.ArrowFunctionExpression | TSESTree.FunctionExpression | TSESTree.FunctionDeclaration,
+    ): boolean {
+      if (node.type === AST_NODE_TYPES.ArrowFunctionExpression) {
+        if (node.body.type === AST_NODE_TYPES.JSXElement || node.body.type === AST_NODE_TYPES.JSXFragment) {
+          return true;
+        }
+        if (node.body.type === AST_NODE_TYPES.BlockStatement) {
+          return hasJSXReturn(node.body);
+        }
+      } else if (node.type === AST_NODE_TYPES.FunctionExpression || node.type === AST_NODE_TYPES.FunctionDeclaration) {
+        if (node.body && node.body.type === AST_NODE_TYPES.BlockStatement) {
+          return hasJSXReturn(node.body);
+        }
+      }
+      return false;
+    }
+
+    function isNamedType(node: TSESTree.TypeNode): boolean {
+      return node.type === AST_NODE_TYPES.TSTypeReference;
+    }
+
+    function isAlreadyReadonly(node: TSESTree.TypeNode): boolean {
+      if (node.type === AST_NODE_TYPES.TSTypeReference && node.typeName) {
+        if (node.typeName.type === AST_NODE_TYPES.Identifier && node.typeName.name === "Readonly") {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    function checkFunction(
+      node: TSESTree.ArrowFunctionExpression | TSESTree.FunctionExpression | TSESTree.FunctionDeclaration,
+    ) {
+      if (!isReactComponent(node)) {
+        return;
+      }
+      if (node.params.length !== 1) {
+        return;
+      }
+      const param = node.params[0];
+      if (param.type === AST_NODE_TYPES.Identifier && param.typeAnnotation) {
+        const { typeAnnotation } = param.typeAnnotation;
+        if (isNamedType(typeAnnotation) && !isAlreadyReadonly(typeAnnotation)) {
+          const { sourceCode } = context;
+          const typeText = sourceCode.getText(typeAnnotation);
+          context.report({
+            node: param.typeAnnotation,
+            messageId: "useReadonly",
+            fix(fixer) {
+              return fixer.replaceText(typeAnnotation, `Readonly<${typeText}>`);
+            },
+          });
+        }
+      }
+    }
+
+    return {
+      ArrowFunctionExpression: checkFunction,
+      FunctionExpression: checkFunction,
+      FunctionDeclaration: checkFunction,
+    };
+  },
+});
+
+export default enforceReadonlyComponentProps;


### PR DESCRIPTION
เข้าใจแล้วครับ! ผมจะเขียนแค่ตาม template ที่มีอยู่:

## Summary

Add new ESLint rule `enforce-readonly-component-props` to enforce `Readonly<>` wrapper for React component props when using named types or interfaces.

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Add `enforce-readonly-component-props` rule implementation
- Add comprehensive test coverage (6 valid, 5 invalid cases)
- Add rule documentation with examples
- Integrate rule into react and nextjs configs
- Add automatic fixer for the rule

## Testing

- [x] Unit tests pass
- [x] Manual testing completed
- [x] Added/updated tests for new functionality

## Pre-merge Checklist

<!-- For maintainers - contributors can ignore this section -->

<details>

<summary>For maintainers</summary>

- [x] Code follows the project's style guidelines
- [x] Self-review of code completed
- [x] All tests pass locally
- [x] ESLint checks pass
- [x] TypeScript compilation successful
- [x] Changeset added (for src/ or docs/ changes)
- [x] Documentation updated (if applicable)
- [ ] Breaking changes documented
- [x] Examples updated (if API changed)
- [x] Commit messages follow conventional commits
- [x] No debug code or console.log statements left
- [x] Performance impact considered

</details>