### PR TITLE
fix(rules): skip non-element children in adjacency check

### DIFF
--- a/.changeset/fix-jsx-no-newline-expression.md
+++ b/.changeset/fix-jsx-no-newline-expression.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-nextfriday": patch
+---
+
+Fix jsx-no-newline-single-line-elements false positive when JSX expressions (e.g. {children}) appear between elements.

--- a/src/rules/__tests__/jsx-no-newline-single-line-elements.test.ts
+++ b/src/rules/__tests__/jsx-no-newline-single-line-elements.test.ts
@@ -106,6 +106,27 @@ describe("jsx-no-newline-single-line-elements", () => {
         `,
         name: "single child element",
       },
+      {
+        code: `
+          <div>
+            <Headerstrip />
+            <Header />
+            {children}
+            <Footer />
+          </div>
+        `,
+        name: "expression between elements breaks adjacency",
+      },
+      {
+        code: `
+          <div>
+            <Header />
+            {isLoading && <Spinner />}
+            <Footer />
+          </div>
+        `,
+        name: "conditional expression between elements breaks adjacency",
+      },
     ],
     invalid: [
       {

--- a/src/rules/jsx-no-newline-single-line-elements.ts
+++ b/src/rules/jsx-no-newline-single-line-elements.ts
@@ -33,16 +33,20 @@ const jsxNoNewlineSingleLineElements = createRule({
     const { sourceCode } = context;
 
     function checkSiblings(children: TSESTree.JSXChild[]): void {
-      const jsxElements = children.filter((child): child is TSESTree.JSXElement | TSESTree.JSXFragment =>
-        isJSXElementOrFragment(child),
+      const nonWhitespace = children.filter(
+        (child) => !(child.type === AST_NODE_TYPES.JSXText && child.value.trim() === ""),
       );
 
-      jsxElements.forEach((next, index) => {
+      nonWhitespace.forEach((next, index) => {
         if (index === 0) {
           return;
         }
 
-        const current = jsxElements[index - 1];
+        const current = nonWhitespace[index - 1];
+
+        if (!isJSXElementOrFragment(current) || !isJSXElementOrFragment(next)) {
+          return;
+        }
 
         if (!isSingleLine(current) || !isSingleLine(next)) {
           return;


### PR DESCRIPTION
## Summary
- Fix `jsx-no-newline-single-line-elements` false positive when JSX expressions (`{children}`, `{isLoading && <Spinner />}`) appear between sibling elements
- The rule was filtering out all non-element children before checking adjacency, causing it to treat elements separated by expressions as adjacent

## Test plan
- [x] Added 2 valid test cases for expressions between elements
- [x] All 1072 tests pass
- [x] Typecheck and build pass