### PR TITLE
chore(release): bump version to 1.2.1

### DIFF
--- a/.changeset/purple-lies-sort.md
+++ b/.changeset/purple-lies-sort.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-nextfriday": patch
+---
+
+Fixed prefer-destructuring-params rule to only target user-defined functions and skip built-in/library/third-party functions.

--- a/src/rules/__tests__/prefer-destructuring-params.test.ts
+++ b/src/rules/__tests__/prefer-destructuring-params.test.ts
@@ -60,6 +60,18 @@ ruleTester.run("prefer-destructuring-params", preferDestructuringParams, {
       code: `function foo({a: {nested}}, {b}) {}`,
       name: "should allow nested destructuring",
     },
+    {
+      code: `function _internalFunction(param1, param2) {}`,
+      name: "should skip functions starting with underscore",
+    },
+    {
+      code: `function $libraryFunction(param1, param2) {}`,
+      name: "should skip functions containing dollar sign",
+    },
+    {
+      code: `function Component(props, context) {}`,
+      name: "should skip constructor-like functions",
+    },
   ],
   invalid: [
     {

--- a/src/rules/prefer-destructuring-params.ts
+++ b/src/rules/prefer-destructuring-params.ts
@@ -23,6 +23,19 @@ const preferDestructuringParams = createRule({
     const checkFunction = (
       node: TSESTree.FunctionDeclaration | TSESTree.FunctionExpression | TSESTree.ArrowFunctionExpression,
     ) => {
+      const { filename } = context;
+      if (filename.includes("node_modules") || filename.includes(".d.ts")) {
+        return;
+      }
+
+      if (node.type === AST_NODE_TYPES.FunctionDeclaration && node.id) {
+        const functionName = node.id.name;
+
+        if (functionName.startsWith("_") || functionName.includes("$") || /^[A-Z][a-zA-Z]*$/.test(functionName)) {
+          return;
+        }
+      }
+
       if (node.params.length <= 1) {
         return;
       }


### PR DESCRIPTION
## Summary

 Fixed prefer-destructuring-params rule to only target user-defined functions and skip built-in/library/third-party functions.

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

  - Added filename filtering to skip functions in node_modules and .d.ts files
  - Added function name pattern filtering to skip:
    - Functions starting with _ (internal functions)
    - Functions containing $ (library functions)
    - PascalCase functions (Constructor/Component functions)
  - Updated tests to cover the new filtering behavior
  - Fixed deprecated context.getFilename() usage

## Testing

- [X] Unit tests pass
- [X] Manual testing completed
- [X] Added/updated tests for new functionality

## Related Issues

Fixes issue where prefer-destructuring-params rule incorrectly flagged built-in and library functions.

## Pre-merge Checklist

<!-- For maintainers - contributors can ignore this section -->

<details>

<summary>For maintainers</summary>

- [X] Code follows the project's style guidelines
- [X] Self-review of code completed
- [X] All tests pass locally
- [X] ESLint checks pass
- [X] TypeScript compilation successful
- [X] Changeset added (for src/ or docs/ changes)
- [X] Documentation updated (if applicable)
- [X] Breaking changes documented
- [X] Examples updated (if API changed)
- [X] Commit messages follow conventional commits
- [X] No debug code or console.log statements left
- [X] Performance impact considered

</details>
