### PR TITLE
docs(rules): add fixable info and bundled configs

### DIFF
--- a/.changeset/update-docs-fixable-bundled.md
+++ b/.changeset/update-docs-fixable-bundled.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-nextfriday": patch
+---
+
+Update docs: add fixable info to sorting rules, add bundled plugin configs section to README.

--- a/README.md
+++ b/README.md
@@ -46,6 +46,21 @@ export default [nextfriday.configs.nextjs];
 export default [nextfriday.configs["nextjs/recommended"]];
 ```
 
+#### Bundled Plugin Configs
+
+Pre-configured configs for popular plugins. No extra install needed — they ship as dependencies.
+
+```js
+import nextfriday from "eslint-plugin-nextfriday";
+
+export default [nextfriday.configs["react/recommended"], ...nextfriday.configs.sonarjs, ...nextfriday.configs.unicorn];
+```
+
+| Config    | Plugin                | Description                                                                                                |
+| --------- | --------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `sonarjs` | eslint-plugin-sonarjs | SonarJS recommended rules for bug detection and code quality                                               |
+| `unicorn` | eslint-plugin-unicorn | Unicorn recommended rules (with `filename-case` and `prevent-abbreviations` off, `no-null` off in JSX/TSX) |
+
 ### Manual Configuration
 
 If you prefer to configure rules manually:
@@ -184,7 +199,7 @@ module.exports = {
 | [no-logic-in-params](docs/rules/NO_LOGIC_IN_PARAMS.md)                       | Disallow logic/conditions in function parameters - extract to const    | ❌      |
 | [enforce-hook-naming](docs/rules/ENFORCE_HOOK_NAMING.md)                     | Enforce 'use' prefix for functions in \*.hook.ts files                 | ❌      |
 | [enforce-service-naming](docs/rules/ENFORCE_SERVICE_NAMING.md)               | Enforce 'fetch' prefix for async functions in \*.service.ts files      | ❌      |
-| [enforce-sorted-destructuring](docs/rules/ENFORCE_SORTED_DESTRUCTURING.md)   | Enforce alphabetical sorting of destructured properties                | ❌      |
+| [enforce-sorted-destructuring](docs/rules/ENFORCE_SORTED_DESTRUCTURING.md)   | Enforce alphabetical sorting of destructured properties                | ✅      |
 | [no-env-fallback](docs/rules/NO_ENV_FALLBACK.md)                             | Disallow fallback values for environment variables                     | ❌      |
 | [no-inline-default-export](docs/rules/NO_INLINE_DEFAULT_EXPORT.md)           | Disallow inline default exports - declare first, then export           | ❌      |
 | [no-direct-date](docs/rules/NO_DIRECT_DATE.md)                               | Disallow direct usage of Date constructor and methods                  | ❌      |
@@ -203,8 +218,8 @@ module.exports = {
 | [no-relative-imports](docs/rules/NO_RELATIVE_IMPORTS.md)             | Disallow relative imports with ../ - use absolute imports | ❌      |
 | [prefer-import-type](docs/rules/PREFER_IMPORT_TYPE.md)               | Enforce using 'import type' for type-only imports         | ✅      |
 | [prefer-react-import-types](docs/rules/PREFER_REACT_IMPORT_TYPES.md) | Enforce direct imports from 'react' instead of React.X    | ✅      |
-| [sort-exports](docs/rules/SORT_EXPORTS.md)                           | Enforce a consistent ordering of export groups            | ❌      |
-| [sort-imports](docs/rules/SORT_IMPORTS.md)                           | Enforce a consistent ordering of import groups            | ❌      |
+| [sort-exports](docs/rules/SORT_EXPORTS.md)                           | Enforce a consistent ordering of export groups            | ✅      |
+| [sort-imports](docs/rules/SORT_IMPORTS.md)                           | Enforce a consistent ordering of import groups            | ✅      |
 
 ### Type Pattern Rules
 
@@ -212,8 +227,8 @@ module.exports = {
 | -------------------------------------------------------------------------------------- | ---------------------------------------------------------------- | ------- |
 | [prefer-named-param-types](docs/rules/PREFER_NAMED_PARAM_TYPES.md)                     | Enforce named types for function parameters with object types    | ❌      |
 | [prefer-interface-over-inline-types](docs/rules/PREFER_INTERFACE_OVER_INLINE_TYPES.md) | Enforce interface declarations over inline types for React props | ❌      |
-| [sort-type-alphabetically](docs/rules/SORT_TYPE_ALPHABETICALLY.md)                     | Enforce A-Z sorting of properties within type groups             | ❌      |
-| [sort-type-required-first](docs/rules/SORT_TYPE_REQUIRED_FIRST.md)                     | Enforce required properties before optional in types/interfaces  | ❌      |
+| [sort-type-alphabetically](docs/rules/SORT_TYPE_ALPHABETICALLY.md)                     | Enforce A-Z sorting of properties within type groups             | ✅      |
+| [sort-type-required-first](docs/rules/SORT_TYPE_REQUIRED_FIRST.md)                     | Enforce required properties before optional in types/interfaces  | ✅      |
 
 ### React/JSX Rules
 

--- a/docs/rules/ENFORCE_SORTED_DESTRUCTURING.md
+++ b/docs/rules/ENFORCE_SORTED_DESTRUCTURING.md
@@ -2,6 +2,8 @@
 
 Enforce alphabetical sorting of destructured properties with defaults first.
 
+This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
+
 ## Rule Details
 
 This rule enforces that object destructuring properties are sorted alphabetically, with properties that have default values coming first. Both groups (defaults and non-defaults) are sorted alphabetically (A-Z).

--- a/docs/rules/SORT_EXPORTS.md
+++ b/docs/rules/SORT_EXPORTS.md
@@ -2,6 +2,8 @@
 
 Enforce a consistent ordering of export groups.
 
+This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
+
 ## Rule Details
 
 This rule enforces that named export statements (without declarations) are grouped and ordered by their source type. It does not enforce alphabetical sorting within groups.

--- a/docs/rules/SORT_IMPORTS.md
+++ b/docs/rules/SORT_IMPORTS.md
@@ -2,6 +2,8 @@
 
 Enforce a consistent ordering of import groups.
 
+This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
+
 ## Rule Details
 
 This rule enforces that import statements are grouped and ordered by their source type. It does not enforce alphabetical sorting within groups.

--- a/docs/rules/SORT_TYPE_ALPHABETICALLY.md
+++ b/docs/rules/SORT_TYPE_ALPHABETICALLY.md
@@ -2,6 +2,8 @@
 
 Enforce alphabetical sorting of properties within required and optional groups in TypeScript interfaces and type aliases.
 
+This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
+
 ## Rule Details
 
 This rule enforces that TypeScript interface and type alias properties are sorted alphabetically (A-Z) within their respective groups (required and optional). It checks each group independently.

--- a/docs/rules/SORT_TYPE_REQUIRED_FIRST.md
+++ b/docs/rules/SORT_TYPE_REQUIRED_FIRST.md
@@ -2,6 +2,8 @@
 
 Enforce required properties come before optional properties in TypeScript interfaces and type aliases.
 
+This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
+
 ## Rule Details
 
 This rule enforces that TypeScript interface and type alias required (non-optional) properties come before optional properties.


### PR DESCRIPTION
## Summary
- Add fixable (`--fix`) info to 5 rule docs: sort-imports, sort-exports, enforce-sorted-destructuring, sort-type-alphabetically, sort-type-required-first
- Update README fixable column for the same 5 rules
- Add bundled plugin configs section to README (sonarjs, unicorn)

## Test plan
- [x] Docs-only change, all tests pass
- [x] Build and typecheck pass