### PR TITLE
fix(deps): sync pnpm-lock.yaml with package.json

### DIFF
--- a/.changeset/fix-external-plugin-loading.md
+++ b/.changeset/fix-external-plugin-loading.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-nextfriday": patch
+---
+
+Fix CJS compatibility for bundled eslint-plugin-sonarjs and eslint-plugin-unicorn configs.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,8 @@ Git hooks (husky): `pre-commit` runs lint-staged, `pre-push` runs tests + typech
 
 - No comments in code files - keep code self-documenting
 - Use clear, descriptive variable and function names
+- Never add "Generated with Claude Code" or any AI branding/attribution to PR descriptions, commit messages, or any public-facing content
+- No Co-Authored-By trailers in commits (commitlint forbids body/footer anyway)
 
 ## Requirements
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       emoji-regex:
         specifier: ^10.5.0
         version: 10.5.0
+      eslint-plugin-sonarjs:
+        specifier: ^3.0.5
+        version: 3.0.5(eslint@9.39.3(jiti@2.5.1))
       eslint-plugin-unicorn:
         specifier: ^63.0.0
         version: 63.0.0(eslint@9.39.3(jiti@2.5.1))
@@ -87,9 +90,6 @@ importers:
       eslint-plugin-prettier:
         specifier: ^5.5.4
         version: 5.5.4(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@9.39.3(jiti@2.5.1)))(eslint@9.39.3(jiti@2.5.1))(prettier@3.6.2)
-      eslint-plugin-sonarjs:
-        specifier: ^3.0.5
-        version: 3.0.5(eslint@9.39.3(jiti@2.5.1))
       husky:
         specifier: ^9.1.7
         version: 9.1.7


### PR DESCRIPTION
## Summary
- Fix `pnpm-lock.yaml` out of sync with `package.json` after `eslint-plugin-sonarjs` was moved from devDependencies to dependencies
- This caused the Release workflow to fail with `ERR_PNPM_OUTDATED_LOCKFILE`

## Test plan
- [x] `pnpm install --frozen-lockfile` succeeds
- [x] All 1070 tests pass
- [x] Typecheck passes
- [x] Build succeeds