### PR TITLE
feat(rules): add three new type pattern rules

### DIFF
--- a/.changeset/three-new-type-rules.md
+++ b/.changeset/three-new-type-rules.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-nextfriday": minor
+---
+
+feat(rules): add prefer-inline-literal-union, no-nested-interface-declaration, and enforce-type-declaration-order rules

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,8 +24,8 @@ pnpm changeset           # Create a changeset for version bumping
 `src/index.ts` - Main plugin export containing:
 
 - `meta` - Plugin name and version from package.json
-- `rules` - All 42 rule implementations keyed by hyphenated name
-- `configs` - Six configuration presets generated via `createConfig()`
+- `rules` - All 51 rule implementations keyed by hyphenated name
+- `configs` - Eight configuration presets (six nextfriday presets via `createConfig()`, plus lazy `sonarjs` and `unicorn` getters that wrap external plugins)
 
 The plugin is exported both as default and as named exports `{ meta, configs, rules }`.
 
@@ -39,13 +39,15 @@ All rules use `schema: []` and `defaultOptions: []` (no configurable options).
 
 ### Configuration Presets
 
-Six configs built from three rule set tiers. Each tier has a `warn` variant and a `Recommended` (`error`) variant defined as separate constants in `src/index.ts` (e.g., `baseRules`/`baseRecommendedRules`, `jsxRules`/`jsxRecommendedRules`, `nextjsOnlyRules`/`nextjsOnlyRecommendedRules`).
+Eight configs total. Six nextfriday presets built from three rule set tiers, each with a `warn` variant and a `Recommended` (`error`) variant defined as separate constants in `src/index.ts` (e.g., `baseRules`/`baseRecommendedRules`, `jsxRules`/`jsxRecommendedRules`, `nextjsOnlyRules`/`nextjsOnlyRecommendedRules`). Two additional configs (`sonarjs`, `unicorn`) are lazy getters wrapping external plugins.
 
