### PR TITLE
docs(skills): add agent skill for eslint rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,16 @@ Additionally included in `nextjs`, `nextjs/recommended` only:
 - **Clean code practices**: Prevents emoji usage, enforces parameter destructuring, and more
 - **Formatting rules**: Enforces consistent blank lines around multi-line blocks and return statements
 
+## Agent Skill
+
+This plugin ships with an [Agent Skill](https://github.com/anthropics/skills) that teaches AI coding assistants (Claude Code, Cursor, etc.) all 51 rules so they generate compliant code from the start.
+
+```bash
+npx skills add next-friday/eslint-plugin-nextfriday --skill eslint-plugin-nextfriday
+```
+
+Once installed, AI assistants will automatically follow the naming, code style, type, JSX, import, and formatting patterns enforced by this plugin — reducing lint errors to zero.
+
 ## Need Help?
 
 If you encounter any issues or have questions:

--- a/skills/eslint-plugin-nextfriday/SKILL.md
+++ b/skills/eslint-plugin-nextfriday/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: eslint-plugin-nextfriday
+description: Code patterns for projects using eslint-plugin-nextfriday (51 rules covering naming, style, types, JSX, imports, and formatting)
+user-invocable: false
+---
+
+# eslint-plugin-nextfriday Patterns
+
+This project enforces 51 lint rules via `eslint-plugin-nextfriday`. Follow the patterns below when writing TypeScript and React code.
+
+Use [complete-examples.md](./complete-examples.md) as file templates. Refer to the topic docs for details on specific patterns.
+
+## Naming
+
+Booleans start with a prefix. Constants use SCREAMING_SNAKE_CASE. Use descriptive names.
+
+```ts
+const isActive = true;
+const hasPermission = checkPermission();
+const MAX_RETRIES = 3;
+const API_BASE_URL = "https://api.example.com";
+const userName = getUser(); // not "u" or "temp"
+```
+
+Prefixes: `is`, `has`, `should`, `can`, `did`, `will`, `was`, `are`, `does`, `had`
+
+Files: `.ts` → `kebab-case.ts`, `.tsx` → `PascalCase.tsx`, `.md` → `UPPER_SNAKE_CASE.md`
+
+See [naming-conventions.md](./naming-conventions.md) for hook/service naming and props suffix rules.
+
+## Functions
+
+Function declarations in `.ts` files. Explicit return types. Destructured params for 2+ arguments.
+
+```ts
+function fetchUser({ userId }: FetchUserParams): Promise<User> {
+  const response = await fetch(url);
+  const data = await response.json();
+
+  return data;
+}
+```
+
+Extract complex expressions before returning or passing to functions:
+
+```ts
+// extract, then return
+const fullName = `${first} ${last}`.trim();
+
+return fullName;
+
+// extract, then pass
+const targetId = isAdmin ? adminId : userId;
+fetchUser(targetId);
+```
+
+See [code-style.md](./code-style.md) for guard clauses, async/await, and export patterns.
+
+## Exports
+
+Declare first, export at the bottom of the file:
+
+```ts
+function getUser(): User {
+  /* ... */
+}
+
+export default getUser;
+```
+
+## Types
+
+Required properties first (A-Z), then optional properties (A-Z). Inline literal unions. Extract nested objects.
+
+```ts
+interface UserCardProps {
+  email: string;
+  name: string;
+  avatar?: string;
+  bio?: string;
+}
+
+interface SettingsProps {
+  theme: "light" | "dark"; // inline literal union, not a type alias
+  notifications: Notification; // extracted, not { title: string; ... }
+}
+```
+
+Declare consumer types before their dependencies (top-down reading order).
+
+See [type-patterns.md](./type-patterns.md) for Readonly props and named param types.
+
+## React Components
+
+Props use `Readonly<>` wrapper. Destructure inside the body.
+
+```tsx
+function UserCard(props: Readonly<UserCardProps>): ReactElement {
+  const { avatar, email, name } = props;
+
+  const displayName = `${name} (${email})`;
+
+  return (
+    <div>
+      <img alt={name} src={avatar} />
+      <p>{displayName}</p>
+    </div>
+  );
+}
+```
+
+See [jsx-patterns.md](./jsx-patterns.md) for prop sorting, Suspense, and callback extraction.
+
+## Imports
+
+Use `import type` for types. Absolute `@/` paths. Direct React imports.
+
+```ts
+import { useCallback, useState } from "react";
+
+import type { ReactElement } from "react";
+
+import type { User } from "@/types/user";
+```
+
+Order: external packages → internal `@/` → type imports. Each group sorted A-Z.
+
+See [import-patterns.md](./import-patterns.md) for sorted exports and destructuring.
+
+## Formatting
+
+```ts
+// blank line after multi-line block
+if (!isValid) {
+  return null;
+}
+
+// blank line before return
+const result = calculate();
+
+return result;
+```
+
+JSX: blank line between multi-line siblings, no blank line between single-line siblings.
+
+See [formatting.md](./formatting.md) for curly brace and nested object rules.

--- a/skills/eslint-plugin-nextfriday/code-style.md
+++ b/skills/eslint-plugin-nextfriday/code-style.md
@@ -1,0 +1,202 @@
+# Code Style
+
+## Function Declarations Over Arrow Functions
+
+In `.ts` files, use function declarations instead of arrow function expressions for top-level functions.
+
+```ts
+// Bad (in .ts files)
+const getUser = (id: string): User => {
+  return db.find(id);
+};
+
+// Good
+function getUser(id: string): User {
+  return db.find(id);
+}
+```
+
+## Destructuring Parameters
+
+Functions with multiple parameters should use destructured object parameters.
+
+```ts
+// Bad
+function createUser(name: string, age: number, email: string): User {
+  return { name, age, email };
+}
+
+// Good
+function createUser({ name, age, email }: CreateUserParams): User {
+  return { name, age, email };
+}
+```
+
+## No Inline Exports
+
+Declare first, then export separately.
+
+```ts
+// Bad
+export default function getUser() {
+  /* ... */
+}
+export function formatDate() {
+  /* ... */
+}
+
+// Good
+function getUser() {
+  /* ... */
+}
+function formatDate() {
+  /* ... */
+}
+
+export default getUser;
+export { formatDate };
+```
+
+## Explicit Return Types
+
+Functions must have explicit return type annotations.
+
+```ts
+// Bad
+function getUser(id: string) {
+  return db.find(id);
+}
+
+// Good
+function getUser(id: string): User {
+  return db.find(id);
+}
+```
+
+## No Complex Inline Returns
+
+Extract complex expressions to a const before returning.
+
+```ts
+// Bad
+function getFullName(user: User): string {
+  return `${user.firstName} ${user.lastName}`.trim().toLowerCase();
+}
+
+// Good
+function getFullName(user: User): string {
+  const fullName = `${user.firstName} ${user.lastName}`.trim().toLowerCase();
+
+  return fullName;
+}
+```
+
+## No Logic in Parameters
+
+Don't embed logic, conditions, or computations in function call arguments. Extract to a variable.
+
+```ts
+// Bad
+fetchUser(isAdmin ? adminId : userId);
+setItems(items.filter((item) => item.isActive));
+
+// Good
+const targetId = isAdmin ? adminId : userId;
+fetchUser(targetId);
+
+const activeItems = items.filter((item) => item.isActive);
+setItems(activeItems);
+```
+
+## Guard Clauses
+
+Use early returns instead of deeply nested if/else blocks.
+
+```ts
+// Bad
+function processUser(user: User): string {
+  if (user) {
+    if (user.isActive) {
+      if (user.hasPermission) {
+        return user.name;
+      }
+    }
+  }
+  return "unknown";
+}
+
+// Good
+function processUser(user: User): string {
+  if (!user) {
+    return "unknown";
+  }
+
+  if (!user.isActive) {
+    return "unknown";
+  }
+
+  if (!user.hasPermission) {
+    return "unknown";
+  }
+
+  return user.name;
+}
+```
+
+## No Nested Ternaries
+
+```ts
+// Bad
+const label = isAdmin ? "Admin" : isMod ? "Moderator" : "User";
+
+// Good
+function getLabel(): string {
+  if (isAdmin) {
+    return "Admin";
+  }
+
+  if (isMod) {
+    return "Moderator";
+  }
+
+  return "User";
+}
+```
+
+## Async/Await Over .then()
+
+```ts
+// Bad
+function getUser(): Promise<User> {
+  return fetch("/api/user")
+    .then((res) => res.json())
+    .then((data) => data.user);
+}
+
+// Good
+async function getUser(): Promise<User> {
+  const res = await fetch("/api/user");
+  const data = await res.json();
+
+  return data.user;
+}
+```
+
+## No Direct Date
+
+Don't use `new Date()` or `Date.now()` directly. Use a date utility library.
+
+## No Environment Variable Fallbacks
+
+```ts
+// Bad
+const apiUrl = process.env.API_URL || "http://localhost:3000";
+const apiUrl = process.env.API_URL ?? "http://localhost:3000";
+
+// Good
+const apiUrl = process.env.API_URL;
+```
+
+## No Emoji in Source Code
+
+Don't use emoji characters in string literals, comments, or identifiers.

--- a/skills/eslint-plugin-nextfriday/complete-examples.md
+++ b/skills/eslint-plugin-nextfriday/complete-examples.md
@@ -1,0 +1,211 @@
+# Complete Examples
+
+These are full file examples that pass ALL 51 eslint-plugin-nextfriday rules with zero errors. Use these as templates when generating code.
+
+## React Component File (`UserProfile.tsx`)
+
+```tsx
+import type { ReactElement } from "react";
+
+import type { User } from "@/types/user";
+
+interface UserProfileProps {
+  email: string;
+  name: string;
+  onSave: (user: User) => void;
+  avatar?: string;
+  bio?: string;
+}
+
+interface UserAvatarProps {
+  alt: string;
+  src: string;
+}
+
+function UserAvatar(props: Readonly<UserAvatarProps>): ReactElement {
+  const { alt, src } = props;
+
+  return <img alt={alt} src={src} />;
+}
+
+function UserProfile(props: Readonly<UserProfileProps>): ReactElement {
+  const { avatar, bio, email, name, onSave } = props;
+
+  const isComplete = Boolean(avatar && bio);
+  const displayName = `${name} (${email})`;
+
+  const handleSave = (): void => {
+    const user = { avatar, bio, email, name };
+    onSave(user);
+  };
+
+  return (
+    <section>
+      <UserAvatar alt={name} src={avatar} />
+
+      <div>
+        <h1>{displayName}</h1>
+        <p>{bio}</p>
+      </div>
+
+      <footer>
+        {isComplete ? (
+          <button type="button" onClick={handleSave}>
+            {`Save ${name}`}
+          </button>
+        ) : (
+          <p>{`Please complete your profile, ${name}`}</p>
+        )}
+      </footer>
+    </section>
+  );
+}
+
+export default UserProfile;
+```
+
+Key patterns: `import type` for types, `@/` absolute paths, `Props` suffix, required A-Z then optional A-Z, `Readonly<>` wrapper, props destructured inside body, explicit return types, `is` prefix on boolean, complex expressions extracted to const, template literals for mixed text, blank lines before return and after multi-line blocks, export at bottom.
+
+## Utility File (`user-service.ts`)
+
+```ts
+import type { User } from "@/types/user";
+
+const API_BASE_URL = "https://api.example.com";
+const MAX_RETRIES = 3;
+
+async function fetchUser({ userId }: FetchUserParams): Promise<User> {
+  const url = `${API_BASE_URL}/users/${userId}`;
+  const response = await fetch(url);
+  const data = await response.json();
+
+  return data;
+}
+
+async function fetchUsers(): Promise<User[]> {
+  const url = `${API_BASE_URL}/users`;
+  const response = await fetch(url);
+  const data = await response.json();
+
+  return data;
+}
+
+interface FetchUserParams {
+  userId: string;
+}
+
+export { fetchUser, fetchUsers };
+```
+
+Key patterns: kebab-case filename, `import type`, SCREAMING_SNAKE_CASE constants, function declarations (not arrows), explicit return types, destructured params with named interface, async/await, blank line before return, export at bottom.
+
+## Hook File (`user-profile.hook.ts`)
+
+```ts
+import { useCallback, useEffect, useState } from "react";
+
+import type { User } from "@/types/user";
+
+function useUserProfile({ userId }: UseUserProfileParams): UseUserProfileReturn {
+  const [user, setUser] = useState<User | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [hasError, setHasError] = useState(false);
+
+  const handleFetch = useCallback(async (): Promise<void> => {
+    setIsLoading(true);
+    setHasError(false);
+
+    const response = await fetch(`/api/users/${userId}`);
+
+    if (!response.ok) {
+      setHasError(true);
+      setIsLoading(false);
+
+      return;
+    }
+
+    const data = await response.json();
+    setUser(data);
+    setIsLoading(false);
+  }, [userId]);
+
+  useEffect(() => {
+    handleFetch();
+  }, [handleFetch]);
+
+  return { hasError, isLoading, user };
+}
+
+interface UseUserProfileParams {
+  userId: string;
+}
+
+interface UseUserProfileReturn {
+  hasError: boolean;
+  isLoading: boolean;
+  user: User | null;
+}
+
+export { useUserProfile };
+```
+
+Key patterns: `use` prefix for hook function, `.hook.ts` kebab-case filename, `is`/`has` prefix on boolean state, guard clause (early return), blank line after multi-line blocks, interfaces sorted A-Z with required first.
+
+## Next.js Page File (`ArticleList.tsx`)
+
+```tsx
+import { Suspense, lazy } from "react";
+
+import type { ReactElement } from "react";
+
+const ArticleCard = lazy(() => import("@/components/ArticleCard"));
+
+interface ArticleListProps {
+  category: "articles" | "dharma" | "faq";
+  title: string;
+  isPublished?: boolean;
+}
+
+interface ArticleItemProps {
+  id: string;
+  title: string;
+}
+
+function ArticleItem(props: Readonly<ArticleItemProps>): ReactElement {
+  const { id, title } = props;
+
+  return (
+    <li key={id}>
+      <Suspense fallback={<div>Loading...</div>}>
+        <ArticleCard id={id} title={title} />
+      </Suspense>
+    </li>
+  );
+}
+
+function ArticleList(props: Readonly<ArticleListProps>): ReactElement {
+  const { category, isPublished, title } = props;
+
+  if (!isPublished) {
+    return <p>{`${title} is not published yet`}</p>;
+  }
+
+  const items = getArticles(category);
+
+  return (
+    <section>
+      <h1>{title}</h1>
+
+      <ul>
+        {items.map((item) => (
+          <ArticleItem id={item.id} title={item.title} />
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+export default ArticleList;
+```
+
+Key patterns: inline literal union (not type alias), lazy component wrapped in `Suspense`, guard clause for early return, template literal for mixed text.

--- a/skills/eslint-plugin-nextfriday/formatting.md
+++ b/skills/eslint-plugin-nextfriday/formatting.md
@@ -1,0 +1,123 @@
+# Formatting
+
+## Blank Lines Between Multi-Line JSX Elements
+
+Sibling JSX elements that span multiple lines must have a blank line between them.
+
+```tsx
+// Bad
+<Header
+  title="Dashboard"
+  subtitle="Welcome back"
+/>
+<MainContent
+  data={data}
+  isLoading={isLoading}
+/>
+
+// Good
+<Header
+  title="Dashboard"
+  subtitle="Welcome back"
+/>
+
+<MainContent
+  data={data}
+  isLoading={isLoading}
+/>
+```
+
+## No Blank Lines Between Single-Line JSX Elements
+
+Sibling single-line JSX elements should NOT have blank lines between them.
+
+```tsx
+// Bad
+<li>Apple</li>
+
+<li>Banana</li>
+
+<li>Cherry</li>
+
+// Good
+<li>Apple</li>
+<li>Banana</li>
+<li>Cherry</li>
+```
+
+## Blank Line After Multi-Line Blocks
+
+Add a blank line after statements that span multiple lines (if/else, try/catch, loops, etc.).
+
+```ts
+// Bad
+if (isValid) {
+  process();
+}
+const result = calculate();
+
+// Good
+if (isValid) {
+  process();
+}
+
+const result = calculate();
+```
+
+## Blank Line Before Return
+
+Add a blank line before `return` statements (except when it's the only statement in the block).
+
+```ts
+// Bad
+function getUser(): User {
+  const user = db.find(id);
+  return user;
+}
+
+// Good
+function getUser(): User {
+  const user = db.find(id);
+
+  return user;
+}
+```
+
+## Curly Braces for Multi-Line If
+
+Multi-line if bodies require curly braces. Single-line if bodies must not have curly braces.
+
+```ts
+// Bad
+if (isValid) {
+  process();
+} // single statement, multi-line braces OK
+
+if (isValid) doSomething();
+doSomethingElse(); // misleading
+
+// Good
+if (isValid) process(); // single-line, no braces
+
+if (isValid) {
+  doSomething();
+  doSomethingElse();
+}
+```
+
+## Nested Objects Must Span Multiple Lines
+
+Inline nested objects and arrays must be written across multiple lines.
+
+```ts
+// Bad
+const config = { database: { host: "localhost", port: 5432 } };
+
+// Good
+const config = {
+  database: {
+    host: "localhost",
+    port: 5432,
+  },
+};
+```

--- a/skills/eslint-plugin-nextfriday/import-patterns.md
+++ b/skills/eslint-plugin-nextfriday/import-patterns.md
@@ -1,0 +1,73 @@
+# Import & Export Patterns
+
+## Absolute Imports
+
+Don't use relative imports with `../`. Use absolute path aliases.
+
+```ts
+// Bad
+import { formatDate } from "../../utils/format-date";
+import { User } from "../types/user";
+
+// Good
+import { formatDate } from "@/utils/format-date";
+import { User } from "@/types/user";
+```
+
+## Import Type
+
+Use `import type` for type-only imports.
+
+```ts
+// Bad
+import { User } from "@/types/user";
+import { ReactNode } from "react";
+
+// Good
+import type { User } from "@/types/user";
+import type { ReactNode } from "react";
+```
+
+## Direct React Imports
+
+Import React types directly instead of using the `React.` namespace.
+
+```ts
+// Bad
+import React from "react";
+const MyComponent = (props: React.PropsWithChildren) => {
+  /* ... */
+};
+
+// Good
+import type { PropsWithChildren } from "react";
+const MyComponent = (props: PropsWithChildren) => {
+  /* ... */
+};
+```
+
+## Sorted Imports
+
+Organize imports into groups in this order:
+
+1. External packages
+2. Internal absolute imports
+3. Type imports
+
+Each group sorted alphabetically.
+
+## Sorted Exports
+
+Organize exports consistently. Named exports grouped and sorted.
+
+## Sorted Destructuring
+
+Destructured properties sorted alphabetically, with properties that have default values first.
+
+```ts
+// Bad
+const { zebra, apple, mango = "default" } = config;
+
+// Good
+const { mango = "default", apple, zebra } = config;
+```

--- a/skills/eslint-plugin-nextfriday/jsx-patterns.md
+++ b/skills/eslint-plugin-nextfriday/jsx-patterns.md
@@ -1,0 +1,121 @@
+# JSX Patterns
+
+## Simple Props Only
+
+JSX props should only contain strings, simple variables, member expressions, callbacks, or ReactNode. Extract complex expressions to a variable.
+
+```tsx
+// Bad
+<UserCard name={`${firstName} ${lastName}`} />
+<Button onClick={isAdmin ? handleAdmin : handleUser} />
+<List items={data.filter((item) => item.isActive)} />
+
+// Good
+const fullName = `${firstName} ${lastName}`;
+const handleClick = isAdmin ? handleAdmin : handleUser;
+const activeItems = data.filter((item) => item.isActive);
+
+<UserCard name={fullName} />
+<Button onClick={handleClick} />
+<List items={activeItems} />
+```
+
+## No Inline Object Props
+
+Don't pass inline object literals as JSX props. Extract to a variable.
+
+```tsx
+// Bad
+<Chart style={{ width: 100, height: 200 }} />
+<Form defaultValues={{ name: "", email: "" }} />
+
+// Good
+const chartStyle = { width: 100, height: 200 };
+const defaultValues = { name: "", email: "" };
+
+<Chart style={chartStyle} />
+<Form defaultValues={defaultValues} />
+```
+
+## No Variables in JSX Callbacks
+
+Don't declare variables inside callback functions in JSX. Extract the callback.
+
+```tsx
+// Bad
+<ul>
+  {items.map((item) => {
+    const label = item.name.toUpperCase();
+    return <li key={item.id}>{label}</li>;
+  })}
+</ul>;
+
+// Good
+function renderItem(item: Item): ReactElement {
+  const label = item.name.toUpperCase();
+
+  return <li key={item.id}>{label}</li>;
+}
+
+<ul>{items.map(renderItem)}</ul>;
+```
+
+## Suspense for Lazy Components
+
+Lazy-loaded components must be wrapped in `<Suspense>`.
+
+```tsx
+// Bad
+const LazyComponent = lazy(() => import("./HeavyComponent"));
+<LazyComponent />;
+
+// Good
+const LazyComponent = lazy(() => import("./HeavyComponent"));
+<Suspense fallback={<Loading />}>
+  <LazyComponent />
+</Suspense>;
+```
+
+## Destructure Props in Component Body
+
+Destructure props inside the component body, not in the parameter list.
+
+```tsx
+// Bad
+function UserCard({ name, age }: Readonly<UserCardProps>) {
+  return <div>{name}</div>;
+}
+
+// Good
+function UserCard(props: Readonly<UserCardProps>) {
+  const { name, age } = props;
+
+  return <div>{name}</div>;
+}
+```
+
+## No Non-Component Functions in .tsx Files
+
+Top-level functions in `.tsx`/`.jsx` files should be React components (return JSX). Move utility functions to `.ts` files.
+
+## Template Literals Over Mixed Text
+
+Use template literals instead of mixing text and JSX expressions.
+
+```tsx
+// Bad
+<p>Hello {name}, welcome!</p>
+
+// Good
+<p>{`Hello ${name}, welcome!`}</p>
+```
+
+## JSX Props Sort Order
+
+Sort JSX props by value type in this order:
+
+1. Shorthand boolean (e.g., `disabled`)
+2. String literals (e.g., `type="submit"`)
+3. Expressions/variables (e.g., `value={count}`)
+4. Callbacks (e.g., `onClick={handleClick}`)
+5. Spread (e.g., `{...rest}`)

--- a/skills/eslint-plugin-nextfriday/naming-conventions.md
+++ b/skills/eslint-plugin-nextfriday/naming-conventions.md
@@ -1,0 +1,97 @@
+# Naming Conventions
+
+## Boolean Variables
+
+Boolean variables and parameters must start with one of: `is`, `has`, `should`, `can`, `did`, `will`, `was`, `are`, `does`, `had`.
+
+```ts
+// Bad
+const active = true;
+const visible = false;
+const loading = true;
+
+// Good
+const isActive = true;
+const isVisible = false;
+const isLoading = true;
+const hasPermission = checkPermission();
+const shouldRender = items.length > 0;
+const canEdit = user.role === "admin";
+```
+
+## Constants
+
+Top-level constant primitive values must use SCREAMING_SNAKE_CASE.
+
+```ts
+// Bad
+const maxRetries = 3;
+const apiUrl = "https://api.example.com";
+
+// Good
+const MAX_RETRIES = 3;
+const API_URL = "https://api.example.com";
+```
+
+## Variable Names
+
+No single-character variables (`d`, `u`, `l`) or lazy identifiers (`xxx`, `asdf`, `qwerty`, `temp`, `foo`, `bar`).
+
+```ts
+// Bad
+const d = new Date();
+const u = getUser();
+const temp = calculate();
+
+// Good
+const currentDate = new Date();
+const user = getUser();
+const calculatedValue = calculate();
+```
+
+## File Naming
+
+| Extension      | Convention       | Example              |
+| -------------- | ---------------- | -------------------- |
+| `.ts`, `.js`   | kebab-case       | `user-service.ts`    |
+| `.tsx`, `.jsx` | PascalCase       | `UserProfile.tsx`    |
+| `.md`          | UPPER_SNAKE_CASE | `GETTING_STARTED.md` |
+
+## Hook and Service Files
+
+- Functions in `*.hook.ts` files must start with `use` prefix
+- Async functions in `*.service.ts` files must start with `fetch` prefix
+
+```ts
+// user.hook.ts
+function useUserProfile() {
+  /* ... */
+}
+
+// user.service.ts
+async function fetchUserProfile() {
+  /* ... */
+}
+```
+
+## Props Interfaces
+
+Interfaces and types used for React component props in `.tsx` files must end with `Props`.
+
+```tsx
+// Bad
+interface UserData {
+  name: string;
+}
+function UserCard(props: UserData) {
+  /* ... */
+}
+
+// Good
+interface UserCardProps {
+  name: string;
+}
+function UserCard(props: UserCardProps) {
+  /* ... */
+}
+```

--- a/skills/eslint-plugin-nextfriday/type-patterns.md
+++ b/skills/eslint-plugin-nextfriday/type-patterns.md
@@ -1,0 +1,154 @@
+# Type Patterns
+
+## Named Types for Function Parameters
+
+Use named interfaces/types instead of inline object types for function parameters.
+
+```ts
+// Bad
+function createUser(params: { name: string; age: number }): User {
+  return { ...params };
+}
+
+// Good
+interface CreateUserParams {
+  name: string;
+  age: number;
+}
+
+function createUser(params: CreateUserParams): User {
+  return { ...params };
+}
+```
+
+## Interface Over Inline Types for Component Props
+
+React component props must use a named interface or type, not inline object types.
+
+```tsx
+// Bad
+const UserCard = (props: { name: string; age: number }) => <div>{props.name}</div>;
+
+// Good
+interface UserCardProps {
+  name: string;
+  age: number;
+}
+
+const UserCard = (props: UserCardProps) => <div>{props.name}</div>;
+```
+
+## Inline Literal Unions
+
+Don't create type aliases for unions of literals. Inline them in interface properties for better IDE hover info.
+
+```ts
+// Bad - hover shows "Status" instead of the actual values
+type Status = "loading" | "success" | "error";
+
+interface Props {
+  status: Status;
+}
+
+// Good - hover shows "loading" | "success" | "error"
+interface Props {
+  status: "loading" | "success" | "error";
+}
+```
+
+## No Nested Object Types in Interfaces
+
+Extract nested object types into separate named interfaces.
+
+```ts
+// Bad
+interface Props {
+  user: {
+    name: string;
+    age: number;
+  };
+}
+
+// Good
+interface UserProps {
+  name: string;
+  age: number;
+}
+
+interface Props {
+  user: UserProps;
+}
+```
+
+## Top-Down Type Declaration Order
+
+Declare consumer types before their dependencies. Main type first, supporting types below.
+
+```ts
+// Bad - dependency before consumer
+interface Address {
+  street: string;
+  city: string;
+}
+
+interface UserProps {
+  address: Address;
+}
+
+// Good - consumer first, dependency after
+interface UserProps {
+  address: Address;
+}
+
+interface Address {
+  street: string;
+  city: string;
+}
+```
+
+## Sort Type Properties
+
+1. Required properties before optional properties
+2. Properties sorted alphabetically within each group
+
+```ts
+// Bad
+interface UserProps {
+  name: string;
+  avatar?: string;
+  email: string;
+  bio?: string;
+}
+
+// Good
+interface UserProps {
+  email: string;
+  name: string;
+  avatar?: string;
+  bio?: string;
+}
+```
+
+## Readonly Component Props
+
+Wrap React component props with `Readonly<>`.
+
+```tsx
+// Bad
+interface UserCardProps {
+  name: string;
+}
+
+function UserCard(props: UserCardProps) {
+  /* ... */
+}
+
+// Good
+interface UserCardProps {
+  name: string;
+}
+
+function UserCard(props: Readonly<UserCardProps>) {
+  /* ... */
+}
+```


### PR DESCRIPTION
## Summary

- Add agent skill (`skills/eslint-plugin-nextfriday/`) that teaches AI coding assistants all 51 lint rules
- Add "Agent Skill" section to README with install command
- Skill includes 8 docs: SKILL.md overview, complete file templates, and 6 topic references (naming, code style, types, JSX, imports, formatting)

Install:
```bash
npx skills add next-friday/eslint-plugin-nextfriday --skill eslint-plugin-nextfriday
```

## Test plan

- [x] All 1118 tests pass
- [x] Build succeeds
- [x] No src/ changes -- docs only, no changeset needed