-| Preset                          | Rules                       | Severity     |
-| ------------------------------- | --------------------------- | ------------ |
-| `base` / `base/recommended`     | 29 base                     | warn / error |
-| `react` / `react/recommended`   | 29 base + 12 JSX            | warn / error |
-| `nextjs` / `nextjs/recommended` | 29 base + 12 JSX + 1 nextjs | warn / error |
+| Preset                          | Rules                             | Severity     |
+| ------------------------------- | --------------------------------- | ------------ |
+| `base` / `base/recommended`     | 36 base                           | warn / error |
+| `react` / `react/recommended`   | 36 base + 14 JSX                  | warn / error |
+| `nextjs` / `nextjs/recommended` | 36 base + 14 JSX + 1 nextjs       | warn / error |
+| `sonarjs`                       | eslint-plugin-sonarjs recommended | -            |
+| `unicorn`                       | eslint-plugin-unicorn recommended | -            |
 
 ### Utilities
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,10 @@ export default [
       "nextfriday/sort-imports": "error",
 
       // Type Patterns
+      "nextfriday/enforce-type-declaration-order": "error",
+      "nextfriday/no-nested-interface-declaration": "error",
       "nextfriday/prefer-named-param-types": "error",
+      "nextfriday/prefer-inline-literal-union": "error",
       "nextfriday/prefer-interface-over-inline-types": "error",
       "nextfriday/sort-type-alphabetically": "error",
       "nextfriday/sort-type-required-first": "error",
@@ -225,7 +228,10 @@ module.exports = {
 
 | Rule                                                                                   | Description                                                      | Fixable |
 | -------------------------------------------------------------------------------------- | ---------------------------------------------------------------- | ------- |
+| [enforce-type-declaration-order](docs/rules/ENFORCE_TYPE_DECLARATION_ORDER.md)         | Enforce referenced types are declared after their consumer       | ❌      |
+| [no-nested-interface-declaration](docs/rules/NO_NESTED_INTERFACE_DECLARATION.md)       | Disallow inline object types in interface/type properties        | ❌      |
 | [prefer-named-param-types](docs/rules/PREFER_NAMED_PARAM_TYPES.md)                     | Enforce named types for function parameters with object types    | ❌      |
+| [prefer-inline-literal-union](docs/rules/PREFER_INLINE_LITERAL_UNION.md)               | Enforce inlining literal union types for better IDE hover info   | ✅      |
 | [prefer-interface-over-inline-types](docs/rules/PREFER_INTERFACE_OVER_INLINE_TYPES.md) | Enforce interface declarations over inline types for React props | ❌      |
 | [sort-type-alphabetically](docs/rules/SORT_TYPE_ALPHABETICALLY.md)                     | Enforce A-Z sorting of properties within type groups             | ✅      |
 | [sort-type-required-first](docs/rules/SORT_TYPE_REQUIRED_FIRST.md)                     | Enforce required properties before optional in types/interfaces  | ✅      |
@@ -259,14 +265,14 @@ module.exports = {
 
 | Preset               | Severity | Base Rules | JSX Rules | Next.js Rules | Total Rules |
 | -------------------- | -------- | ---------- | --------- | ------------- | ----------- |
-| `base`               | warn     | 33         | 0         | 0             | 33          |
-| `base/recommended`   | error    | 33         | 0         | 0             | 33          |
-| `react`              | warn     | 33         | 14        | 0             | 47          |
-| `react/recommended`  | error    | 33         | 14        | 0             | 47          |
-| `nextjs`             | warn     | 33         | 14        | 1             | 48          |
-| `nextjs/recommended` | error    | 33         | 14        | 1             | 48          |
+| `base`               | warn     | 36         | 0         | 0             | 36          |
+| `base/recommended`   | error    | 36         | 0         | 0             | 36          |
+| `react`              | warn     | 36         | 14        | 0             | 50          |
+| `react/recommended`  | error    | 36         | 14        | 0             | 50          |
+| `nextjs`             | warn     | 36         | 14        | 1             | 51          |
+| `nextjs/recommended` | error    | 36         | 14        | 1             | 51          |
 
-### Base Configuration Rules (33 rules)
+### Base Configuration Rules (36 rules)
 
 Included in `base`, `base/recommended`, and all other presets:
 
@@ -276,6 +282,7 @@ Included in `base`, `base/recommended`, and all other presets:
 - `nextfriday/enforce-hook-naming`
 - `nextfriday/enforce-service-naming`
 - `nextfriday/enforce-sorted-destructuring`
+- `nextfriday/enforce-type-declaration-order`
 - `nextfriday/file-kebab-case`
 - `nextfriday/md-filename-case-restriction`
 - `nextfriday/newline-after-multiline-block`
@@ -288,6 +295,7 @@ Included in `base`, `base/recommended`, and all other presets:
 - `nextfriday/no-inline-nested-object`
 - `nextfriday/no-lazy-identifiers`
 - `nextfriday/no-logic-in-params`
+- `nextfriday/no-nested-interface-declaration`
 - `nextfriday/no-nested-ternary`
 - `nextfriday/no-relative-imports`
 - `nextfriday/no-single-char-variables`
@@ -296,6 +304,7 @@ Included in `base`, `base/recommended`, and all other presets:
 - `nextfriday/prefer-function-declaration`
 - `nextfriday/prefer-guard-clause`
 - `nextfriday/prefer-import-type`
+- `nextfriday/prefer-inline-literal-union`
 - `nextfriday/prefer-named-param-types`
 - `nextfriday/prefer-react-import-types`
 - `nextfriday/require-explicit-return-type`

--- a/docs/rules/ENFORCE_TYPE_DECLARATION_ORDER.md
+++ b/docs/rules/ENFORCE_TYPE_DECLARATION_ORDER.md
@@ -1,0 +1,87 @@
+# enforce-type-declaration-order
+
+Enforce that referenced types and interfaces are declared after the type that uses them.
+
+## Rule Details
+
+This rule enforces a top-down reading order for type declarations. When an interface or type references another locally-declared type, the referenced (dependency) type must appear _after_ the consumer. This ensures the "main" type is read first, with its supporting types following below.
+
+### Why?
+
+1. **Top-down readability**: The primary type appears first, making it easy to understand the high-level structure before drilling into details
+2. **Consistency**: A uniform ordering convention eliminates debates about where to place types
+3. **Natural flow**: Mirrors how you'd explain a data structure - start with the big picture, then define the parts
+
+## Examples
+
+### Incorrect
+
+```ts
+// Dependency declared before consumer
+interface Baz {
+  baz: string;
+}
+
+interface Foo {
+  bar: Baz;
+}
+```
+
+```ts
+type Config = {
+  theme: string;
+};
+
+type Props = {
+  config: Config;
+};
+```
+
+### Correct
+
+```ts
+// Consumer first, dependency after
+interface Foo {
+  bar: Baz;
+}
+
+interface Baz {
+  baz: string;
+}
+```
+
+```ts
+type Props = {
+  config: Config;
+};
+
+type Config = {
+  theme: string;
+};
+```
+
+```ts
+// Chain of dependencies in top-down order
+interface Parent {
+  child: Child;
+}
+
+interface Child {
+  grandchild: Grandchild;
+}
+
+interface Grandchild {
+  value: string;
+}
+```
+
+```ts
+// External/imported types are ignored (not locally declared)
+interface Props {
+  items: ExternalType[];
+}
+```
+
+## When Not To Use It
+
+If you prefer declaring dependency types before the types that reference them (bottom-up order), or if you don't want to enforce any particular declaration order, you can disable this rule.

--- a/docs/rules/NO_NESTED_INTERFACE_DECLARATION.md
+++ b/docs/rules/NO_NESTED_INTERFACE_DECLARATION.md
@@ -1,0 +1,102 @@
+# no-nested-interface-declaration
+
+Disallow inline object type literals in interface or type properties.
+
+## Rule Details
+
+This rule flags inline object type literals nested inside interface or type properties. Nested object types should be extracted into separate named interfaces or type declarations for clarity and reusability.
+
+### Why?
+
+1. **Readability**: Deeply nested inline types make interfaces harder to scan
+2. **Reusability**: Extracted types can be imported and reused across files
+3. **Maintainability**: Flat, named types are easier to modify and extend
+4. **IDE experience**: Named types provide better hover information and navigation
+
+## Examples
+
+### Incorrect
+
+```ts
+interface Foo {
+  bar: {
+    baz: string;
+  };
+}
+```
+
+```ts
+interface Props {
+  user: {
+    name: string;
+    age: number;
+  };
+}
+```
+
+```ts
+interface Props {
+  items: {
+    id: number;
+    label: string;
+  }[];
+}
+```
+
+```ts
+interface Props {
+  data: Readonly<{
+    id: number;
+    name: string;
+  }>;
+}
+```
+
+### Correct
+
+```ts
+interface Bar {
+  baz: string;
+}
+
+interface Foo {
+  bar: Bar;
+}
+```
+
+```ts
+interface User {
+  name: string;
+  age: number;
+}
+
+interface Props {
+  user: User;
+}
+```
+
+```ts
+interface Item {
+  id: number;
+  label: string;
+}
+
+interface Props {
+  items: Item[];
+}
+```
+
+```ts
+// Primitive and simple types are fine inline
+interface Props {
+  name: string;
+  age: number;
+  isActive: boolean;
+  ids: string[];
+  callback: () => void;
+}
+```
+
+## When Not To Use It
+
+If you prefer keeping small object types inline within interfaces for co-location, you can disable this rule.

--- a/docs/rules/PREFER_INLINE_LITERAL_UNION.md
+++ b/docs/rules/PREFER_INLINE_LITERAL_UNION.md
@@ -1,0 +1,87 @@
+# prefer-inline-literal-union
+
+Enforce inlining literal union types in interface properties instead of using type aliases for better IDE hover information.
+
+This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
+
+## Rule Details
+
+This rule detects type aliases that are unions of only literal values (strings, numbers, booleans, null, undefined) and flags their usage in interface or type properties. The fix inlines the union directly into the property type annotation.
+
+### Why?
+
+When you hover over a prop in your IDE, a type alias shows the alias name (e.g., `ArticleFaqCategoryId`) instead of the actual values (`"articles" | "dharma" | "faq"`). Inlining literal unions gives immediate visibility into the allowed values without needing to jump to the type definition.
+
+## Examples
+
+### Incorrect
+
+```ts
+type ArticleFaqCategoryId = "articles" | "dharma" | "faq";
+
+interface ArticleFaqCategoryFilterProps {
+  activeCategoryId?: ArticleFaqCategoryId;
+}
+```
+
+```ts
+type Status = "loading" | "success" | "error";
+
+interface Props {
+  status: Status;
+}
+```
+
+```ts
+type Size = 1 | 2 | 3 | 4;
+
+interface Props {
+  size: Size;
+}
+```
+
+### Correct
+
+```ts
+interface ArticleFaqCategoryFilterProps {
+  activeCategoryId?: "articles" | "dharma" | "faq";
+}
+```
+
+```ts
+interface Props {
+  status: "loading" | "success" | "error";
+}
+```
+
+```ts
+interface Props {
+  size: 1 | 2 | 3 | 4;
+}
+```
+
+```ts
+// Non-literal unions are allowed as type aliases
+type User = { name: string; age: number };
+
+interface Props {
+  user: User;
+}
+```
+
+```ts
+// Using the alias outside of interface properties is fine
+type Status = "loading" | "success" | "error";
+function getStatus(s: Status): string {
+  return s;
+}
+```
+
+## When Not To Use It
+
+If you prefer using type aliases for literal unions (e.g., for reuse across multiple interfaces or for self-documenting code), you can disable this rule.
+
+## Further Reading
+
+- [TypeScript Union Types](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#union-types)
+- [TypeScript Literal Types](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types)

--- a/src/__tests__/rules.test.ts
+++ b/src/__tests__/rules.test.ts
@@ -96,8 +96,8 @@ describe("ESLint Plugin Rules", () => {
     expect(typeof rules["no-env-fallback"].create).toBe("function");
   });
 
-  it("should have exactly 48 rules", () => {
-    expect(Object.keys(rules)).toHaveLength(48);
+  it("should have exactly 51 rules", () => {
+    expect(Object.keys(rules)).toHaveLength(51);
   });
 
   it("should have correct rule names", () => {
@@ -150,6 +150,9 @@ describe("ESLint Plugin Rules", () => {
     expect(ruleNames).toContain("sort-imports");
     expect(ruleNames).toContain("sort-type-alphabetically");
     expect(ruleNames).toContain("sort-type-required-first");
+    expect(ruleNames).toContain("prefer-inline-literal-union");
+    expect(ruleNames).toContain("no-nested-interface-declaration");
+    expect(ruleNames).toContain("enforce-type-declaration-order");
   });
 
   it("should have prefer-interface-over-inline-types rule", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import enforcePropsSuffix from "./rules/enforce-props-suffix";
 import enforceReadonlyComponentProps from "./rules/enforce-readonly-component-props";
 import enforceServiceNaming from "./rules/enforce-service-naming";
 import enforceSortedDestructuring from "./rules/enforce-sorted-destructuring";
+import enforceTypeDeclarationOrder from "./rules/enforce-type-declaration-order";
 import fileKebabCase from "./rules/file-kebab-case";
 import jsxNewlineBetweenElements from "./rules/jsx-newline-between-elements";
 import jsxNoInlineObjectProp from "./rules/jsx-no-inline-object-prop";
@@ -30,6 +31,7 @@ import noInlineNestedObject from "./rules/no-inline-nested-object";
 import requireExplicitReturnType from "./rules/require-explicit-return-type";
 import jsxNoNonComponentFunction from "./rules/jsx-no-non-component-function";
 import noLogicInParams from "./rules/no-logic-in-params";
+import noNestedInterfaceDeclaration from "./rules/no-nested-interface-declaration";
 import noNestedTernary from "./rules/no-nested-ternary";
 import newlineAfterMultilineBlock from "./rules/newline-after-multiline-block";
 import newlineBeforeReturn from "./rules/newline-before-return";
@@ -41,6 +43,7 @@ import preferDestructuringParams from "./rules/prefer-destructuring-params";
 import preferFunctionDeclaration from "./rules/prefer-function-declaration";
 import preferGuardClause from "./rules/prefer-guard-clause";
 import preferImportType from "./rules/prefer-import-type";
+import preferInlineLiteralUnion from "./rules/prefer-inline-literal-union";
 import preferInterfaceOverInlineTypes from "./rules/prefer-interface-over-inline-types";
 import preferJSXTemplateLiterals from "./rules/prefer-jsx-template-literals";
 import preferNamedParamTypes from "./rules/prefer-named-param-types";
@@ -73,6 +76,7 @@ const rules = {
   "enforce-readonly-component-props": enforceReadonlyComponentProps,
   "enforce-service-naming": enforceServiceNaming,
   "enforce-sorted-destructuring": enforceSortedDestructuring,
+  "enforce-type-declaration-order": enforceTypeDeclarationOrder,
   "file-kebab-case": fileKebabCase,
   "jsx-newline-between-elements": jsxNewlineBetweenElements,
   "jsx-no-inline-object-prop": jsxNoInlineObjectProp,
@@ -95,6 +99,7 @@ const rules = {
   "require-explicit-return-type": requireExplicitReturnType,
   "no-lazy-identifiers": noLazyIdentifiers,
   "no-logic-in-params": noLogicInParams,
+  "no-nested-interface-declaration": noNestedInterfaceDeclaration,
   "no-nested-ternary": noNestedTernary,
   "no-relative-imports": noRelativeImports,
   "no-single-char-variables": noSingleCharVariables,
@@ -103,6 +108,7 @@ const rules = {
   "prefer-function-declaration": preferFunctionDeclaration,
   "prefer-guard-clause": preferGuardClause,
   "prefer-import-type": preferImportType,
+  "prefer-inline-literal-union": preferInlineLiteralUnion,
   "prefer-interface-over-inline-types": preferInterfaceOverInlineTypes,
   "prefer-jsx-template-literals": preferJSXTemplateLiterals,
   "prefer-named-param-types": preferNamedParamTypes,
@@ -128,6 +134,7 @@ const baseRules = {
   "nextfriday/enforce-hook-naming": "warn",
   "nextfriday/enforce-service-naming": "warn",
   "nextfriday/enforce-sorted-destructuring": "warn",
+  "nextfriday/enforce-type-declaration-order": "warn",
   "nextfriday/file-kebab-case": "warn",
   "nextfriday/md-filename-case-restriction": "warn",
   "nextfriday/newline-after-multiline-block": "warn",
@@ -137,11 +144,13 @@ const baseRules = {
   "nextfriday/prefer-guard-clause": "warn",
   "nextfriday/require-explicit-return-type": "warn",
   "nextfriday/prefer-import-type": "warn",
+  "nextfriday/prefer-inline-literal-union": "warn",
   "nextfriday/prefer-named-param-types": "warn",
   "nextfriday/prefer-react-import-types": "warn",
   "nextfriday/no-complex-inline-return": "warn",
   "nextfriday/no-direct-date": "warn",
   "nextfriday/no-logic-in-params": "warn",
+  "nextfriday/no-nested-interface-declaration": "warn",
   "nextfriday/no-nested-ternary": "warn",
   "nextfriday/no-env-fallback": "warn",
   "nextfriday/no-inline-default-export": "warn",
@@ -164,6 +173,7 @@ const baseRecommendedRules = {
   "nextfriday/enforce-hook-naming": "error",
   "nextfriday/enforce-service-naming": "error",
   "nextfriday/enforce-sorted-destructuring": "error",
+  "nextfriday/enforce-type-declaration-order": "error",
   "nextfriday/file-kebab-case": "error",
   "nextfriday/md-filename-case-restriction": "error",
   "nextfriday/newline-after-multiline-block": "error",
@@ -173,11 +183,13 @@ const baseRecommendedRules = {
   "nextfriday/prefer-guard-clause": "error",
   "nextfriday/require-explicit-return-type": "error",
   "nextfriday/prefer-import-type": "error",
+  "nextfriday/prefer-inline-literal-union": "error",
   "nextfriday/prefer-named-param-types": "error",
   "nextfriday/prefer-react-import-types": "error",
   "nextfriday/no-complex-inline-return": "error",
   "nextfriday/no-direct-date": "error",
   "nextfriday/no-logic-in-params": "error",
+  "nextfriday/no-nested-interface-declaration": "error",
   "nextfriday/no-nested-ternary": "error",
   "nextfriday/no-env-fallback": "error",
   "nextfriday/no-inline-default-export": "error",

--- a/src/rules/__tests__/enforce-type-declaration-order.test.ts
+++ b/src/rules/__tests__/enforce-type-declaration-order.test.ts
@@ -1,0 +1,206 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import { afterAll, describe, it } from "@jest/globals";
+
+import enforceTypeDeclarationOrder from "../enforce-type-declaration-order";
+
+RuleTester.afterAll = afterAll;
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parserOptions: {
+      ecmaVersion: 2020,
+      sourceType: "module",
+    },
+  },
+});
+
+describe("enforce-type-declaration-order", () => {
+  it("should have meta property", () => {
+    expect(enforceTypeDeclarationOrder.meta).toBeDefined();
+  });
+
+  it("should have create method", () => {
+    expect(typeof enforceTypeDeclarationOrder.create).toBe("function");
+  });
+
+  ruleTester.run("enforce-type-declaration-order", enforceTypeDeclarationOrder, {
+    valid: [
+      {
+        code: `
+          interface Foo {
+            bar: Baz;
+          }
+          interface Baz {
+            baz: string;
+          }
+        `,
+      },
+      {
+        code: `
+          interface Parent {
+            child: Child;
+          }
+          interface Child {
+            grandchild: Grandchild;
+          }
+          interface Grandchild {
+            value: string;
+          }
+        `,
+      },
+      {
+        code: `
+          type Props = {
+            config: Config;
+          };
+          type Config = {
+            theme: string;
+          };
+        `,
+      },
+      {
+        code: `
+          interface Props {
+            name: string;
+            age: number;
+          }
+        `,
+      },
+      {
+        code: `
+          interface Props {
+            items: ExternalType[];
+          }
+        `,
+      },
+      {
+        code: `
+          interface Props {
+            data: Readonly<Item>;
+          }
+          interface Item {
+            id: number;
+          }
+        `,
+      },
+      {
+        code: `
+          interface Foo {
+            bar: string;
+          }
+          interface Baz {
+            qux: string;
+          }
+        `,
+      },
+    ],
+    invalid: [
+      {
+        code: `
+          interface Baz {
+            baz: string;
+          }
+          interface Foo {
+            bar: Baz;
+          }
+        `,
+        errors: [
+          {
+            messageId: "dependencyBeforeConsumer",
+            data: { dependency: "Baz", consumer: "Foo" },
+          },
+        ],
+      },
+      {
+        code: `
+          type Config = {
+            theme: string;
+          };
+          type Props = {
+            config: Config;
+          };
+        `,
+        errors: [
+          {
+            messageId: "dependencyBeforeConsumer",
+            data: { dependency: "Config", consumer: "Props" },
+          },
+        ],
+      },
+      {
+        code: `
+          interface Child {
+            value: string;
+          }
+          interface Parent {
+            child: Child;
+          }
+        `,
+        errors: [
+          {
+            messageId: "dependencyBeforeConsumer",
+            data: { dependency: "Child", consumer: "Parent" },
+          },
+        ],
+      },
+      {
+        code: `
+          interface Item {
+            id: number;
+          }
+          interface Props {
+            data: Readonly<Item>;
+          }
+        `,
+        errors: [
+          {
+            messageId: "dependencyBeforeConsumer",
+            data: { dependency: "Item", consumer: "Props" },
+          },
+        ],
+      },
+      {
+        code: `
+          interface A {
+            value: string;
+          }
+          interface B {
+            value: number;
+          }
+          interface C {
+            a: A;
+            b: B;
+          }
+        `,
+        errors: [
+          {
+            messageId: "dependencyBeforeConsumer",
+            data: { dependency: "A", consumer: "C" },
+          },
+          {
+            messageId: "dependencyBeforeConsumer",
+            data: { dependency: "B", consumer: "C" },
+          },
+        ],
+      },
+      {
+        code: `
+          type Item = {
+            id: number;
+          };
+          interface Props {
+            items: Item[];
+          }
+        `,
+        errors: [
+          {
+            messageId: "dependencyBeforeConsumer",
+            data: { dependency: "Item", consumer: "Props" },
+          },
+        ],
+      },
+    ],
+  });
+});

--- a/src/rules/__tests__/no-nested-interface-declaration.test.ts
+++ b/src/rules/__tests__/no-nested-interface-declaration.test.ts
@@ -1,0 +1,164 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import { afterAll, describe, it } from "@jest/globals";
+
+import noNestedInterfaceDeclaration from "../no-nested-interface-declaration";
+
+RuleTester.afterAll = afterAll;
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parserOptions: {
+      ecmaVersion: 2020,
+      sourceType: "module",
+    },
+  },
+});
+
+describe("no-nested-interface-declaration", () => {
+  it("should have meta property", () => {
+    expect(noNestedInterfaceDeclaration.meta).toBeDefined();
+  });
+
+  it("should have create method", () => {
+    expect(typeof noNestedInterfaceDeclaration.create).toBe("function");
+  });
+
+  ruleTester.run("no-nested-interface-declaration", noNestedInterfaceDeclaration, {
+    valid: [
+      {
+        code: `
+          interface Baz {
+            baz: string;
+          }
+          interface Foo {
+            bar: Baz;
+          }
+        `,
+      },
+      {
+        code: `
+          interface Props {
+            name: string;
+            age: number;
+            isActive: boolean;
+          }
+        `,
+      },
+      {
+        code: `
+          type Item = { id: number; label: string };
+          interface Props {
+            items: Item[];
+          }
+        `,
+      },
+      {
+        code: `
+          interface Config {
+            timeout: number;
+          }
+          interface Props {
+            config: Readonly<Config>;
+          }
+        `,
+      },
+      {
+        code: `
+          interface Props {
+            ids: string[];
+          }
+        `,
+      },
+      {
+        code: `
+          interface Props {
+            callback: () => void;
+          }
+        `,
+      },
+    ],
+    invalid: [
+      {
+        code: `
+          interface Foo {
+            bar: {
+              baz: string;
+            };
+          }
+        `,
+        errors: [{ messageId: "noNestedInterface" }],
+      },
+      {
+        code: `
+          interface Props {
+            user: {
+              name: string;
+              age: number;
+            };
+          }
+        `,
+        errors: [{ messageId: "noNestedInterface" }],
+      },
+      {
+        code: `
+          interface Props {
+            items: {
+              id: number;
+              label: string;
+            }[];
+          }
+        `,
+        errors: [{ messageId: "noNestedInterface" }],
+      },
+      {
+        code: `
+          interface Props {
+            data: Readonly<{
+              id: number;
+              name: string;
+            }>;
+          }
+        `,
+        errors: [{ messageId: "noNestedInterface" }],
+      },
+      {
+        code: `
+          type Props = {
+            config: {
+              theme: string;
+              lang: string;
+            };
+          };
+        `,
+        errors: [{ messageId: "noNestedInterface" }],
+      },
+      {
+        code: `
+          interface Props {
+            first: {
+              a: string;
+            };
+            second: {
+              b: number;
+            };
+          }
+        `,
+        errors: [{ messageId: "noNestedInterface" }, { messageId: "noNestedInterface" }],
+      },
+      {
+        code: `
+          interface Props {
+            nested: {
+              deep: {
+                value: string;
+              };
+            };
+          }
+        `,
+        errors: [{ messageId: "noNestedInterface" }, { messageId: "noNestedInterface" }],
+      },
+    ],
+  });
+});

--- a/src/rules/__tests__/prefer-inline-literal-union.test.ts
+++ b/src/rules/__tests__/prefer-inline-literal-union.test.ts
@@ -1,0 +1,193 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import { afterAll, describe, it } from "@jest/globals";
+
+import preferInlineLiteralUnion from "../prefer-inline-literal-union";
+
+RuleTester.afterAll = afterAll;
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parserOptions: {
+      ecmaVersion: 2020,
+      sourceType: "module",
+    },
+  },
+});
+
+describe("prefer-inline-literal-union", () => {
+  it("should have meta property", () => {
+    expect(preferInlineLiteralUnion.meta).toBeDefined();
+  });
+
+  it("should have create method", () => {
+    expect(typeof preferInlineLiteralUnion.create).toBe("function");
+  });
+
+  ruleTester.run("prefer-inline-literal-union", preferInlineLiteralUnion, {
+    valid: [
+      {
+        code: `
+          interface Props {
+            status: string;
+          }
+        `,
+      },
+      {
+        code: `
+          interface Props {
+            activeCategoryId?: "articles" | "dharma" | "faq";
+          }
+        `,
+      },
+      {
+        code: `
+          type User = { name: string; age: number };
+          interface Props {
+            user: User;
+          }
+        `,
+      },
+      {
+        code: `
+          type Callback = () => void;
+          interface Props {
+            onClick: Callback;
+          }
+        `,
+      },
+      {
+        code: `
+          type Status = "loading" | "success" | "error";
+          function getStatus(s: Status): string { return s; }
+        `,
+      },
+      {
+        code: `
+          type MixedUnion = "a" | string;
+          interface Props {
+            value: MixedUnion;
+          }
+        `,
+      },
+      {
+        code: `
+          type ObjectType = { key: string };
+          interface Props {
+            data: ObjectType;
+          }
+        `,
+      },
+    ],
+    invalid: [
+      {
+        code: `
+          type ArticleFaqCategoryId = "articles" | "dharma" | "faq";
+          interface ArticleFaqCategoryFilterProps {
+            activeCategoryId?: ArticleFaqCategoryId;
+          }
+        `,
+        output: `
+          type ArticleFaqCategoryId = "articles" | "dharma" | "faq";
+          interface ArticleFaqCategoryFilterProps {
+            activeCategoryId?: "articles" | "dharma" | "faq";
+          }
+        `,
+        errors: [{ messageId: "inlineLiteralUnion" }],
+      },
+      {
+        code: `
+          type Status = "loading" | "success" | "error";
+          interface Props {
+            status: Status;
+          }
+        `,
+        output: `
+          type Status = "loading" | "success" | "error";
+          interface Props {
+            status: "loading" | "success" | "error";
+          }
+        `,
+        errors: [{ messageId: "inlineLiteralUnion" }],
+      },
+      {
+        code: `
+          type Size = 1 | 2 | 3 | 4;
+          interface Props {
+            size: Size;
+          }
+        `,
+        output: `
+          type Size = 1 | 2 | 3 | 4;
+          interface Props {
+            size: 1 | 2 | 3 | 4;
+          }
+        `,
+        errors: [{ messageId: "inlineLiteralUnion" }],
+      },
+      {
+        code: `
+          type Theme = "light" | "dark";
+          interface Props {
+            theme: Theme;
+            fallbackTheme: Theme;
+          }
+        `,
+        output: `
+          type Theme = "light" | "dark";
+          interface Props {
+            theme: "light" | "dark";
+            fallbackTheme: "light" | "dark";
+          }
+        `,
+        errors: [{ messageId: "inlineLiteralUnion" }, { messageId: "inlineLiteralUnion" }],
+      },
+      {
+        code: `
+          type Nullable = "yes" | "no" | null;
+          interface Props {
+            value: Nullable;
+          }
+        `,
+        output: `
+          type Nullable = "yes" | "no" | null;
+          interface Props {
+            value: "yes" | "no" | null;
+          }
+        `,
+        errors: [{ messageId: "inlineLiteralUnion" }],
+      },
+      {
+        code: `
+          type MaybeStatus = "active" | "inactive" | undefined;
+          interface Props {
+            status: MaybeStatus;
+          }
+        `,
+        output: `
+          type MaybeStatus = "active" | "inactive" | undefined;
+          interface Props {
+            status: "active" | "inactive" | undefined;
+          }
+        `,
+        errors: [{ messageId: "inlineLiteralUnion" }],
+      },
+      {
+        code: `
+          type IsEnabled = true | false;
+          interface Props {
+            enabled: IsEnabled;
+          }
+        `,
+        output: `
+          type IsEnabled = true | false;
+          interface Props {
+            enabled: true | false;
+          }
+        `,
+        errors: [{ messageId: "inlineLiteralUnion" }],
+      },
+    ],
+  });
+});

--- a/src/rules/enforce-type-declaration-order.ts
+++ b/src/rules/enforce-type-declaration-order.ts
@@ -1,0 +1,101 @@
+import { AST_NODE_TYPES, ESLintUtils } from "@typescript-eslint/utils";
+
+import type { TSESTree } from "@typescript-eslint/utils";
+
+const createRule = ESLintUtils.RuleCreator(
+  (name) =>
+    `https://github.com/next-friday/eslint-plugin-nextfriday/blob/main/docs/rules/${name.replaceAll("-", "_").toUpperCase()}.md`,
+);
+
+function getTypeDeclarationName(node: TSESTree.Node): { name: string; position: number } | null {
+  if (node.type === AST_NODE_TYPES.TSInterfaceDeclaration && node.id.type === AST_NODE_TYPES.Identifier) {
+    return { name: node.id.name, position: node.range[0] };
+  }
+
+  if (node.type === AST_NODE_TYPES.TSTypeAliasDeclaration && node.id.type === AST_NODE_TYPES.Identifier) {
+    return { name: node.id.name, position: node.range[0] };
+  }
+
+  return null;
+}
+
+const enforceTypeDeclarationOrder = createRule({
+  name: "enforce-type-declaration-order",
+  meta: {
+    type: "suggestion",
+    docs: {
+      description: "Enforce that referenced types and interfaces are declared after the type that uses them",
+    },
+    fixable: undefined,
+    schema: [],
+    messages: {
+      dependencyBeforeConsumer: "'{{dependency}}' should be declared after '{{consumer}}' which references it",
+    },
+  },
+  defaultOptions: [],
+  create(context) {
+    const typeDeclarations = new Map<string, number>();
+    const reported = new Set<string>();
+
+    return {
+      TSInterfaceDeclaration(node) {
+        const info = getTypeDeclarationName(node);
+
+        if (info) {
+          typeDeclarations.set(info.name, info.position);
+        }
+      },
+
+      TSTypeAliasDeclaration(node) {
+        const info = getTypeDeclarationName(node);
+
+        if (info) {
+          typeDeclarations.set(info.name, info.position);
+        }
+      },
+
+      "TSPropertySignature TSTypeReference": function checkTypeReference(node: TSESTree.TSTypeReference) {
+        if (node.typeName.type !== AST_NODE_TYPES.Identifier) {
+          return;
+        }
+
+        const referencedName = node.typeName.name;
+        const referencedPosition = typeDeclarations.get(referencedName);
+
+        if (referencedPosition === undefined) {
+          return;
+        }
+
+        let current: TSESTree.Node | undefined = node.parent;
+
+        while (current) {
+          const consumerInfo = getTypeDeclarationName(current);
+
+          if (consumerInfo) {
+            if (referencedPosition < consumerInfo.position) {
+              const reportKey = `${referencedName}-${consumerInfo.name}`;
+
+              if (!reported.has(reportKey)) {
+                reported.add(reportKey);
+                context.report({
+                  node: node.typeName,
+                  messageId: "dependencyBeforeConsumer",
+                  data: {
+                    dependency: referencedName,
+                    consumer: consumerInfo.name,
+                  },
+                });
+              }
+            }
+
+            break;
+          }
+
+          current = current.parent;
+        }
+      },
+    };
+  },
+});
+
+export default enforceTypeDeclarationOrder;

--- a/src/rules/no-nested-interface-declaration.ts
+++ b/src/rules/no-nested-interface-declaration.ts
@@ -1,0 +1,66 @@
+import { AST_NODE_TYPES, ESLintUtils } from "@typescript-eslint/utils";
+
+const createRule = ESLintUtils.RuleCreator(
+  (name) =>
+    `https://github.com/next-friday/eslint-plugin-nextfriday/blob/main/docs/rules/${name.replaceAll("-", "_").toUpperCase()}.md`,
+);
+
+const noNestedInterfaceDeclaration = createRule({
+  name: "no-nested-interface-declaration",
+  meta: {
+    type: "suggestion",
+    docs: {
+      description: "Disallow inline object type literals in interface or type properties",
+    },
+    fixable: undefined,
+    schema: [],
+    messages: {
+      noNestedInterface: "Extract nested object type into a separate interface or type declaration",
+    },
+  },
+  defaultOptions: [],
+  create(context) {
+    return {
+      TSPropertySignature(node) {
+        if (!node.typeAnnotation) {
+          return;
+        }
+
+        const { typeAnnotation } = node.typeAnnotation;
+
+        if (typeAnnotation.type === AST_NODE_TYPES.TSTypeLiteral) {
+          context.report({
+            node: typeAnnotation,
+            messageId: "noNestedInterface",
+          });
+
+          return;
+        }
+
+        if (typeAnnotation.type === AST_NODE_TYPES.TSArrayType) {
+          if (typeAnnotation.elementType.type === AST_NODE_TYPES.TSTypeLiteral) {
+            context.report({
+              node: typeAnnotation.elementType,
+              messageId: "noNestedInterface",
+            });
+          }
+
+          return;
+        }
+
+        if (typeAnnotation.type === AST_NODE_TYPES.TSTypeReference && typeAnnotation.typeArguments) {
+          typeAnnotation.typeArguments.params.forEach((param) => {
+            if (param.type === AST_NODE_TYPES.TSTypeLiteral) {
+              context.report({
+                node: param,
+                messageId: "noNestedInterface",
+              });
+            }
+          });
+        }
+      },
+    };
+  },
+});
+
+export default noNestedInterfaceDeclaration;

--- a/src/rules/prefer-inline-literal-union.ts
+++ b/src/rules/prefer-inline-literal-union.ts
@@ -1,0 +1,86 @@
+import { AST_NODE_TYPES, ESLintUtils } from "@typescript-eslint/utils";
+
+import type { TSESTree } from "@typescript-eslint/utils";
+
+const createRule = ESLintUtils.RuleCreator(
+  (name) =>
+    `https://github.com/next-friday/eslint-plugin-nextfriday/blob/main/docs/rules/${name.replaceAll("-", "_").toUpperCase()}.md`,
+);
+
+function isLiteralUnionType(node: TSESTree.TypeNode): boolean {
+  if (node.type !== AST_NODE_TYPES.TSUnionType) {
+    return false;
+  }
+
+  return node.types.every(
+    (member) =>
+      member.type === AST_NODE_TYPES.TSLiteralType ||
+      member.type === AST_NODE_TYPES.TSNullKeyword ||
+      member.type === AST_NODE_TYPES.TSUndefinedKeyword,
+  );
+}
+
+const preferInlineLiteralUnion = createRule({
+  name: "prefer-inline-literal-union",
+  meta: {
+    type: "suggestion",
+    docs: {
+      description:
+        "Enforce inlining literal union types in interface properties instead of using type aliases for better IDE hover information",
+    },
+    fixable: "code",
+    schema: [],
+    messages: {
+      inlineLiteralUnion:
+        "Inline the literal union type instead of using a type alias for better IDE hover information",
+    },
+  },
+  defaultOptions: [],
+  create(context) {
+    const literalUnionAliases = new Map<string, TSESTree.TSTypeAliasDeclaration>();
+
+    return {
+      TSTypeAliasDeclaration(node) {
+        if (isLiteralUnionType(node.typeAnnotation)) {
+          literalUnionAliases.set(node.id.name, node);
+        }
+      },
+
+      TSPropertySignature(node) {
+        if (!node.typeAnnotation) {
+          return;
+        }
+
+        const { typeAnnotation } = node.typeAnnotation;
+
+        if (typeAnnotation.type !== AST_NODE_TYPES.TSTypeReference) {
+          return;
+        }
+
+        if (typeAnnotation.typeName.type !== AST_NODE_TYPES.Identifier) {
+          return;
+        }
+
+        const aliasName = typeAnnotation.typeName.name;
+        const aliasDeclaration = literalUnionAliases.get(aliasName);
+
+        if (!aliasDeclaration) {
+          return;
+        }
+
+        const { sourceCode } = context;
+        const unionText = sourceCode.getText(aliasDeclaration.typeAnnotation);
+
+        context.report({
+          node: typeAnnotation,
+          messageId: "inlineLiteralUnion",
+          fix(fixer) {
+            return fixer.replaceText(typeAnnotation, unionText);
+          },
+        });
+      },
+    };
+  },
+});
+
+export default preferInlineLiteralUnion;


### PR DESCRIPTION
## Summary

- **prefer-inline-literal-union**: Enforce inlining literal union types (string/number/boolean literals, null, undefined) in interface properties instead of using type aliases, for better IDE hover information. Auto-fixable.
- **no-nested-interface-declaration**: Disallow inline object type literals nested in interface/type properties; extract them into separate named types instead.
- **enforce-type-declaration-order**: Enforce that referenced types are declared after their consumer, ensuring top-down readability (main type first, dependencies below).

All three rules are added to the `base` config tier (warn + error variants).

## Test plan

- [x] All 1118 tests pass (55 test suites)
- [x] Typecheck passes
- [x] Build succeeds
- [x] Lint passes
- [x] Changeset included