### PR TITLE
docs(rules): standardize all documentation and code

### DIFF
--- a/.changeset/standardize-docs-and-code.md
+++ b/.changeset/standardize-docs-and-code.md
@@ -1,0 +1,4 @@
+---
+---
+
+Standardize documentation structure, import patterns, and test boilerplate across all rules

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,55 @@ Eight configs total. Six nextfriday presets built from three rule set tiers, eac
    - Add rule name to "should have correct rule names" test
 7. Create a changeset: `pnpm changeset` (required for CI to pass on PRs that change `src/` or `docs/`)
 
+### Rule Import Pattern
+
+All rule files follow a standardized import pattern:
+
+```typescript
+import { AST_NODE_TYPES, ESLintUtils } from "@typescript-eslint/utils";
+import type { TSESTree } from "@typescript-eslint/utils";
+```
+
+- Runtime imports (`AST_NODE_TYPES`, `ESLintUtils`) use a regular import
+- Type-only imports (`TSESTree`) use a separate `import type`
+- Imports are sorted alphabetically by specifier
+
+### Rule Documentation Format
+
+Standard structure for `docs/rules/{RULE_NAME}.md`:
+
+1. `# rule-name` — hyphenated name
+2. One-line description
+3. Optional fixable notice: `> This rule is auto-fixable using \`--fix\`.`
+4. `## Rule Details` — explanation, optional `### Why?` subsection
+5. `## Examples` with `### Incorrect` / `### Correct` subsections
+6. Optional reference sections (e.g., `## What This Rule Checks`, `## Exceptions`, `## Allowed Prefixes`)
+7. `## When Not To Use It`
+8. Optional `## Related Rules`
+
+Code blocks use `ts` for TypeScript, `tsx` for JSX — never `typescript`, `javascript`, or `jsx`. No emoji in docs. No `## Benefits`, `## Compatibility`, `## Version`, `## Code Examples`, or `## Applies To` sections.
+
+### Test Boilerplate
+
+```typescript
+import { afterAll, describe, it } from "@jest/globals";
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import rule from "../rule-name";
+
+RuleTester.afterAll = afterAll;
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const ruleTester = new RuleTester();
+```
+
+- Hooks are sorted alphabetically: `afterAll`, `describe`, `it`
+- No `RuleTester.itOnly` — omit it
+- No `import parser` — RuleTester uses its built-in parser
+- No `expect` import — structural tests use `toBeDefined()` from the `it` callback
+- Add `parserOptions: { ecmaFeatures: { jsx: true } }` only for JSX rules
+- Each test file ends with a `describe("rule structure", ...)` block asserting `meta` and `create` exist
+
 ### Rule Documentation URL Pattern
 
 ```typescript
@@ -100,6 +149,7 @@ Git hooks (husky): `pre-commit` runs lint-staged, `pre-push` runs tests + typech
 
 - No comments in code files - keep code self-documenting
 - Use clear, descriptive variable and function names
+- In `src/index.ts`: all imports, `rules` object keys, and rule set entries (`baseRules`, `jsxRules`, etc.) must be sorted alphabetically
 - Never add "Generated with Claude Code" or any AI branding/attribution to PR descriptions, commit messages, or any public-facing content
 - No Co-Authored-By trailers in commits (commitlint forbids body/footer anyway)
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ export default [nextfriday.configs["nextjs/recommended"]];
 
 #### Bundled Plugin Configs
 
-Pre-configured configs for popular plugins. No extra install needed — they ship as dependencies.
+Pre-configured configs for popular plugins. No extra install needed — they ship as dependencies. These configs are arrays, so use the spread operator (`...`) to merge them into your flat config.
 
 ```js
 import nextfriday from "eslint-plugin-nextfriday";
@@ -142,34 +142,7 @@ export default [
 ];
 ```
 
-### Legacy Config (ESLint 8 and below)
-
-#### Base Legacy Configuration
-
-```js
-module.exports = {
-  plugins: ["nextfriday"],
-  extends: ["plugin:nextfriday/base"], // or "plugin:nextfriday/base/recommended"
-};
-```
-
-#### React Legacy Configuration
-
-```js
-module.exports = {
-  plugins: ["nextfriday"],
-  extends: ["plugin:nextfriday/react"], // or "plugin:nextfriday/react/recommended"
-};
-```
-
-#### Next.js Legacy Configuration
-
-```js
-module.exports = {
-  plugins: ["nextfriday"],
-  extends: ["plugin:nextfriday/nextjs"], // or "plugin:nextfriday/nextjs/recommended"
-};
-```
+> **Note:** This plugin requires ESLint 9+ and only supports the flat config format. Legacy `.eslintrc` configurations are not supported.
 
 ## Rules
 
@@ -373,4 +346,4 @@ If you encounter any issues or have questions:
 
 ## License
 
-MIT - feel free to use this plugin in your projects!
+MIT

--- a/docs/rules/BOOLEAN_NAMING_PREFIX.md
+++ b/docs/rules/BOOLEAN_NAMING_PREFIX.md
@@ -8,9 +8,11 @@ This rule enforces that boolean variables and parameters use a descriptive prefi
 
 **Recommended prefixes:** `is`, `has`, `should`, `can`, `did`, `will`, `was`, `are`, `does`, `had`
 
-**Incorrect** code for this rule:
+## Examples
 
-```typescript
+### Incorrect
+
+```ts
 const valid = true;
 const user = false;
 const open = true;
@@ -30,9 +32,9 @@ const fn = (enabled: boolean) => {};
 function toggle(active = true) {}
 ```
 
-**Correct** code for this rule:
+### Correct
 
-```typescript
+```ts
 const isValid = true;
 const hasUser = false;
 const isOpen = true;
@@ -78,23 +80,11 @@ The rule identifies boolean variables and parameters by:
 | `does`   | Action capability             | `doesExist`, `doesMatch`, `doesContain`       |
 | `had`    | Past possession               | `hadError`, `hadAccess`, `hadPrevious`        |
 
-## Benefits
-
-- **Self-documenting code**: Boolean intent is immediately clear
-- **Reads like English**: `if (isActive)` reads as "if is active"
-- **Reduced ambiguity**: `user = false` vs `hasUser = false` - the latter is clear
-- **Consistent codebase**: Enforces uniform boolean naming across the project
-- **Better code review**: Reviewers can quickly understand boolean logic
-
-## When Not To Use
+## When Not To Use It
 
 - When working with external APIs that return boolean fields with different naming conventions
 - In mathematical or scientific code where single-letter variables are conventional
 - When interfacing with legacy code that would require extensive refactoring
-
-## Configuration
-
-This rule has no configuration options.
 
 ## Related Rules
 

--- a/docs/rules/ENFORCE_CONSTANT_CASE.md
+++ b/docs/rules/ENFORCE_CONSTANT_CASE.md
@@ -4,19 +4,13 @@ Enforce SCREAMING_SNAKE_CASE for constant primitive values.
 
 ## Rule Details
 
-This rule ensures that `const` declarations with primitive values (strings, numbers, booleans, template literals) use SCREAMING_SNAKE_CASE naming convention.
-
-### Why?
-
-- **Clarity**: SCREAMING_SNAKE_CASE clearly indicates a value is a constant that shouldn't change
-- **Convention**: Follows common JavaScript/TypeScript naming patterns for constants
-- **Readability**: Makes it easy to distinguish constants from regular variables
+This rule ensures that `const` declarations with primitive values (strings, numbers, booleans, template literals) use SCREAMING_SNAKE_CASE naming convention. Objects, arrays, and functions are not checked. Only `const` declarations are checked; `let` and `var` are ignored.
 
 ## Examples
 
-### ❌ Incorrect
+### Incorrect
 
-```typescript
+```ts
 const defaultCover = "/images/default.jpg";
 const pageLimit = 10;
 const isEnabled = true;
@@ -24,9 +18,9 @@ const apiBaseUrl = "https://api.example.com";
 const template = `hello world`;
 ```
 
-### ✅ Correct
+### Correct
 
-```typescript
+```ts
 const DEFAULT_COVER = "/images/default.jpg";
 const PAGE_LIMIT = 10;
 const IS_ENABLED = true;
@@ -47,10 +41,3 @@ var pageLimit = 10;
 
 - If your project uses different naming conventions for constants
 - If you prefer camelCase for all variable declarations
-
-## Notes
-
-- Only applies to `const` declarations
-- Only applies to primitive values: strings, numbers, booleans, template literals
-- Objects, arrays, and functions are not checked (can use camelCase/PascalCase)
-- `let` and `var` declarations are not checked

--- a/docs/rules/ENFORCE_CURLY_NEWLINE.md
+++ b/docs/rules/ENFORCE_CURLY_NEWLINE.md
@@ -13,9 +13,9 @@ This rule manages curly braces for `IfStatement` based on visual layout (line br
 
 ## Examples
 
-### ❌ Incorrect
+### Incorrect
 
-```tsx
+```ts
 // Single-line with braces (BAD)
 if (!data) {
   return [];
@@ -30,9 +30,9 @@ if (veryLongCondition && anotherCondition) return [];
 if (condition) doSomething();
 ```
 
-### ✅ Correct
+### Correct
 
-```tsx
+```ts
 // Single-line without braces (GOOD)
 if (!data) return [];
 if (x > 0) doSomething();

--- a/docs/rules/ENFORCE_HOOK_NAMING.md
+++ b/docs/rules/ENFORCE_HOOK_NAMING.md
@@ -4,7 +4,7 @@ Enforce `use` prefix for functions in custom hook files (`*.hook.ts`, `*.hooks.t
 
 ## Rule Details
 
-This rule ensures that all exported functions in custom hook files follow React's hook naming convention by starting with `use`.
+This rule ensures that all exported functions in custom hook files (`*.hook.ts`, `*.hooks.ts`) follow React's hook naming convention by starting with `use`.
 
 ### Why?
 
@@ -14,9 +14,9 @@ This rule ensures that all exported functions in custom hook files follow React'
 
 ## Examples
 
-### ❌ Incorrect
+### Incorrect
 
-```typescript
+```ts
 // search-params.hook.ts
 export function searchParamsHandler() {}
 export default handleSearch;
@@ -26,9 +26,9 @@ export const authManager = () => {};
 export default function customHook() {}
 ```
 
-### ✅ Correct
+### Correct
 
-```typescript
+```ts
 // search-params.hook.ts
 export function useSearchParamsHandler() {}
 export default useSearchParamsHandler;
@@ -42,10 +42,3 @@ export default function useCustomHook() {}
 
 - If your project uses a different naming convention for hook files
 - If you don't use the `*.hook.ts` or `*.hooks.ts` file naming pattern
-
-## Applies To
-
-This rule only applies to files matching:
-
-- `*.hook.ts`
-- `*.hooks.ts`

--- a/docs/rules/ENFORCE_PROPS_SUFFIX.md
+++ b/docs/rules/ENFORCE_PROPS_SUFFIX.md
@@ -4,17 +4,11 @@ Enforce `Props` suffix for interfaces and types in component files (`*.tsx`, `*.
 
 ## Rule Details
 
-This rule ensures that all interfaces and object type aliases in React component files end with the `Props` suffix for consistency and clarity.
-
-### Why?
-
-- **Clarity**: Clearly identifies types that represent component props
-- **Consistency**: Standardizes naming across all component files
-- **Convention**: Follows common React/TypeScript naming patterns
+This rule ensures that all interfaces and object type aliases in React component files (`.tsx`, `.jsx`) end with the `Props` suffix. Only interfaces and type aliases with object literal types are checked; union types, function types, and type references are not affected.
 
 ## Examples
 
-### ❌ Incorrect
+### Incorrect
 
 ```tsx
 // Button.tsx
@@ -25,7 +19,7 @@ interface Card {
 type ButtonType = { disabled: boolean };
 ```
 
-### ✅ Correct
+### Correct
 
 ```tsx
 // Button.tsx
@@ -46,15 +40,3 @@ type ButtonState = SomeOtherType;
 
 - If your project uses different naming conventions for prop types
 - If you have utility types in component files that shouldn't end with `Props`
-
-## Applies To
-
-This rule only applies to files with extensions:
-
-- `.tsx`
-- `.jsx`
-
-## Notes
-
-- Only interfaces and type aliases with object literal types are checked
-- Union types, function types, and type references are not affected

--- a/docs/rules/ENFORCE_READONLY_COMPONENT_PROPS.md
+++ b/docs/rules/ENFORCE_READONLY_COMPONENT_PROPS.md
@@ -8,7 +8,7 @@ This rule enforces that React component props using named types (interfaces or t
 
 ## Examples
 
-### ❌ Incorrect
+### Incorrect
 
 ```tsx
 interface Props {
@@ -35,7 +35,7 @@ function Layout(props: LayoutProps) {
 }
 ```
 
-### ✅ Correct
+### Correct
 
 ```tsx
 interface Props {
@@ -77,7 +77,7 @@ const helper = (props: HelperProps) => {
 };
 ```
 
-## When Not To Use
+## When Not To Use It
 
 This rule should not be used if:
 
@@ -93,12 +93,3 @@ This rule is fixable using ESLint's `--fix` option. The fixer will automatically
 
 - [`prefer-interface-over-inline-types`](./PREFER_INTERFACE_OVER_INLINE_TYPES.md) - Enforces interface declarations over inline types
 - [`react-props-destructure`](./REACT_PROPS_DESTRUCTURE.md) - Enforces destructuring props inside component body
-
-## Configuration
-
-This rule is included in the following configurations:
-
-- `react` (warn)
-- `react/recommended` (error)
-- `nextjs` (warn)
-- `nextjs/recommended` (error)

--- a/docs/rules/ENFORCE_SERVICE_NAMING.md
+++ b/docs/rules/ENFORCE_SERVICE_NAMING.md
@@ -4,7 +4,7 @@ Enforce `fetch` prefix for async functions in `*.service.ts` files instead of `g
 
 ## Rule Details
 
-This rule ensures consistent naming conventions for service layer functions. In service files, async data-fetching functions should use the `fetch` prefix to clearly indicate they perform network/API calls.
+This rule ensures consistent naming conventions for service layer functions. In `*.service.ts` files, async data-fetching functions should use the `fetch` prefix to clearly indicate they perform network/API calls.
 
 ### Why?
 
@@ -14,9 +14,9 @@ This rule ensures consistent naming conventions for service layer functions. In 
 
 ## Examples
 
-### ❌ Incorrect
+### Incorrect
 
-```typescript
+```ts
 // article.service.ts
 export async function getArticles() {}
 export async function loadFaq() {}
@@ -24,9 +24,9 @@ export async function getUserById() {}
 export const getUsers = async () => {};
 ```
 
-### ✅ Correct
+### Correct
 
-```typescript
+```ts
 // article.service.ts
 export async function fetchArticles() {}
 export async function fetchFaqList() {}
@@ -46,7 +46,3 @@ export async function deleteComment() {}
 
 - If your project uses different naming conventions for service functions
 - If you prefer `get`/`load` prefixes for data-fetching operations
-
-## Applies To
-
-This rule only applies to files matching `*.service.ts`.

--- a/docs/rules/ENFORCE_SORTED_DESTRUCTURING.md
+++ b/docs/rules/ENFORCE_SORTED_DESTRUCTURING.md
@@ -24,7 +24,7 @@ Properties are sorted in this order:
 
 ## Examples
 
-### ❌ Incorrect
+### Incorrect
 
 ```js
 // Bad: Not sorted alphabetically
@@ -66,7 +66,7 @@ const { b, a } = foo;
 const { duration = 5000, autoplay = false, totalSlides } = options;
 ```
 
-### ✅ Correct
+### Correct
 
 ```js
 // Good: Alphabetically sorted without defaults

--- a/docs/rules/FILE_KEBAB_CASE.md
+++ b/docs/rules/FILE_KEBAB_CASE.md
@@ -4,13 +4,13 @@ Enforce kebab-case filenames for .ts and .js files.
 
 ## Rule Details
 
-This rule enforces that all TypeScript (.ts) and JavaScript (.js) files use kebab-case naming convention for their **filenames**. Kebab-case uses lowercase letters and hyphens to separate words, making filenames more consistent and URL-friendly.
+This rule enforces that all TypeScript (.ts) and JavaScript (.js) files use kebab-case naming convention for their **filenames**. Kebab-case uses lowercase letters and hyphens to separate words, making filenames more consistent and URL-friendly. Single word filenames are considered valid kebab-case.
 
-**This rule checks the filename, not the code content.**
+**This rule checks the filename, not the code content.** Only `.ts` and `.js` files are checked; other file types are ignored.
 
 ## Examples
 
-**Incorrect** filenames for this rule:
+### Incorrect
 
 - `MyFile.ts` (PascalCase)
 - `camelCase.js` (camelCase)
@@ -19,7 +19,7 @@ This rule enforces that all TypeScript (.ts) and JavaScript (.js) files use keba
 - `UPPERCASE.ts` (UPPERCASE)
 - `My File.js` (contains spaces)
 
-**Correct** filenames for this rule:
+### Correct
 
 - `my-file.ts`
 - `kebab-case.js`
@@ -28,56 +28,6 @@ This rule enforces that all TypeScript (.ts) and JavaScript (.js) files use keba
 - `user-service.ts`
 - `api-utils.ts`
 
-## Code Examples
-
-The content of the file doesn't matter - only the filename is checked:
-
-```typescript
-// INCORRECT: File: MyFile.ts (incorrect filename)
-function myFunction() {
-  return "Hello World";
-}
-
-export { myFunction };
-```
-
-```typescript
-// CORRECT: File: my-file.ts (correct filename)
-function myFunction() {
-  return "Hello World";
-}
-
-export { myFunction };
-```
-
-```javascript
-// INCORRECT: File: UserService.js (incorrect filename)
-class UserService {
-  getUser() {
-    return {};
-  }
-}
-
-export { UserService };
-```
-
-```javascript
-// CORRECT: File: user-service.js (correct filename)
-class UserService {
-  getUser() {
-    return {};
-  }
-}
-
-export { UserService };
-```
-
 ## When Not To Use It
 
 If your project has established naming conventions that conflict with kebab-case, or if you're working with frameworks that require specific filename patterns, you may want to disable this rule.
-
-## Notes
-
-- This rule only applies to `.ts` and `.js` files
-- Other file types (`.jsx`, `.tsx`, `.json`, etc.) are ignored
-- Single word filenames are considered valid kebab-case

--- a/docs/rules/JSX_NEWLINE_BETWEEN_ELEMENTS.md
+++ b/docs/rules/JSX_NEWLINE_BETWEEN_ELEMENTS.md
@@ -6,9 +6,9 @@ Require empty lines between sibling JSX elements when at least one spans multipl
 
 This rule enforces empty lines between sibling JSX elements when either element spans multiple lines. This improves visual separation and readability of complex component structures. Single-line elements do not require empty lines between them.
 
-### Examples
+## Examples
 
-#### Incorrect
+### Incorrect
 
 ```jsx
 function Dashboard() {
@@ -37,7 +37,7 @@ function UserProfile() {
 }
 ```
 
-#### Correct
+### Correct
 
 Multi-line elements need empty lines between them:
 

--- a/docs/rules/JSX_NO_INLINE_OBJECT_PROP.md
+++ b/docs/rules/JSX_NO_INLINE_OBJECT_PROP.md
@@ -14,7 +14,7 @@ This rule flags inline object literals used directly as JSX prop values. Inline 
 
 ## Examples
 
-### ❌ Incorrect
+### Incorrect
 
 ```tsx
 <Component style={{ color: "red" }} />
@@ -23,7 +23,7 @@ This rule flags inline object literals used directly as JSX prop values. Inline 
 <div style={{ margin: 0 }} />
 ```
 
-### ✅ Correct
+### Correct
 
 ```tsx
 const style = { color: "red" };

--- a/docs/rules/JSX_NO_NEWLINE_SINGLE_LINE_ELEMENTS.md
+++ b/docs/rules/JSX_NO_NEWLINE_SINGLE_LINE_ELEMENTS.md
@@ -2,6 +2,8 @@
 
 Disallow empty lines between single-line sibling JSX elements.
 
+> This rule is auto-fixable using `--fix`.
+
 ## Rule Details
 
 This rule enforces that sibling JSX elements which are both single-line should not have empty lines between them. Single-line elements should be compact and grouped together.
@@ -16,7 +18,7 @@ Use with `jsx-newline-between-elements` which requires empty lines between multi
 
 ## Examples
 
-### ❌ Incorrect
+### Incorrect
 
 ```tsx
 // Bad: Unnecessary empty line between single-line siblings
@@ -38,7 +40,7 @@ Use with `jsx-newline-between-elements` which requires empty lines between multi
 </ul>
 ```
 
-### ✅ Correct
+### Correct
 
 ```tsx
 // Good: Single-line siblings are compact

--- a/docs/rules/JSX_NO_NON_COMPONENT_FUNCTION.md
+++ b/docs/rules/JSX_NO_NON_COMPONENT_FUNCTION.md
@@ -18,7 +18,7 @@ This rule prevents non-component functions from being defined at the top level i
 
 ## Examples
 
-### ❌ Incorrect
+### Incorrect
 
 ```tsx
 // Bad: Non-component function defined at top level in .tsx file
@@ -62,7 +62,7 @@ const OrderSummary = () => {
 export { OrderSummary };
 ```
 
-### ✅ Correct
+### Correct
 
 ```tsx
 // Good: Function imported from separate file
@@ -91,7 +91,7 @@ const Component = () => {
 };
 ```
 
-```typescript
+```ts
 // Good: Functions in .ts or .js files are allowed
 // utils.ts
 function helper(name: string) {

--- a/docs/rules/JSX_NO_VARIABLE_IN_CALLBACK.md
+++ b/docs/rules/JSX_NO_VARIABLE_IN_CALLBACK.md
@@ -15,7 +15,7 @@ This rule prevents variable declarations inside callback functions that are dire
 
 ## Examples
 
-### ❌ Incorrect
+### Incorrect
 
 ```tsx
 // Bad: Variable declared inside map callback in JSX
@@ -61,7 +61,7 @@ const OrderSummary = ({ orders }) => {
 };
 ```
 
-### ✅ Correct
+### Correct
 
 ```tsx
 // Good: Extract logic to a separate function

--- a/docs/rules/JSX_PASCAL_CASE.md
+++ b/docs/rules/JSX_PASCAL_CASE.md
@@ -10,7 +10,7 @@ This rule enforces that JSX and TSX files use PascalCase naming convention for t
 
 ## Examples
 
-**Incorrect** filenames for this rule:
+### Incorrect
 
 - `my-component.jsx` (kebab-case)
 - `userProfile.jsx` (camelCase)
@@ -20,7 +20,7 @@ This rule enforces that JSX and TSX files use PascalCase naming convention for t
 - `My Component.jsx` (contains spaces)
 - `My.Component.tsx` (contains dots)
 
-**Correct** filenames for this rule:
+### Correct
 
 - `MyComponent.jsx`
 - `UserProfile.tsx`
@@ -28,47 +28,7 @@ This rule enforces that JSX and TSX files use PascalCase naming convention for t
 - `LoginForm.tsx`
 - `UserProfile2.jsx` (PascalCase with numbers)
 
-## Code Examples
-
-The content of the file doesn't matter - only the filename is checked:
-
-```jsx
-// INCORRECT: File: my-component.jsx (incorrect filename)
-function MyComponent() {
-  return <div>Hello</div>;
-}
-
-export default MyComponent;
-```
-
-```jsx
-// CORRECT: File: MyComponent.jsx (correct filename)
-function MyComponent() {
-  return <div>Hello</div>;
-}
-
-export default MyComponent;
-```
-
-```tsx
-// INCORRECT: File: user-profile.tsx (incorrect filename)
-function UserProfile() {
-  return <div>Profile</div>;
-}
-
-export default UserProfile;
-```
-
-```tsx
-// CORRECT: File: UserProfile.tsx (correct filename)
-function UserProfile() {
-  return <div>Profile</div>;
-}
-
-export default UserProfile;
-```
-
-## When Not To Use
+## When Not To Use It
 
 If your project uses different naming conventions for JSX/TSX files, you can disable this rule.
 

--- a/docs/rules/JSX_REQUIRE_SUSPENSE.md
+++ b/docs/rules/JSX_REQUIRE_SUSPENSE.md
@@ -14,7 +14,7 @@ This rule ensures that components created with `lazy()` or `React.lazy()` are al
 
 ## Examples
 
-### ❌ Incorrect
+### Incorrect
 
 ```tsx
 const AsyncComponent = lazy(() => import("./Component"));
@@ -29,7 +29,7 @@ const LazyModal = React.lazy(() => import("./Modal"));
 </div>
 ```
 
-### ✅ Correct
+### Correct
 
 ```tsx
 const AsyncComponent = lazy(() => import("./Component"));

--- a/docs/rules/JSX_SIMPLE_PROPS.md
+++ b/docs/rules/JSX_SIMPLE_PROPS.md
@@ -15,7 +15,7 @@ This rule flags complex expressions used as JSX prop values. Props should only c
 
 ## Examples
 
-### ❌ Incorrect
+### Incorrect
 
 ```tsx
 <Component onClick={handleClick()} />
@@ -28,7 +28,7 @@ This rule flags complex expressions used as JSX prop values. Props should only c
 <Component visible={a && b} />
 ```
 
-### ✅ Correct
+### Correct
 
 ```tsx
 <Component name="test" />

--- a/docs/rules/JSX_SORT_PROPS.md
+++ b/docs/rules/JSX_SORT_PROPS.md
@@ -23,7 +23,7 @@ Props with values that cannot be statically determined (variables, member expres
 
 ## Examples
 
-### ❌ Incorrect
+### Incorrect
 
 ```tsx
 <Component disabled title="hello" />
@@ -31,7 +31,7 @@ Props with values that cannot be statically determined (variables, member expres
 <Component icon={<Icon />} style={{ color: "red" }} />
 ```
 
-### ✅ Correct
+### Correct
 
 ```tsx
 <Component

--- a/docs/rules/MD_FILENAME_CASE_RESTRICTION.md
+++ b/docs/rules/MD_FILENAME_CASE_RESTRICTION.md
@@ -4,13 +4,13 @@ Enforce SNAKE_CASE filenames for .md files.
 
 ## Rule Details
 
-This rule enforces that all Markdown (.md) files use SNAKE_CASE naming convention for their **filenames**. SNAKE_CASE uses UPPERCASE letters and underscores to separate words. This helps maintain consistency for documentation files and ensures they stand out from regular code files.
+This rule enforces that all Markdown (.md) files use UPPER_SNAKE_CASE naming convention for their **filenames**. All letters must be uppercase with underscores separating words. May contain numbers.
 
-**This rule checks the filename, not the file content.**
+**This rule checks the filename, not the file content.** Only `.md` files are checked; other file types are ignored.
 
 ## Examples
 
-**Correct** filenames for this rule:
+### Correct
 
 - `README.md` (SNAKE_CASE)
 - `CHANGELOG.md` (SNAKE_CASE)
@@ -22,7 +22,7 @@ This rule enforces that all Markdown (.md) files use SNAKE_CASE naming conventio
 - `GUIDE_2024.md` (SNAKE_CASE with numbers)
 - `LICENSE_MIT.md` (SNAKE_CASE with underscores)
 
-**Incorrect** filenames for this rule:
+### Incorrect
 
 - `readme.md` (lowercase)
 - `user-guide.md` (kebab-case)
@@ -31,58 +31,6 @@ This rule enforces that all Markdown (.md) files use SNAKE_CASE naming conventio
 - `myREADME.md` (mixed case)
 - `User guide.md` (contains spaces)
 
-## Code Examples
-
-The content of the file doesn't matter - only the filename is checked:
-
-```markdown
-<!-- INCORRECT: File: readme.md (incorrect filename) -->
-
-# My Project
-
-This is a sample project.
-```
-
-```markdown
-<!-- CORRECT: File: README.md (correct filename) -->
-
-# My Project
-
-This is a sample project.
-```
-
-```markdown
-<!-- INCORRECT: File: user-guide.md (incorrect filename) -->
-
-# User Guide
-
-Follow these steps to get started.
-```
-
-```markdown
-<!-- CORRECT: File: USER_GUIDE.md (correct filename) -->
-
-# User Guide
-
-Follow these steps to get started.
-```
-
-## Valid Patterns
-
-### SNAKE_CASE
-
-- All letters are UPPERCASE
-- Uses underscores to separate words
-- May contain numbers
-- Examples: `README.md`, `USER_GUIDE.md`, `GUIDE_2024.md`, `LICENSE_MIT.md`
-
 ## When Not To Use It
 
 If your project has established naming conventions for documentation that conflict with this rule, or if you need to maintain compatibility with external tools that expect specific markdown filename patterns, you may want to disable this rule.
-
-## Notes
-
-- This rule only applies to `.md` files
-- Other file types are ignored
-- Single word filenames must be UPPERCASE (e.g., `README.md`, `LICENSE.md`)
-- Underscores are used to separate words in multi-word filenames

--- a/docs/rules/NEWLINE_AFTER_MULTILINE_BLOCK.md
+++ b/docs/rules/NEWLINE_AFTER_MULTILINE_BLOCK.md
@@ -6,9 +6,9 @@ Require a blank line before and after multi-line statements.
 
 This rule enforces a blank line before and after any statement that spans multiple lines. This improves code readability by visually separating logical blocks. Single-line statements do not require blank lines between them.
 
-### Examples
+## Examples
 
-#### Incorrect
+### Incorrect
 
 ```ts
 const apiClient = axios.create({
@@ -45,7 +45,7 @@ const nestedCategory = CATEGORIES.flatMap((category) => category.children ?? [])
 );
 ```
 
-#### Correct
+### Correct
 
 Multi-line statements need a blank line before and after them:
 

--- a/docs/rules/NEWLINE_BEFORE_RETURN.md
+++ b/docs/rules/NEWLINE_BEFORE_RETURN.md
@@ -6,9 +6,9 @@ Require a blank line before return statements.
 
 This rule enforces a blank line before `return` statements when they are preceded by other statements. This improves readability by visually separating the return value from the logic that precedes it. A blank line is not required when the return statement is the only statement in the function body.
 
-### Examples
+## Examples
 
-#### Incorrect
+### Incorrect
 
 ```ts
 function findUserById(users: User[], id: string): User | null {
@@ -34,7 +34,7 @@ function getNodeValue(node: ASTNode): ASTNode {
 }
 ```
 
-#### Correct
+### Correct
 
 ```ts
 function findUserById(users: User[], id: string): User | null {

--- a/docs/rules/NEXTJS_REQUIRE_PUBLIC_ENV.md
+++ b/docs/rules/NEXTJS_REQUIRE_PUBLIC_ENV.md
@@ -4,17 +4,11 @@ Require `NEXT_PUBLIC_` prefix for environment variables in client components.
 
 ## Rule Details
 
-This rule ensures that environment variables accessed in Next.js client components (files with `"use client"` directive) use the `NEXT_PUBLIC_` prefix. In Next.js, only environment variables prefixed with `NEXT_PUBLIC_` are exposed to the browser.
-
-### Why?
-
-- **Security**: Prevents accidental exposure of server-only secrets to the client bundle
-- **Runtime Errors**: Non-public env vars will be `undefined` in client components
-- **Next.js Requirement**: Only `NEXT_PUBLIC_` prefixed variables are available client-side
+This rule ensures that environment variables accessed in Next.js client components (files with `"use client"` directive) use the `NEXT_PUBLIC_` prefix. In Next.js, only environment variables prefixed with `NEXT_PUBLIC_` are exposed to the browser. Only files with `"use client"` directive are checked. `NODE_ENV` is always allowed.
 
 ## Examples
 
-### ❌ Incorrect
+### Incorrect
 
 ```tsx
 "use client";
@@ -25,7 +19,7 @@ const secret = process.env.DATABASE_SECRET;
 const key = process.env.PRIVATE_API_KEY;
 ```
 
-### ✅ Correct
+### Correct
 
 ```tsx
 "use client";
@@ -48,13 +42,3 @@ const secret = process.env.API_SECRET;
 
 - If you're not using Next.js
 - If you have a custom build setup that exposes env vars differently
-
-## Notes
-
-- Only applies to files with `"use client"` directive
-- `NODE_ENV` is always allowed (built into Next.js)
-- Server components (without `"use client"`) are not checked
-
-## Related
-
-- [Next.js Environment Variables Documentation](https://nextjs.org/docs/app/building-your-application/configuring/environment-variables)

--- a/docs/rules/NO_COMPLEX_INLINE_RETURN.md
+++ b/docs/rules/NO_COMPLEX_INLINE_RETURN.md
@@ -6,9 +6,11 @@ Disallow complex inline expressions in return statements - prefer extracting to 
 
 This rule enforces a pattern where complex expressions (ternary operators, logical expressions, new expressions) are extracted to a const variable before being returned. This improves code readability and makes debugging easier by allowing you to inspect intermediate values.
 
-**Incorrect** code for this rule:
+## Examples
 
-```typescript
+### Incorrect
+
+```ts
 function waitForLoad(targetWindow: Window) {
   return targetWindow.document.readyState === "complete"
     ? Promise.resolve()
@@ -42,9 +44,9 @@ function checkStatus(a: boolean, b: boolean) {
 }
 ```
 
-**Correct** code for this rule:
+### Correct
 
-```typescript
+```ts
 function waitForLoad(targetWindow: Window) {
   const loadPromise =
     targetWindow.document.readyState === "complete"
@@ -102,14 +104,7 @@ function getMath() {
 }
 ```
 
-## Benefits
-
-- **Better readability**: Complex logic is separated from the return statement
-- **Easier debugging**: Intermediate values can be inspected in debuggers
-- **Self-documenting**: Variable names can describe what the complex expression represents
-- **Consistent style**: Enforces a uniform approach to handling complex return values
-
-## When Not To Use
+## When Not To Use It
 
 - For very simple projects where inline expressions are preferred
 - When you prefer a more compact coding style
@@ -130,7 +125,3 @@ The following are allowed in return statements:
 - Binary expressions (math operations like `a + b`)
 - Object/array literals
 - Member expressions (`obj.prop`)
-
-## Related Rules
-
-- No related rules

--- a/docs/rules/NO_DIRECT_DATE.md
+++ b/docs/rules/NO_DIRECT_DATE.md
@@ -8,7 +8,7 @@ This rule prevents the use of the native JavaScript `Date` constructor and its s
 
 ## Examples
 
-**Incorrect** code for this rule:
+### Incorrect
 
 ```js
 const now = new Date();
@@ -19,7 +19,7 @@ const dateFromTimestamp = new Date(1704067200000);
 const dateFromParts = new Date(2024, 0, 1);
 ```
 
-**Correct** code for this rule:
+### Correct
 
 ```js
 import dayjs from "dayjs";

--- a/docs/rules/NO_EMOJI.md
+++ b/docs/rules/NO_EMOJI.md
@@ -8,18 +8,18 @@ This rule prevents the use of emoji characters in JavaScript and TypeScript sour
 
 ## Examples
 
-**Incorrect** code for this rule:
+### Incorrect
 
-```js
+```ts
 const message = "Hello 🌍 world";
 const greeting = "Hi there! 👋";
 // Comment with emoji 😀
 const celebration = "🎉 Party time! 🎊";
 ```
 
-**Correct** code for this rule:
+### Correct
 
-```js
+```ts
 const message = "Hello world";
 const greeting = "Hi there!";
 // Comment without emoji

--- a/docs/rules/NO_ENV_FALLBACK.md
+++ b/docs/rules/NO_ENV_FALLBACK.md
@@ -10,7 +10,7 @@ It's safer to let the application fail explicitly when required environment vari
 
 ## Examples
 
-**Incorrect** code for this rule:
+### Incorrect
 
 ```js
 const apiKey = process.env.API_KEY || "default-key";
@@ -27,7 +27,7 @@ function getToken() {
 }
 ```
 
-**Correct** code for this rule:
+### Correct
 
 ```js
 const apiKey = process.env.API_KEY;

--- a/docs/rules/NO_INLINE_DEFAULT_EXPORT.md
+++ b/docs/rules/NO_INLINE_DEFAULT_EXPORT.md
@@ -6,9 +6,11 @@ Disallow inline exports. Declare first, then export separately.
 
 This rule enforces separating declarations from exports. Instead of `export function`, declare the function first, then export it.
 
-**Incorrect** code for this rule:
+## Examples
 
-```typescript
+### Incorrect
+
+```ts
 // Inline named export
 export function fetchData() {
   return fetch("/api");
@@ -42,9 +44,9 @@ export default function () {
 export default () => "arrow";
 ```
 
-**Correct** code for this rule:
+### Correct
 
-```typescript
+```ts
 // Declare function, then export
 function fetchData() {
   return fetch("/api");
@@ -86,13 +88,7 @@ export default "literal";
 export default { key: "value" };
 ```
 
-## Benefits
-
-- **Readability**: Easy to see what a module exports at a glance
-- **Consistency**: All exports follow the same pattern
-- **Refactoring**: Easier to rename or move declarations
-
-## When Not To Use
+## When Not To Use It
 
 If your project prefers inline exports for brevity, you may want to disable this rule.
 

--- a/docs/rules/NO_INLINE_NESTED_OBJECT.md
+++ b/docs/rules/NO_INLINE_NESTED_OBJECT.md
@@ -6,9 +6,9 @@ Require nested objects and arrays to span multiple lines.
 
 This rule enforces that when an object property's value is another object or array, it should span multiple lines rather than being written inline. This improves readability and makes diffs cleaner when properties are added or removed.
 
-### Examples
+## Examples
 
-#### Incorrect
+### Incorrect
 
 ```ts
 const config = {
@@ -23,13 +23,7 @@ const routes = {
 };
 ```
 
-```ts
-const validationRules = {
-  required: ["name", "email", "password"],
-};
-```
-
-#### Correct
+### Correct
 
 ```ts
 const config = {

--- a/docs/rules/NO_LAZY_IDENTIFIERS.md
+++ b/docs/rules/NO_LAZY_IDENTIFIERS.md
@@ -6,9 +6,11 @@ Disallow lazy, meaningless variable names that hurt code readability.
 
 This rule enforces meaningful variable names by detecting and disallowing lazy identifiers. It uses pattern-based detection to find repeated characters and keyboard sequences.
 
-**Incorrect** code for this rule:
+## Examples
 
-```typescript
+### Incorrect
+
+```ts
 const xxx = "value";
 const yyy = 123;
 const zzz = true;
@@ -29,9 +31,9 @@ const { xxx } = obj;
 const [aaa, bbb] = array;
 ```
 
-**Correct** code for this rule:
+### Correct
 
-```typescript
+```ts
 const userName = "john";
 const itemCount = 123;
 const isActive = true;
@@ -80,25 +82,14 @@ Identifiers shorter than 3 characters are ignored (use `no-single-char-variables
 
 Variables starting with `_` are allowed (commonly used for unused variables):
 
-```typescript
+```ts
 const _unused = getValue();
 ```
 
-## Benefits
-
-- **Readable code**: Meaningful names make code self-documenting
-- **Maintainability**: Other developers can understand the purpose of variables
-- **Professionalism**: Clean code reflects well on the team
-- **Debugging**: Clear names make debugging easier
-
-## When Not To Use
+## When Not To Use It
 
 - In test files where placeholder data is acceptable
 - When working with legacy code that would be disruptive to change
-
-## Configuration
-
-This rule has no configuration options.
 
 ## Related Rules
 

--- a/docs/rules/NO_LOGIC_IN_PARAMS.md
+++ b/docs/rules/NO_LOGIC_IN_PARAMS.md
@@ -6,9 +6,11 @@ Disallow logic or conditions in function parameters - extract to a const variabl
 
 This rule enforces a pattern where complex expressions (logical operators, ternary operators, comparison operators) are extracted to a const variable before being passed as function arguments. This improves code readability, makes debugging easier, and helps maintain cleaner function calls.
 
-**Incorrect** code for this rule:
+## Examples
 
-```typescript
+### Incorrect
+
+```ts
 // Nullish coalescing
 functionFoo(bar ?? baz);
 
@@ -35,9 +37,9 @@ createUser(username, age >= 18, status === "active");
 new MyClass(a || b);
 ```
 
-**Correct** code for this rule:
+### Correct
 
-```typescript
+```ts
 // Extract logic to a variable first
 const value = bar ?? baz;
 functionFoo(value);
@@ -83,15 +85,7 @@ configure({ key: "value" });
 process([1, 2, 3]);
 ```
 
-## Benefits
-
-- **Better readability**: Logic is separated from function calls, making code easier to scan
-- **Easier debugging**: Intermediate values can be inspected in debuggers before being passed to functions
-- **Self-documenting**: Variable names describe what the complex expression represents
-- **Consistent style**: Enforces a uniform approach to handling complex function arguments
-- **Reduced cognitive load**: Readers don't need to mentally evaluate expressions while also understanding function calls
-
-## When Not To Use
+## When Not To Use It
 
 - For very simple projects where inline expressions are preferred
 - When you prefer a more compact coding style

--- a/docs/rules/NO_NESTED_TERNARY.md
+++ b/docs/rules/NO_NESTED_TERNARY.md
@@ -8,9 +8,9 @@ Nested ternary expressions are difficult to read and understand. This rule enfor
 
 ## Examples
 
-### ❌ Incorrect
+### Incorrect
 
-```tsx
+```ts
 const status = isLoading ? "loading" : isError ? "error" : "success";
 
 const value = a ? (b ? 1 : 2) : 3;
@@ -18,9 +18,9 @@ const value = a ? (b ? 1 : 2) : 3;
 const result = condition1 ? value1 : condition2 ? value2 : condition3 ? value3 : defaultValue;
 ```
 
-### ✅ Correct
+### Correct
 
-```tsx
+```ts
 // Simple ternary (no nesting)
 const status = isLoading ? "loading" : "success";
 

--- a/docs/rules/NO_RELATIVE_IMPORTS.md
+++ b/docs/rules/NO_RELATIVE_IMPORTS.md
@@ -14,9 +14,9 @@ This rule flags imports that use `../` to traverse parent directories. Sibling i
 
 ## Examples
 
-### ❌ Incorrect
+### Incorrect
 
-```typescript
+```ts
 import { Button } from "../../../components/base/button";
 import { Header } from "../components/Header";
 import { utils } from "../utils";
@@ -24,9 +24,9 @@ import type { Props } from "../types";
 export { foo } from "../shared";
 ```
 
-### ✅ Correct
+### Correct
 
-```typescript
+```ts
 import { Button } from "src/components/base/button";
 import { Header } from "@/components/Header";
 import { mapper } from "./article.mapper"; // sibling imports are OK

--- a/docs/rules/NO_SINGLE_CHAR_VARIABLES.md
+++ b/docs/rules/NO_SINGLE_CHAR_VARIABLES.md
@@ -6,9 +6,11 @@ Disallow single character variable and parameter names for better code readabili
 
 This rule enforces descriptive variable and parameter names by disallowing single character identifiers. Single character names like `d`, `u`, `l`, `r` are cryptic and make code harder to understand. They require readers to guess or track what each variable represents.
 
-**Incorrect** code for this rule:
+## Examples
 
-```typescript
+### Incorrect
+
+```ts
 const d = new Date();
 const u = await getUser();
 const l = list.length;
@@ -31,9 +33,9 @@ try {
 } catch (e) {}
 ```
 
-**Correct** code for this rule:
+### Correct
 
-```typescript
+```ts
 const currentDate = new Date();
 const currentUser = await getUser();
 const itemCount = list.length;
@@ -66,7 +68,7 @@ The rule allows the following exceptions:
 
 Single character loop counters `i`, `j`, `k`, `n` are allowed in traditional for loops:
 
-```typescript
+```ts
 for (let i = 0; i < 10; i++) {}
 for (let j = 0; j < items.length; j++) {}
 for (let i = 0, j = 10; i < j; i++, j--) {}
@@ -78,29 +80,17 @@ Note: These are only allowed in traditional `for` loops, not in `for...of` or `f
 
 A single underscore `_` is allowed to indicate intentionally unused variables:
 
-```typescript
+```ts
 const _ = unusedValue;
 const [_, second] = array;
 array.map((_, index) => index);
 ```
 
-## Benefits
-
-- **Self-documenting code**: Descriptive names make code readable without additional comments
-- **Reduced cognitive load**: No need to track or guess what single letters represent
-- **Better IDE support**: Meaningful names provide better autocomplete and search results
-- **Easier debugging**: Clear variable names make debugging and code review faster
-- **Improved collaboration**: Team members can understand code without additional context
-
-## When Not To Use
+## When Not To Use It
 
 - For very short scripts or throwaway code
 - When working with mathematical formulas where single letters are conventional (e.g., `x`, `y` for coordinates)
 - In legacy codebases where this pattern is established and changing would be disruptive
-
-## Configuration
-
-This rule has no configuration options.
 
 ## Related Rules
 

--- a/docs/rules/PREFER_ASYNC_AWAIT.md
+++ b/docs/rules/PREFER_ASYNC_AWAIT.md
@@ -15,9 +15,9 @@ This rule flags the use of `.then()` method calls and encourages using async/awa
 
 ## Examples
 
-### ❌ Incorrect
+### Incorrect
 
-```typescript
+```ts
 fetch(url)
   .then((res) => res.json())
   .then((data) => setData(data));
@@ -31,9 +31,9 @@ fetchData().then(handleSuccess).catch(handleError);
 promise.then(step1).then(step2).then(step3);
 ```
 
-### ✅ Correct
+### Correct
 
-```typescript
+```ts
 async function fetchData() {
   const res = await fetch(url);
   const data = await res.json();

--- a/docs/rules/PREFER_DESTRUCTURING_PARAMS.md
+++ b/docs/rules/PREFER_DESTRUCTURING_PARAMS.md
@@ -6,9 +6,11 @@ Enforce destructuring for functions with multiple parameters.
 
 This rule enforces the use of object destructuring for functions that have multiple parameters. This improves code readability and makes it easier to understand what parameters a function expects.
 
-**Incorrect** code for this rule:
+## Examples
 
-```javascript
+### Incorrect
+
+```ts
 function createUser(name, email, age, address) {
   // ...
 }
@@ -18,9 +20,9 @@ const processOrder = (orderId, customerId, items, total) => {
 };
 ```
 
-**Correct** code for this rule:
+### Correct
 
-```javascript
+```ts
 function createUser({ name, email, age, address }) {
   // ...
 }
@@ -45,19 +47,8 @@ function updateUser({ name, email }, additionalData) {
 }
 ```
 
-## Benefits
-
-- **Improved readability**: It's clear what properties are expected
-- **Better maintainability**: Adding or removing parameters is easier
-- **Self-documenting code**: Parameter names are explicit at the call site
-- **TypeScript benefits**: Better type inference and autocompletion
-
-## When Not To Use
+## When Not To Use It
 
 - If your project prefers traditional parameter lists
 - For performance-critical functions where destructuring overhead matters
 - When dealing with legacy code that can't be easily refactored
-
-## Related Rules
-
-- No related rules

--- a/docs/rules/PREFER_FUNCTION_DECLARATION.md
+++ b/docs/rules/PREFER_FUNCTION_DECLARATION.md
@@ -8,9 +8,11 @@ This rule requires using function declarations instead of arrow functions or fun
 
 **Target:** `.ts` files only (not `.tsx`, `.js`, or `.d.ts`)
 
-**Incorrect** code for this rule:
+## Examples
 
-```typescript
+### Incorrect
+
+```ts
 // Arrow function assigned to variable
 const formatDate = (date: Date) => {
   return date.toLocaleDateString("th-TH");
@@ -30,9 +32,9 @@ const fetchUser = async (id: string) => {
 };
 ```
 
-**Correct** code for this rule:
+### Correct
 
-```typescript
+```ts
 // Function declaration
 function formatDate(date: Date) {
   return date.toLocaleDateString("th-TH");
@@ -60,7 +62,7 @@ Arrow functions are still allowed in the following contexts:
 
 ### Callbacks
 
-```typescript
+```ts
 const years = dates.map((date) => date.getFullYear());
 const active = items.filter((item) => item.active);
 const sorted = items.sort((a, b) => a.name.localeCompare(b.name));
@@ -70,7 +72,7 @@ setTimeout(() => console.log("done"), 1000);
 
 ### Object Properties
 
-```typescript
+```ts
 const handler = {
   onClick: () => console.log("clicked"),
   onHover: () => setHovered(true),
@@ -79,13 +81,13 @@ const handler = {
 
 ### Array Elements
 
-```typescript
+```ts
 const callbacks = [() => 1, () => 2, () => 3];
 ```
 
 ### Return Values
 
-```typescript
+```ts
 function createHandler() {
   return () => console.log("handled");
 }
@@ -93,32 +95,19 @@ function createHandler() {
 
 ### Conditional/Logical Expressions
 
-```typescript
+```ts
 const fn = condition ? () => valueA : () => valueB;
 const handler = defaultFn || (() => fallback);
 ```
 
 ### TSX Files
 
-```typescript
+```ts
 // components/Button.tsx - Arrow functions allowed
 const Button = () => <button>Click me</button>;
 ```
 
-## Benefits
-
-- **Hoisting**: Function declarations are hoisted
-- **Better readability**: Function declarations are more explicit
-- **Clearer stack traces**: Named function declarations provide better debugging
-- **Self-documenting**: `function formatDate()` is clearer than `const formatDate = () =>`
-
-## Why Only `.ts` Files?
-
-- **`.tsx` files**: Arrow functions are commonly used for React components
-- **`.js` files**: JavaScript projects may have different conventions
-- **`.d.ts` files**: Declaration files don't contain implementations
-
-## When Not To Use
+## When Not To Use It
 
 - When you prefer arrow functions for all function definitions
 - In projects where arrow function style is established

--- a/docs/rules/PREFER_GUARD_CLAUSE.md
+++ b/docs/rules/PREFER_GUARD_CLAUSE.md
@@ -8,9 +8,9 @@ Nested if statements increase code complexity and make it harder to read. This r
 
 ## Examples
 
-### ❌ Incorrect
+### Incorrect
 
-```tsx
+```ts
 function process(data) {
   if (data) {
     if (data.items) {
@@ -30,9 +30,9 @@ function validate(user) {
 }
 ```
 
-### ✅ Correct
+### Correct
 
-```tsx
+```ts
 function process(data) {
   if (!data) return [];
   if (!data.items) return [];

--- a/docs/rules/PREFER_IMPORT_TYPE.md
+++ b/docs/rules/PREFER_IMPORT_TYPE.md
@@ -8,9 +8,11 @@ This rule is automatically fixable by the [`--fix` CLI option](https://eslint.or
 
 This rule enforces the use of TypeScript's `import type` syntax for imports that are only used for type annotations. This helps with tree-shaking and makes it clear which imports are type-only vs runtime imports.
 
-**Incorrect** code for this rule:
+## Examples
 
-```typescript
+### Incorrect
+
+```ts
 import { Component } from "react";
 import { TSESTree } from "@typescript-eslint/utils";
 import { RuleContext } from "@typescript-eslint/utils";
@@ -22,9 +24,9 @@ interface Props {
 }
 ```
 
-**Correct** code for this rule:
+### Correct
 
-```typescript
+```ts
 import type { Component } from "react";
 import type { TSESTree } from "@typescript-eslint/utils";
 import type { RuleContext } from "@typescript-eslint/utils";
@@ -38,7 +40,7 @@ interface Props {
 
 **Allowed runtime imports:**
 
-```typescript
+```ts
 import React from "react";
 import { ESLintUtils } from "@typescript-eslint/utils";
 import * as utils from "./utils";
@@ -47,26 +49,11 @@ import * as utils from "./utils";
 import { ESLintUtils, type TSESTree } from "@typescript-eslint/utils";
 ```
 
-## Benefits
-
-- **Better tree-shaking**: Type-only imports are completely removed from the bundle
-- **Clearer intent**: Makes it obvious which imports are for types vs runtime
-- **Faster compilation**: TypeScript can optimize type-only imports
-- **Bundle size**: Reduces final JavaScript bundle size
-
-## Detection Logic
-
-The rule identifies type-only imports by checking if:
-
-1. The imported identifier starts with an uppercase letter (indicating a type/interface)
-2. It's not a known runtime import like `ESLintUtils` or `RuleTester`
-3. The import is not already using `import type`
-
 ## Auto-fixing
 
 This rule automatically converts regular imports to `import type` when appropriate:
 
-```typescript
+```ts
 // Before
 import { TSESTree } from "@typescript-eslint/utils";
 
@@ -74,7 +61,7 @@ import { TSESTree } from "@typescript-eslint/utils";
 import type { TSESTree } from "@typescript-eslint/utils";
 ```
 
-## When Not To Use
+## When Not To Use It
 
 - If your project doesn't use TypeScript
 - When you prefer to keep all imports as regular imports for consistency

--- a/docs/rules/PREFER_INTERFACE_OVER_INLINE_TYPES.md
+++ b/docs/rules/PREFER_INTERFACE_OVER_INLINE_TYPES.md
@@ -6,7 +6,9 @@ Enforce interface declarations over inline type annotations for React component 
 
 This rule enforces the use of interface declarations instead of inline type annotations for React component props when the type is complex. This promotes better code organization, reusability, and readability.
 
-Examples of **incorrect** code for this rule:
+## Examples
+
+### Incorrect
 
 ```tsx
 // More than 2 properties - should use interface
@@ -46,7 +48,7 @@ const Component = function (props: { config: { theme: string; lang: string }; ch
 };
 ```
 
-Examples of **correct** code for this rule:
+### Correct
 
 ```tsx
 // Using interface for complex props
@@ -106,106 +108,8 @@ const Component = () => <div>Hello</div>;
 const Component = (props: { title: string }, ref: any) => <div>{props.title}</div>;
 ```
 
-## Why?
-
-### Benefits of interface declarations:
-
-1. **Reusability**: Interfaces can be reused across multiple components
-2. **Better organization**: Separates type definitions from component logic
-3. **Improved readability**: Makes component signatures cleaner and easier to understand
-4. **Better IDE support**: Enhanced autocomplete, refactoring, and navigation
-5. **Documentation**: Interfaces serve as clear documentation of component APIs
-6. **Extensibility**: Interfaces can be extended and composed more easily
-
-## Rule Scope
-
-This rule applies to:
-
-- React functional components (arrow functions, function expressions, function declarations)
-- Functions that return JSX elements or fragments
-- Props with inline type annotations that meet complexity criteria
-
-**Complexity criteria:**
-
-- More than 2 properties in the type literal
-- Contains nested object types (`{ user: { name: string } }`)
-- Contains array types (`string[]`, `Array<T>`)
-- Contains union types (`'a' | 'b' | 'c'`)
-
-The rule ignores:
-
-- Non-React functions (functions that don't return JSX)
-- Functions with multiple parameters
-- Functions with no parameters
-- Simple inline types (2 or fewer properties with primitive types)
-- Components already using named types or interfaces
-
 ## When Not To Use It
 
-This rule should not be used if you:
-
-- Prefer inline types for consistency across your codebase
-- Are working with very simple components that don't benefit from interface extraction
-- Have specific naming conventions that conflict with interface declarations
-- Are maintaining legacy code with established patterns
-
-## Configuration
-
-This rule is included in the following configurations:
-
-- `nextfriday/react`
-- `nextfriday/react/recommended`
-- `nextfriday/nextjs`
-- `nextfriday/nextjs/recommended`
-
-To enable this rule manually:
-
-```json
-{
-  "rules": {
-    "nextfriday/prefer-interface-over-inline-types": "error"
-  }
-}
-```
-
-## Examples of Complexity Detection
-
-### Simple types (allowed as inline)
-
-```tsx
-// ✅ Simple - only 1 property
-const Component = (props: { children: ReactNode }) => <div>{props.children}</div>;
-
-// ✅ Simple - only 2 properties with primitive types
-const Component = (props: { title: string; count: number }) => (
-  <div>
-    {props.title}: {props.count}
-  </div>
-);
-```
-
-### Complex types (should use interface)
-
-```tsx
-// ❌ Complex - more than 2 properties
-const Component = (props: { title: string; count: number; isActive: boolean }) => <div>...</div>;
-
-// ❌ Complex - nested object
-const Component = (props: { user: { name: string }; isActive: boolean }) => <div>...</div>;
-
-// ❌ Complex - array type
-const Component = (props: { items: string[]; title: string }) => <div>...</div>;
-
-// ❌ Complex - union type
-const Component = (props: { status: "loading" | "success"; message: string }) => <div>...</div>;
-```
-
-## Compatibility
-
-- React 16.8+ (functional components)
-- TypeScript 3.0+ (interface declarations)
-- ESLint 9+ with flat config
-
-## Version
-
-This rule was introduced in eslint-plugin-nextfriday v1.2.0.
+- If you prefer inline types for consistency across your codebase
+- When working with very simple components that don't benefit from interface extraction
+- In legacy code with established inline type patterns

--- a/docs/rules/PREFER_JSX_TEMPLATE_LITERALS.md
+++ b/docs/rules/PREFER_JSX_TEMPLATE_LITERALS.md
@@ -2,6 +2,8 @@
 
 Enforce using template literals instead of mixing text and JSX expressions.
 
+> This rule is auto-fixable using `--fix`.
+
 ## Rule Details
 
 This rule prevents mixing plain text with JSX expressions in JSX elements, which can lead to incorrect spacing and readability issues. Instead, it enforces using template literals to combine text and expressions.
@@ -23,7 +25,7 @@ Using template literals ensures:
 
 ## Examples
 
-### ❌ Incorrect
+### Incorrect
 
 ```tsx
 // Bad: Text followed by expression
@@ -39,7 +41,7 @@ Using template literals ensures:
 <div>{price}$</div>
 ```
 
-### ✅ Correct
+### Correct
 
 ```tsx
 // Good: Using template literals

--- a/docs/rules/PREFER_NAMED_PARAM_TYPES.md
+++ b/docs/rules/PREFER_NAMED_PARAM_TYPES.md
@@ -6,9 +6,11 @@ Enforce named interfaces or types instead of inline object types for function pa
 
 This rule enforces extracting inline object type annotations for function parameters into named interfaces or type aliases. This promotes better code organization, reusability, and readability across your codebase.
 
-Examples of **incorrect** code for this rule:
+## Examples
 
-```typescript
+### Incorrect
+
+```ts
 // Destructured parameter with inline type
 const foo = ({ bar, baz }: { bar: string; baz: number }) => {
   console.log(bar, baz);
@@ -36,9 +38,9 @@ const foo = (first: { a: string; b: number }, second: { x: boolean; y: string })
 };
 ```
 
-Examples of **correct** code for this rule:
+### Correct
 
-```typescript
+```ts
 // Using interface
 interface Params {
   bar: string;
@@ -87,86 +89,12 @@ const setup = (config: Config) => {
 };
 ```
 
-## Why?
-
-### Benefits of named parameter types:
-
-1. **Reusability**: Named types can be reused across multiple functions
-2. **Better organization**: Separates type definitions from function logic
-3. **Improved readability**: Makes function signatures cleaner and easier to understand
-4. **Better IDE support**: Enhanced autocomplete, refactoring, and navigation
-5. **Documentation**: Named types serve as clear documentation of function APIs
-6. **Extensibility**: Types and interfaces can be extended and composed more easily
-7. **Type inference**: Named types can improve TypeScript's type inference in complex scenarios
-
-## Rule Scope
-
-This rule applies to:
-
-- All function types: arrow functions, function expressions, and function declarations
-- Function parameters with inline object type literals
-- Method definitions with inline object type parameters
-- TypeScript method signatures
-
-The rule triggers when:
-
-- A parameter has an inline object type literal (e.g., `{ bar: string; baz: number }`)
-- The parameter is destructured with an inline type (e.g., `({ bar, baz }: { bar: string; baz: number })`)
-
-The rule allows:
-
-- Primitive type annotations (string, number, boolean, etc.)
-- Named types and interfaces
-- Type aliases
-- Functions with no parameters
-- Array types (e.g., `string[]`)
-- Union/intersection types without object literals
-
 ## When Not To Use It
 
-This rule should not be used if you:
+- If you prefer inline types for simple, one-off function parameters
+- When working with very simple functions that don't benefit from type extraction
+- In legacy code with established inline type patterns
 
-- Prefer inline types for simple, one-off function parameters
-- Are working with very simple functions that don't benefit from type extraction
-- Have specific code style requirements that favor inline types
-- Are maintaining legacy code with established patterns
+## Related Rules
 
-## Configuration
-
-This rule is included in the following configurations:
-
-- `nextfriday/base`
-- `nextfriday/base/recommended`
-- `nextfriday/react`
-- `nextfriday/react/recommended`
-- `nextfriday/nextjs`
-- `nextfriday/nextjs/recommended`
-
-To enable this rule manually:
-
-```json
-{
-  "rules": {
-    "nextfriday/prefer-named-param-types": "error"
-  }
-}
-```
-
-## Relationship to Other Rules
-
-This rule complements but differs from `prefer-interface-over-inline-types`:
-
-- `prefer-interface-over-inline-types`: Focuses on React component props with complexity criteria
-- `prefer-named-param-types`: Applies to ALL functions with inline object types, regardless of complexity
-
-Both rules can be used together for comprehensive type organization.
-
-## Compatibility
-
-- TypeScript 3.0+ (interface and type alias declarations)
-- ESLint 9+ with flat config
-- Works with all function types in JavaScript/TypeScript
-
-## Version
-
-This rule was introduced in eslint-plugin-nextfriday v1.2.3.
+- [prefer-interface-over-inline-types](./PREFER_INTERFACE_OVER_INLINE_TYPES.md) - Similar rule focused on React component props with complexity criteria

--- a/docs/rules/PREFER_REACT_IMPORT_TYPES.md
+++ b/docs/rules/PREFER_REACT_IMPORT_TYPES.md
@@ -6,7 +6,9 @@ Enforce importing React types and utilities from 'react' instead of using React.
 
 This rule enforces direct imports of React types and utilities instead of using the React namespace notation (`React.ReactNode`, `React.useState`, etc.). This promotes cleaner imports and better tree-shaking in modern bundlers.
 
-Examples of **incorrect** code for this rule:
+## Examples
+
+### Incorrect
 
 ```tsx
 // Types with React namespace
@@ -45,7 +47,7 @@ const MyFragment = () => (
 );
 ```
 
-Examples of **correct** code for this rule:
+### Correct
 
 ```tsx
 // Direct type imports
@@ -90,24 +92,6 @@ const MyFragment = () => (
 );
 ```
 
-## Why?
-
-### Benefits of direct imports
-
-1. **Better tree-shaking**: Bundlers can more easily eliminate unused code when imports are explicit
-2. **Cleaner code**: Reduces namespace pollution and makes dependencies more explicit
-3. **Improved IDE support**: Better autocomplete and refactoring capabilities
-4. **Smaller bundle sizes**: Only import what you actually use
-5. **TypeScript optimization**: Better type checking and inference with explicit imports
-6. **Modern practices**: Aligns with current React ecosystem conventions
-
-## Automatic Fixing
-
-This rule provides automatic fixing that replaces `React.X` with the direct import name. However, you will need to manually add the appropriate import statements:
-
-- **Types**: Use `import type { TypeName } from "react"`
-- **Runtime code**: Use `import { functionName } from "react"`
-
 ## Supported React Exports
 
 ### Types (use `import type`)
@@ -136,40 +120,5 @@ This rule provides automatic fixing that replaces `React.X` with the direct impo
 
 ## When Not To Use It
 
-This rule should not be used if you:
-
-- Prefer the React namespace for consistency across a large codebase
-- Are working with legacy code that heavily uses React namespace
-- Need to maintain compatibility with older bundlers that don't support tree-shaking
-
-## Configuration
-
-This rule is included in the following configurations:
-
-- `nextfriday/base`
-- `nextfriday/base/recommended`
-- `nextfriday/react`
-- `nextfriday/react/recommended`
-- `nextfriday/nextjs`
-- `nextfriday/nextjs/recommended`
-
-To enable this rule manually:
-
-```json
-{
-  "rules": {
-    "nextfriday/prefer-react-import-types": "error"
-  }
-}
-```
-
-## Compatibility
-
-- React 16.8+ (hooks support)
-- TypeScript 3.8+ (type-only imports)
-- Modern bundlers with tree-shaking support
-- ESLint 9+ with flat config
-
-## Version
-
-This rule was introduced in eslint-plugin-nextfriday v1.1.0.
+- If you prefer the React namespace for consistency across a large codebase
+- When working with legacy code that heavily uses React namespace

--- a/docs/rules/REACT_PROPS_DESTRUCTURE.md
+++ b/docs/rules/REACT_PROPS_DESTRUCTURE.md
@@ -6,7 +6,9 @@ Enforce destructuring props inside React component body instead of parameters.
 
 This rule enforces a consistent pattern for handling props in React components by requiring destructuring to be done inside the component body rather than in the parameter list. This promotes better code readability and makes prop usage more explicit.
 
-Examples of **incorrect** code for this rule:
+## Examples
+
+### Incorrect
 
 ```jsx
 const Component = ({ children }) => <div>{children}</div>;
@@ -37,7 +39,7 @@ const Component = ({ show, children }) => {
 };
 ```
 
-Examples of **correct** code for this rule:
+### Correct
 
 ```jsx
 const Component = (props) => {
@@ -91,68 +93,7 @@ const regularFunction = ({ data }) => {
 };
 ```
 
-## Why?
-
-### Benefits of destructuring inside component body
-
-1. **Explicit prop usage**: Makes it clear which props are being used within the component
-2. **Better readability**: Separates prop extraction from component signature
-3. **Easier refactoring**: Props can be easily modified without changing the function signature
-4. **Consistent patterns**: Promotes a uniform approach across the codebase
-5. **Better TypeScript integration**: Works better with prop type definitions
-
 ## When Not To Use It
 
-This rule should not be used if you:
-
-- Prefer parameter destructuring for brevity
-- Are working on a codebase that already consistently uses parameter destructuring
-- Need to maintain compatibility with existing patterns
-
-## Rule Scope
-
-This rule only applies to:
-
-- Functions that return JSX elements or fragments
-- Functions with exactly one parameter that is object destructuring
-- Arrow functions, function expressions, and function declarations
-
-The rule ignores:
-
-- Non-React functions (functions that don't return JSX)
-- Functions with multiple parameters
-- Functions with no parameters
-- Functions already using a `props` parameter without destructuring
-
-## Configuration
-
-This rule is included in the following configurations:
-
-- `nextfriday/react`
-- `nextfriday/react/recommended`
-- `nextfriday/nextjs`
-- `nextfriday/nextjs/recommended`
-
-To enable this rule manually:
-
-```json
-{
-  "rules": {
-    "nextfriday/react-props-destructure": "error"
-  }
-}
-```
-
-## Compatibility
-
-- React functional components
-- Arrow functions with JSX
-- Function declarations with JSX
-- Function expressions with JSX
-- Conditional JSX returns
-- Logical operator JSX returns
-- JSX fragments
-
-## Version
-
-This rule was introduced in eslint-plugin-nextfriday v1.0.0.
+- If you prefer parameter destructuring for brevity
+- When working on a codebase that already consistently uses parameter destructuring

--- a/docs/rules/REQUIRE_EXPLICIT_RETURN_TYPE.md
+++ b/docs/rules/REQUIRE_EXPLICIT_RETURN_TYPE.md
@@ -6,9 +6,11 @@ Require explicit return types on functions for better code documentation and typ
 
 This rule enforces that all functions have explicit return type annotations. Explicit return types serve as documentation, help catch bugs early, and make the codebase more maintainable.
 
-**Incorrect** code for this rule:
+## Examples
 
-```typescript
+### Incorrect
+
+```ts
 function getName() {
   return "John Doe";
 }
@@ -34,9 +36,9 @@ function validateEmail(email: string) {
 }
 ```
 
-**Correct** code for this rule:
+### Correct
 
-```typescript
+```ts
 function getName(): string {
   return "John Doe";
 }
@@ -68,7 +70,7 @@ This rule does NOT require return types for:
 
 ### Callback Functions
 
-```typescript
+```ts
 // All of these are allowed without return types
 items.map((item) => item.name);
 items.filter((item) => item.active);
@@ -79,7 +81,7 @@ promise.then((result) => result.data);
 
 ### Object Properties
 
-```typescript
+```ts
 const handler = {
   onClick: () => console.log("clicked"),
 };
@@ -87,13 +89,13 @@ const handler = {
 
 ### Array Elements
 
-```typescript
+```ts
 const callbacks = [() => 1, () => 2];
 ```
 
 ### React Components (PascalCase)
 
-```typescript
+```ts
 // React components don't need explicit return types
 const MyComponent = () => <div>Hello</div>;
 
@@ -106,23 +108,11 @@ const Button = () => {
 };
 ```
 
-## Benefits
-
-- **Self-documenting code**: Return types serve as documentation for function contracts
-- **Early error detection**: Type mismatches are caught at compile time
-- **Better IDE support**: Explicit types improve autocomplete and refactoring
-- **API clarity**: Public functions have clear type signatures
-- **Maintainability**: Easier to understand function behavior at a glance
-
-## When Not To Use
+## When Not To Use It
 
 - When you prefer TypeScript's type inference for all functions
 - In rapid prototyping where explicit types slow down development
 - When the inferred type is exactly what you want
-
-## Configuration
-
-This rule has no configuration options.
 
 ## Related Rules
 

--- a/docs/rules/SORT_EXPORTS.md
+++ b/docs/rules/SORT_EXPORTS.md
@@ -26,7 +26,7 @@ Non-contiguous exports (separated by other statements) are checked independently
 
 ## Examples
 
-### ❌ Incorrect
+### Incorrect
 
 ```ts
 // Bad: Local before re-export
@@ -40,7 +40,7 @@ export { bar } from "../bar";
 export { foo } from "react";
 ```
 
-### ✅ Correct
+### Correct
 
 ```ts
 // Good: All 3 groups in correct order

--- a/docs/rules/SORT_IMPORTS.md
+++ b/docs/rules/SORT_IMPORTS.md
@@ -28,7 +28,7 @@ Non-contiguous imports (separated by other statements) are checked independently
 
 ## Examples
 
-### ❌ Incorrect
+### Incorrect
 
 ```ts
 // Bad: Relative before external
@@ -48,7 +48,7 @@ import React from "react";
 import "./setup";
 ```
 
-### ✅ Correct
+### Correct
 
 ```ts
 // Good: All 5 groups in correct order

--- a/docs/rules/SORT_TYPE_ALPHABETICALLY.md
+++ b/docs/rules/SORT_TYPE_ALPHABETICALLY.md
@@ -25,7 +25,7 @@ Use with `sort-type-required-first` to also enforce required properties come bef
 
 ## Examples
 
-### ❌ Incorrect
+### Incorrect
 
 ```ts
 // Bad: Required not sorted A-Z
@@ -54,7 +54,7 @@ interface HeroBannerRootProps {
 }
 ```
 
-### ✅ Correct
+### Correct
 
 ```ts
 // Good: Required A-Z, optional A-Z

--- a/docs/rules/SORT_TYPE_REQUIRED_FIRST.md
+++ b/docs/rules/SORT_TYPE_REQUIRED_FIRST.md
@@ -23,7 +23,7 @@ Use with `sort-type-alphabetically` to also enforce A-Z ordering within each gro
 
 ## Examples
 
-### ❌ Incorrect
+### Incorrect
 
 ```ts
 // Bad: Optional mixed in with required
@@ -54,7 +54,7 @@ interface Props {
 }
 ```
 
-### ✅ Correct
+### Correct
 
 ```ts
 // Good: Required first, then optional

--- a/skills/eslint-plugin-nextfriday/SKILL.md
+++ b/skills/eslint-plugin-nextfriday/SKILL.md
@@ -33,7 +33,7 @@ See [naming-conventions.md](./naming-conventions.md) for hook/service naming and
 Function declarations in `.ts` files. Explicit return types. Destructured params for 2+ arguments.
 
 ```ts
-function fetchUser({ userId }: FetchUserParams): Promise<User> {
+async function fetchUser({ userId }: FetchUserParams): Promise<User> {
   const response = await fetch(url);
   const data = await response.json();
 

--- a/skills/eslint-plugin-nextfriday/formatting.md
+++ b/skills/eslint-plugin-nextfriday/formatting.md
@@ -83,22 +83,23 @@ function getUser(): User {
 }
 ```
 
-## Curly Braces for Multi-Line If
+## Curly Braces for If Statements
 
-Multi-line if bodies require curly braces. Single-line if bodies must not have curly braces.
+If the `if` consequent fits on one line, omit braces. If it spans multiple lines, use braces.
 
 ```ts
-// Bad
+// Bad: single-line body with braces
 if (isValid) {
   process();
-} // single statement, multi-line braces OK
+}
 
-if (isValid) doSomething();
-doSomethingElse(); // misleading
+// Bad: multi-line body without braces
+if (veryLongCondition && anotherCondition) process();
 
-// Good
-if (isValid) process(); // single-line, no braces
+// Good: single-line body, no braces
+if (isValid) process();
 
+// Good: multi-line body, with braces
 if (isValid) {
   doSomething();
   doSomethingElse();

--- a/skills/eslint-plugin-nextfriday/jsx-patterns.md
+++ b/skills/eslint-plugin-nextfriday/jsx-patterns.md
@@ -114,8 +114,11 @@ Use template literals instead of mixing text and JSX expressions.
 
 Sort JSX props by value type in this order:
 
-1. Shorthand boolean (e.g., `disabled`)
-2. String literals (e.g., `type="submit"`)
-3. Expressions/variables (e.g., `value={count}`)
-4. Callbacks (e.g., `onClick={handleClick}`)
-5. Spread (e.g., `{...rest}`)
+1. String literals (e.g., `type="submit"`)
+2. Number/Boolean/Null (e.g., `count={42}`)
+3. Object/Array (e.g., `style={chartStyle}`)
+4. Function (e.g., `onClick={handleClick}`)
+5. JSX Element (e.g., `icon={<HomeIcon />}`)
+6. Shorthand boolean (e.g., `disabled`)
+
+Variables, member expressions, and call expressions are skipped. Spread attributes reset ordering.

--- a/skills/eslint-plugin-nextfriday/naming-conventions.md
+++ b/skills/eslint-plugin-nextfriday/naming-conventions.md
@@ -35,18 +35,16 @@ const API_URL = "https://api.example.com";
 
 ## Variable Names
 
-No single-character variables (`d`, `u`, `l`) or lazy identifiers (`xxx`, `asdf`, `qwerty`, `temp`, `foo`, `bar`).
+No single-character variables (`d`, `u`, `l`) or lazy identifiers (`xxx`, `asdf`, `qwerty`).
 
 ```ts
 // Bad
 const d = new Date();
 const u = getUser();
-const temp = calculate();
 
 // Good
 const currentDate = new Date();
 const user = getUser();
-const calculatedValue = calculate();
 ```
 
 ## File Naming

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,26 +16,26 @@ import fileKebabCase from "./rules/file-kebab-case";
 import jsxNewlineBetweenElements from "./rules/jsx-newline-between-elements";
 import jsxNoInlineObjectProp from "./rules/jsx-no-inline-object-prop";
 import jsxNoNewlineSingleLineElements from "./rules/jsx-no-newline-single-line-elements";
+import jsxNoNonComponentFunction from "./rules/jsx-no-non-component-function";
+import jsxNoVariableInCallback from "./rules/jsx-no-variable-in-callback";
 import jsxPascalCase from "./rules/jsx-pascal-case";
 import jsxRequireSuspense from "./rules/jsx-require-suspense";
 import jsxSimpleProps from "./rules/jsx-simple-props";
 import jsxSortProps from "./rules/jsx-sort-props";
-import noDirectDate from "./rules/no-direct-date";
-import jsxNoVariableInCallback from "./rules/jsx-no-variable-in-callback";
 import mdFilenameCaseRestriction from "./rules/md-filename-case-restriction";
+import newlineAfterMultilineBlock from "./rules/newline-after-multiline-block";
+import newlineBeforeReturn from "./rules/newline-before-return";
+import nextjsRequirePublicEnv from "./rules/nextjs-require-public-env";
 import noComplexInlineReturn from "./rules/no-complex-inline-return";
+import noDirectDate from "./rules/no-direct-date";
 import noEmoji from "./rules/no-emoji";
 import noEnvFallback from "./rules/no-env-fallback";
 import noInlineDefaultExport from "./rules/no-inline-default-export";
 import noInlineNestedObject from "./rules/no-inline-nested-object";
-import requireExplicitReturnType from "./rules/require-explicit-return-type";
-import jsxNoNonComponentFunction from "./rules/jsx-no-non-component-function";
+import noLazyIdentifiers from "./rules/no-lazy-identifiers";
 import noLogicInParams from "./rules/no-logic-in-params";
 import noNestedInterfaceDeclaration from "./rules/no-nested-interface-declaration";
 import noNestedTernary from "./rules/no-nested-ternary";
-import newlineAfterMultilineBlock from "./rules/newline-after-multiline-block";
-import newlineBeforeReturn from "./rules/newline-before-return";
-import noLazyIdentifiers from "./rules/no-lazy-identifiers";
 import noRelativeImports from "./rules/no-relative-imports";
 import noSingleCharVariables from "./rules/no-single-char-variables";
 import preferAsyncAwait from "./rules/prefer-async-await";
@@ -49,11 +49,11 @@ import preferJSXTemplateLiterals from "./rules/prefer-jsx-template-literals";
 import preferNamedParamTypes from "./rules/prefer-named-param-types";
 import preferReactImportTypes from "./rules/prefer-react-import-types";
 import reactPropsDestructure from "./rules/react-props-destructure";
+import requireExplicitReturnType from "./rules/require-explicit-return-type";
 import sortExports from "./rules/sort-exports";
 import sortImports from "./rules/sort-imports";
 import sortTypeAlphabetically from "./rules/sort-type-alphabetically";
 import sortTypeRequiredFirst from "./rules/sort-type-required-first";
-import nextjsRequirePublicEnv from "./rules/nextjs-require-public-env";
 
 import type { TSESLint } from "@typescript-eslint/utils";
 
@@ -80,23 +80,23 @@ const rules = {
   "file-kebab-case": fileKebabCase,
   "jsx-newline-between-elements": jsxNewlineBetweenElements,
   "jsx-no-inline-object-prop": jsxNoInlineObjectProp,
+  "jsx-no-newline-single-line-elements": jsxNoNewlineSingleLineElements,
+  "jsx-no-non-component-function": jsxNoNonComponentFunction,
+  "jsx-no-variable-in-callback": jsxNoVariableInCallback,
   "jsx-pascal-case": jsxPascalCase,
   "jsx-require-suspense": jsxRequireSuspense,
   "jsx-simple-props": jsxSimpleProps,
   "jsx-sort-props": jsxSortProps,
-  "jsx-no-newline-single-line-elements": jsxNoNewlineSingleLineElements,
-  "jsx-no-non-component-function": jsxNoNonComponentFunction,
-  "jsx-no-variable-in-callback": jsxNoVariableInCallback,
   "md-filename-case-restriction": mdFilenameCaseRestriction,
   "newline-after-multiline-block": newlineAfterMultilineBlock,
   "newline-before-return": newlineBeforeReturn,
+  "nextjs-require-public-env": nextjsRequirePublicEnv,
   "no-complex-inline-return": noComplexInlineReturn,
   "no-direct-date": noDirectDate,
   "no-emoji": noEmoji,
   "no-env-fallback": noEnvFallback,
   "no-inline-default-export": noInlineDefaultExport,
   "no-inline-nested-object": noInlineNestedObject,
-  "require-explicit-return-type": requireExplicitReturnType,
   "no-lazy-identifiers": noLazyIdentifiers,
   "no-logic-in-params": noLogicInParams,
   "no-nested-interface-declaration": noNestedInterfaceDeclaration,
@@ -114,11 +114,11 @@ const rules = {
   "prefer-named-param-types": preferNamedParamTypes,
   "prefer-react-import-types": preferReactImportTypes,
   "react-props-destructure": reactPropsDestructure,
+  "require-explicit-return-type": requireExplicitReturnType,
   "sort-exports": sortExports,
   "sort-imports": sortImports,
   "sort-type-alphabetically": sortTypeAlphabetically,
   "sort-type-required-first": sortTypeRequiredFirst,
-  "nextjs-require-public-env": nextjsRequirePublicEnv,
 } as const satisfies Record<string, TSESLint.RuleModule<string, readonly unknown[]>>;
 
 const plugin = {
@@ -130,7 +130,6 @@ const baseRules = {
   "nextfriday/boolean-naming-prefix": "warn",
   "nextfriday/enforce-constant-case": "warn",
   "nextfriday/enforce-curly-newline": "warn",
-  "nextfriday/no-emoji": "warn",
   "nextfriday/enforce-hook-naming": "warn",
   "nextfriday/enforce-service-naming": "warn",
   "nextfriday/enforce-sorted-destructuring": "warn",
@@ -139,26 +138,27 @@ const baseRules = {
   "nextfriday/md-filename-case-restriction": "warn",
   "nextfriday/newline-after-multiline-block": "warn",
   "nextfriday/newline-before-return": "warn",
-  "nextfriday/prefer-destructuring-params": "warn",
-  "nextfriday/prefer-function-declaration": "warn",
-  "nextfriday/prefer-guard-clause": "warn",
-  "nextfriday/require-explicit-return-type": "warn",
-  "nextfriday/prefer-import-type": "warn",
-  "nextfriday/prefer-inline-literal-union": "warn",
-  "nextfriday/prefer-named-param-types": "warn",
-  "nextfriday/prefer-react-import-types": "warn",
   "nextfriday/no-complex-inline-return": "warn",
   "nextfriday/no-direct-date": "warn",
-  "nextfriday/no-logic-in-params": "warn",
-  "nextfriday/no-nested-interface-declaration": "warn",
-  "nextfriday/no-nested-ternary": "warn",
+  "nextfriday/no-emoji": "warn",
   "nextfriday/no-env-fallback": "warn",
   "nextfriday/no-inline-default-export": "warn",
   "nextfriday/no-inline-nested-object": "warn",
   "nextfriday/no-lazy-identifiers": "warn",
+  "nextfriday/no-logic-in-params": "warn",
+  "nextfriday/no-nested-interface-declaration": "warn",
+  "nextfriday/no-nested-ternary": "warn",
   "nextfriday/no-relative-imports": "warn",
   "nextfriday/no-single-char-variables": "warn",
   "nextfriday/prefer-async-await": "warn",
+  "nextfriday/prefer-destructuring-params": "warn",
+  "nextfriday/prefer-function-declaration": "warn",
+  "nextfriday/prefer-guard-clause": "warn",
+  "nextfriday/prefer-import-type": "warn",
+  "nextfriday/prefer-inline-literal-union": "warn",
+  "nextfriday/prefer-named-param-types": "warn",
+  "nextfriday/prefer-react-import-types": "warn",
+  "nextfriday/require-explicit-return-type": "warn",
   "nextfriday/sort-exports": "warn",
   "nextfriday/sort-imports": "warn",
   "nextfriday/sort-type-alphabetically": "warn",
@@ -169,7 +169,6 @@ const baseRecommendedRules = {
   "nextfriday/boolean-naming-prefix": "error",
   "nextfriday/enforce-constant-case": "error",
   "nextfriday/enforce-curly-newline": "error",
-  "nextfriday/no-emoji": "error",
   "nextfriday/enforce-hook-naming": "error",
   "nextfriday/enforce-service-naming": "error",
   "nextfriday/enforce-sorted-destructuring": "error",
@@ -178,26 +177,27 @@ const baseRecommendedRules = {
   "nextfriday/md-filename-case-restriction": "error",
   "nextfriday/newline-after-multiline-block": "error",
   "nextfriday/newline-before-return": "error",
-  "nextfriday/prefer-destructuring-params": "error",
-  "nextfriday/prefer-function-declaration": "error",
-  "nextfriday/prefer-guard-clause": "error",
-  "nextfriday/require-explicit-return-type": "error",
-  "nextfriday/prefer-import-type": "error",
-  "nextfriday/prefer-inline-literal-union": "error",
-  "nextfriday/prefer-named-param-types": "error",
-  "nextfriday/prefer-react-import-types": "error",
   "nextfriday/no-complex-inline-return": "error",
   "nextfriday/no-direct-date": "error",
-  "nextfriday/no-logic-in-params": "error",
-  "nextfriday/no-nested-interface-declaration": "error",
-  "nextfriday/no-nested-ternary": "error",
+  "nextfriday/no-emoji": "error",
   "nextfriday/no-env-fallback": "error",
   "nextfriday/no-inline-default-export": "error",
   "nextfriday/no-inline-nested-object": "error",
   "nextfriday/no-lazy-identifiers": "error",
+  "nextfriday/no-logic-in-params": "error",
+  "nextfriday/no-nested-interface-declaration": "error",
+  "nextfriday/no-nested-ternary": "error",
   "nextfriday/no-relative-imports": "error",
   "nextfriday/no-single-char-variables": "error",
   "nextfriday/prefer-async-await": "error",
+  "nextfriday/prefer-destructuring-params": "error",
+  "nextfriday/prefer-function-declaration": "error",
+  "nextfriday/prefer-guard-clause": "error",
+  "nextfriday/prefer-import-type": "error",
+  "nextfriday/prefer-inline-literal-union": "error",
+  "nextfriday/prefer-named-param-types": "error",
+  "nextfriday/prefer-react-import-types": "error",
+  "nextfriday/require-explicit-return-type": "error",
   "nextfriday/sort-exports": "error",
   "nextfriday/sort-imports": "error",
   "nextfriday/sort-type-alphabetically": "error",

--- a/src/rules/__tests__/boolean-naming-prefix.test.ts
+++ b/src/rules/__tests__/boolean-naming-prefix.test.ts
@@ -1,27 +1,21 @@
 import { RuleTester } from "@typescript-eslint/rule-tester";
-import { afterAll, describe, it, expect } from "@jest/globals";
-import parser from "@typescript-eslint/parser";
+import { afterAll, describe, it } from "@jest/globals";
 
 import booleanNamingPrefix from "../boolean-naming-prefix";
 
 RuleTester.afterAll = afterAll;
-RuleTester.it = it;
-RuleTester.itOnly = it.only;
 RuleTester.describe = describe;
+RuleTester.it = it;
 
-const ruleTester = new RuleTester({
-  languageOptions: {
-    parser,
-    parserOptions: {
-      ecmaVersion: 2020,
-      sourceType: "module",
-    },
-  },
-});
+const ruleTester = new RuleTester();
 
 describe("boolean-naming-prefix", () => {
-  it("should be defined", () => {
-    expect(booleanNamingPrefix).toBeDefined();
+  it("should have meta property", () => {
+    expect(booleanNamingPrefix.meta).toBeDefined();
+  });
+
+  it("should have create method", () => {
+    expect(typeof booleanNamingPrefix.create).toBe("function");
   });
 
   ruleTester.run("boolean-naming-prefix", booleanNamingPrefix, {

--- a/src/rules/__tests__/enforce-constant-case.test.ts
+++ b/src/rules/__tests__/enforce-constant-case.test.ts
@@ -1,173 +1,174 @@
 import { RuleTester } from "@typescript-eslint/rule-tester";
-import { afterAll, describe, it, expect } from "@jest/globals";
+import { afterAll, describe, it } from "@jest/globals";
 
 import enforceConstantCase from "../enforce-constant-case";
 
 RuleTester.afterAll = afterAll;
-RuleTester.it = it;
-RuleTester.itOnly = it.only;
 RuleTester.describe = describe;
+RuleTester.it = it;
 
 const ruleTester = new RuleTester();
 
-ruleTester.run("enforce-constant-case", enforceConstantCase, {
-  valid: [
-    {
-      code: `const DEFAULT_COVER = "/images/default.jpg";`,
-      name: "should allow SCREAMING_SNAKE_CASE string constant",
-    },
-    {
-      code: `const PAGE_LIMIT = 10;`,
-      name: "should allow SCREAMING_SNAKE_CASE number constant",
-    },
-    {
-      code: `const IS_PRODUCTION = true;`,
-      name: "should allow SCREAMING_SNAKE_CASE boolean constant",
-    },
-    {
-      code: `const API_URL = "https://api.example.com";`,
-      name: "should allow SCREAMING_SNAKE_CASE url constant",
-    },
-    {
-      code: `const MAX_RETRY_COUNT = 3;`,
-      name: "should allow multi-word SCREAMING_SNAKE_CASE",
-    },
-    {
-      code: `const A = 1;`,
-      name: "should allow single letter uppercase constant",
-    },
-    {
-      code: `const config = { key: "value" };`,
-      name: "should allow camelCase for object constants",
-    },
-    {
-      code: `const items = [1, 2, 3];`,
-      name: "should allow camelCase for array constants",
-    },
-    {
-      code: `const handleClick = () => {};`,
-      name: "should allow camelCase for function constants",
-    },
-    {
-      code: `const Component = () => {};`,
-      name: "should allow PascalCase for component constants",
-    },
-    {
-      code: `let defaultCover = "/images/default.jpg";`,
-      name: "should allow camelCase for let declarations",
-    },
-    {
-      code: `var pageLimit = 10;`,
-      name: "should allow camelCase for var declarations",
-    },
-    {
-      code: `const NEGATIVE_VALUE = -1;`,
-      name: "should allow SCREAMING_SNAKE_CASE for negative numbers",
-    },
-    {
-      code: `const TEMPLATE = \`hello world\`;`,
-      name: "should allow SCREAMING_SNAKE_CASE for template literals",
-    },
-  ],
-  invalid: [
-    {
-      code: `const defaultCover = "/images/default.jpg";`,
-      name: "should disallow camelCase for string constant",
-      errors: [
-        {
-          messageId: "useScreamingSnakeCase",
-          data: {
-            name: "defaultCover",
-            suggestion: "DEFAULT_COVER",
-          },
-        },
-      ],
-    },
-    {
-      code: `const pageLimit = 10;`,
-      name: "should disallow camelCase for number constant",
-      errors: [
-        {
-          messageId: "useScreamingSnakeCase",
-          data: {
-            name: "pageLimit",
-            suggestion: "PAGE_LIMIT",
-          },
-        },
-      ],
-    },
-    {
-      code: `const isEnabled = true;`,
-      name: "should disallow camelCase for boolean constant",
-      errors: [
-        {
-          messageId: "useScreamingSnakeCase",
-          data: {
-            name: "isEnabled",
-            suggestion: "IS_ENABLED",
-          },
-        },
-      ],
-    },
-    {
-      code: `const apiBaseUrl = "https://api.example.com";`,
-      name: "should disallow camelCase for URL constant",
-      errors: [
-        {
-          messageId: "useScreamingSnakeCase",
-          data: {
-            name: "apiBaseUrl",
-            suggestion: "API_BASE_URL",
-          },
-        },
-      ],
-    },
-    {
-      code: `const maxRetryCount = 5;`,
-      name: "should disallow camelCase for multi-word constant",
-      errors: [
-        {
-          messageId: "useScreamingSnakeCase",
-          data: {
-            name: "maxRetryCount",
-            suggestion: "MAX_RETRY_COUNT",
-          },
-        },
-      ],
-    },
-    {
-      code: `const template = \`hello\`;`,
-      name: "should disallow camelCase for template literal constant",
-      errors: [
-        {
-          messageId: "useScreamingSnakeCase",
-          data: {
-            name: "template",
-            suggestion: "TEMPLATE",
-          },
-        },
-      ],
-    },
-    {
-      code: `const negativeOne = -1;`,
-      name: "should disallow camelCase for negative number constant",
-      errors: [
-        {
-          messageId: "useScreamingSnakeCase",
-          data: {
-            name: "negativeOne",
-            suggestion: "NEGATIVE_ONE",
-          },
-        },
-      ],
-    },
-  ],
-});
+describe("enforce-constant-case", () => {
+  it("should have meta property", () => {
+    expect(enforceConstantCase.meta).toBeDefined();
+  });
 
-describe("enforce-constant-case rule structure", () => {
-  it("should have correct rule structure", () => {
-    expect(enforceConstantCase).toHaveProperty("meta");
-    expect(enforceConstantCase).toHaveProperty("create");
+  it("should have create method", () => {
     expect(typeof enforceConstantCase.create).toBe("function");
+  });
+
+  ruleTester.run("enforce-constant-case", enforceConstantCase, {
+    valid: [
+      {
+        code: `const DEFAULT_COVER = "/images/default.jpg";`,
+        name: "should allow SCREAMING_SNAKE_CASE string constant",
+      },
+      {
+        code: `const PAGE_LIMIT = 10;`,
+        name: "should allow SCREAMING_SNAKE_CASE number constant",
+      },
+      {
+        code: `const IS_PRODUCTION = true;`,
+        name: "should allow SCREAMING_SNAKE_CASE boolean constant",
+      },
+      {
+        code: `const API_URL = "https://api.example.com";`,
+        name: "should allow SCREAMING_SNAKE_CASE url constant",
+      },
+      {
+        code: `const MAX_RETRY_COUNT = 3;`,
+        name: "should allow multi-word SCREAMING_SNAKE_CASE",
+      },
+      {
+        code: `const A = 1;`,
+        name: "should allow single letter uppercase constant",
+      },
+      {
+        code: `const config = { key: "value" };`,
+        name: "should allow camelCase for object constants",
+      },
+      {
+        code: `const items = [1, 2, 3];`,
+        name: "should allow camelCase for array constants",
+      },
+      {
+        code: `const handleClick = () => {};`,
+        name: "should allow camelCase for function constants",
+      },
+      {
+        code: `const Component = () => {};`,
+        name: "should allow PascalCase for component constants",
+      },
+      {
+        code: `let defaultCover = "/images/default.jpg";`,
+        name: "should allow camelCase for let declarations",
+      },
+      {
+        code: `var pageLimit = 10;`,
+        name: "should allow camelCase for var declarations",
+      },
+      {
+        code: `const NEGATIVE_VALUE = -1;`,
+        name: "should allow SCREAMING_SNAKE_CASE for negative numbers",
+      },
+      {
+        code: `const TEMPLATE = \`hello world\`;`,
+        name: "should allow SCREAMING_SNAKE_CASE for template literals",
+      },
+    ],
+    invalid: [
+      {
+        code: `const defaultCover = "/images/default.jpg";`,
+        name: "should disallow camelCase for string constant",
+        errors: [
+          {
+            messageId: "useScreamingSnakeCase",
+            data: {
+              name: "defaultCover",
+              suggestion: "DEFAULT_COVER",
+            },
+          },
+        ],
+      },
+      {
+        code: `const pageLimit = 10;`,
+        name: "should disallow camelCase for number constant",
+        errors: [
+          {
+            messageId: "useScreamingSnakeCase",
+            data: {
+              name: "pageLimit",
+              suggestion: "PAGE_LIMIT",
+            },
+          },
+        ],
+      },
+      {
+        code: `const isEnabled = true;`,
+        name: "should disallow camelCase for boolean constant",
+        errors: [
+          {
+            messageId: "useScreamingSnakeCase",
+            data: {
+              name: "isEnabled",
+              suggestion: "IS_ENABLED",
+            },
+          },
+        ],
+      },
+      {
+        code: `const apiBaseUrl = "https://api.example.com";`,
+        name: "should disallow camelCase for URL constant",
+        errors: [
+          {
+            messageId: "useScreamingSnakeCase",
+            data: {
+              name: "apiBaseUrl",
+              suggestion: "API_BASE_URL",
+            },
+          },
+        ],
+      },
+      {
+        code: `const maxRetryCount = 5;`,
+        name: "should disallow camelCase for multi-word constant",
+        errors: [
+          {
+            messageId: "useScreamingSnakeCase",
+            data: {
+              name: "maxRetryCount",
+              suggestion: "MAX_RETRY_COUNT",
+            },
+          },
+        ],
+      },
+      {
+        code: `const template = \`hello\`;`,
+        name: "should disallow camelCase for template literal constant",
+        errors: [
+          {
+            messageId: "useScreamingSnakeCase",
+            data: {
+              name: "template",
+              suggestion: "TEMPLATE",
+            },
+          },
+        ],
+      },
+      {
+        code: `const negativeOne = -1;`,
+        name: "should disallow camelCase for negative number constant",
+        errors: [
+          {
+            messageId: "useScreamingSnakeCase",
+            data: {
+              name: "negativeOne",
+              suggestion: "NEGATIVE_ONE",
+            },
+          },
+        ],
+      },
+    ],
   });
 });

--- a/src/rules/__tests__/enforce-curly-newline.test.ts
+++ b/src/rules/__tests__/enforce-curly-newline.test.ts
@@ -1,27 +1,35 @@
 import { RuleTester } from "@typescript-eslint/rule-tester";
-import { afterAll, describe, it, expect } from "@jest/globals";
+import { afterAll, describe, it } from "@jest/globals";
 
 import enforceCurlyNewline from "../enforce-curly-newline";
 
 RuleTester.afterAll = afterAll;
-RuleTester.it = it;
-RuleTester.itOnly = it.only;
 RuleTester.describe = describe;
+RuleTester.it = it;
 
 const ruleTester = new RuleTester();
 
-ruleTester.run("enforce-curly-newline", enforceCurlyNewline, {
-  valid: [
-    {
-      code: `if (!data) return [];`,
-      name: "single-line without braces - allowed",
-    },
-    {
-      code: `if (x > 0) doSomething();`,
-      name: "single-line function call without braces - allowed",
-    },
-    {
-      code: `
+describe("enforce-curly-newline", () => {
+  it("should have meta property", () => {
+    expect(enforceCurlyNewline.meta).toBeDefined();
+  });
+
+  it("should have create method", () => {
+    expect(typeof enforceCurlyNewline.create).toBe("function");
+  });
+
+  ruleTester.run("enforce-curly-newline", enforceCurlyNewline, {
+    valid: [
+      {
+        code: `if (!data) return [];`,
+        name: "single-line without braces - allowed",
+      },
+      {
+        code: `if (x > 0) doSomething();`,
+        name: "single-line function call without braces - allowed",
+      },
+      {
+        code: `
 if (
   veryLongCondition &&
   anotherCondition
@@ -29,55 +37,55 @@ if (
   return [];
 }
       `.trim(),
-      name: "multi-line with braces (wrapped condition) - allowed",
-    },
-    {
-      code: `
+        name: "multi-line with braces (wrapped condition) - allowed",
+      },
+      {
+        code: `
 if (condition) {
   doSomething();
 }
       `.trim(),
-      name: "multi-line with braces (body on new line) - allowed",
-    },
-    {
-      code: `
+        name: "multi-line with braces (body on new line) - allowed",
+      },
+      {
+        code: `
 if (a && b && c) {
   doA();
   doB();
 }
       `.trim(),
-      name: "multi-line with multiple statements - allowed",
-    },
-  ],
-  invalid: [
-    {
-      code: `if (!data) { return []; }`,
-      name: "single-line with braces - should remove braces",
-      errors: [{ messageId: "forbidBraces" }],
-      output: `if (!data) return [];`,
-    },
-    {
-      code: `if (x > 0) { doSomething(); }`,
-      name: "single-line function call with braces - should remove braces",
-      errors: [{ messageId: "forbidBraces" }],
-      output: `if (x > 0) doSomething();`,
-    },
-    {
-      code: `if (isValid) { return true; }`,
-      name: "single-line return with braces - should remove braces",
-      errors: [{ messageId: "forbidBraces" }],
-      output: `if (isValid) return true;`,
-    },
-    {
-      code: `
+        name: "multi-line with multiple statements - allowed",
+      },
+    ],
+    invalid: [
+      {
+        code: `if (!data) { return []; }`,
+        name: "single-line with braces - should remove braces",
+        errors: [{ messageId: "forbidBraces" }],
+        output: `if (!data) return [];`,
+      },
+      {
+        code: `if (x > 0) { doSomething(); }`,
+        name: "single-line function call with braces - should remove braces",
+        errors: [{ messageId: "forbidBraces" }],
+        output: `if (x > 0) doSomething();`,
+      },
+      {
+        code: `if (isValid) { return true; }`,
+        name: "single-line return with braces - should remove braces",
+        errors: [{ messageId: "forbidBraces" }],
+        output: `if (isValid) return true;`,
+      },
+      {
+        code: `
 if (
   veryLongCondition &&
   anotherCondition
 ) return [];
       `.trim(),
-      name: "multi-line without braces (wrapped condition) - should add braces",
-      errors: [{ messageId: "requireBraces" }],
-      output: `
+        name: "multi-line without braces (wrapped condition) - should add braces",
+        errors: [{ messageId: "requireBraces" }],
+        output: `
 if (
   veryLongCondition &&
   anotherCondition
@@ -85,31 +93,20 @@ if (
   return [];
 }
       `.trim(),
-    },
-    {
-      code: `
+      },
+      {
+        code: `
 if (condition)
   doSomething();
       `.trim(),
-      name: "multi-line without braces (body on new line) - should add braces",
-      errors: [{ messageId: "requireBraces" }],
-      output: `
+        name: "multi-line without braces (body on new line) - should add braces",
+        errors: [{ messageId: "requireBraces" }],
+        output: `
 if (condition) {
   doSomething();
 }
       `.trim(),
-    },
-  ],
-});
-
-describe("enforce-curly-newline rule structure", () => {
-  it("should have correct rule structure", () => {
-    expect(enforceCurlyNewline).toHaveProperty("meta");
-    expect(enforceCurlyNewline).toHaveProperty("create");
-    expect(typeof enforceCurlyNewline.create).toBe("function");
-  });
-
-  it("should be fixable", () => {
-    expect(enforceCurlyNewline.meta.fixable).toBe("code");
+      },
+    ],
   });
 });

--- a/src/rules/__tests__/enforce-hook-naming.test.ts
+++ b/src/rules/__tests__/enforce-hook-naming.test.ts
@@ -1,163 +1,164 @@
 import { RuleTester } from "@typescript-eslint/rule-tester";
-import { afterAll, describe, it, expect } from "@jest/globals";
+import { afterAll, describe, it } from "@jest/globals";
 
 import enforceHookNaming from "../enforce-hook-naming";
 
 RuleTester.afterAll = afterAll;
-RuleTester.it = it;
-RuleTester.itOnly = it.only;
 RuleTester.describe = describe;
+RuleTester.it = it;
 
 const ruleTester = new RuleTester();
 
-ruleTester.run("enforce-hook-naming", enforceHookNaming, {
-  valid: [
-    {
-      code: `export function useSearchParamsHandler() {}`,
-      filename: "search-params.hook.ts",
-      name: "should allow use prefix in hook file",
-    },
-    {
-      code: `export default useSearchParamsHandler;`,
-      filename: "search-params.hook.ts",
-      name: "should allow default export with use prefix",
-    },
-    {
-      code: `export function useAuth() { return useState(); }`,
-      filename: "auth.hook.ts",
-      name: "should allow use prefix for auth hook",
-    },
-    {
-      code: `export const useModal = () => {}`,
-      filename: "modal.hook.ts",
-      name: "should allow use prefix with arrow function",
-    },
-    {
-      code: `export default function useCustomHook() {}`,
-      filename: "custom.hook.ts",
-      name: "should allow default function export with use prefix",
-    },
-    {
-      code: `export function useData() {}`,
-      filename: "data.hooks.ts",
-      name: "should allow use prefix in .hooks.ts file",
-    },
-    {
-      code: `export function searchHandler() {}`,
-      filename: "search.ts",
-      name: "should allow any name in non-hook files",
-    },
-    {
-      code: `export function handleSearch() {}`,
-      filename: "search.utils.ts",
-      name: "should allow any name in utility files",
-    },
-    {
-      code: `export default handleSearch;`,
-      filename: "search.ts",
-      name: "should allow default export without use prefix in non-hook files",
-    },
-  ],
-  invalid: [
-    {
-      code: `export function searchParamsHandler() {}`,
-      filename: "search-params.hook.ts",
-      name: "should disallow missing use prefix in named export",
-      errors: [
-        {
-          messageId: "missingUsePrefix",
-          data: {
-            name: "searchParamsHandler",
-            suggestion: "useSearchParamsHandler",
-          },
-        },
-      ],
-    },
-    {
-      code: `export default handleSearch;`,
-      filename: "search.hook.ts",
-      name: "should disallow default export without use prefix",
-      errors: [
-        {
-          messageId: "defaultExportMissingUsePrefix",
-          data: {
-            name: "handleSearch",
-            suggestion: "useHandleSearch",
-          },
-        },
-      ],
-    },
-    {
-      code: `export const modalHandler = () => {}`,
-      filename: "modal.hook.ts",
-      name: "should disallow arrow function without use prefix",
-      errors: [
-        {
-          messageId: "missingUsePrefix",
-          data: {
-            name: "modalHandler",
-            suggestion: "useModalHandler",
-          },
-        },
-      ],
-    },
-    {
-      code: `export function authManager() {}`,
-      filename: "auth.hooks.ts",
-      name: "should disallow missing use prefix in .hooks.ts file",
-      errors: [
-        {
-          messageId: "missingUsePrefix",
-          data: {
-            name: "authManager",
-            suggestion: "useAuthManager",
-          },
-        },
-      ],
-    },
-    {
-      code: `export default function customHook() {}`,
-      filename: "custom.hook.ts",
-      name: "should disallow default function export without use prefix",
-      errors: [
-        {
-          messageId: "defaultExportMissingUsePrefix",
-          data: {
-            name: "customHook",
-            suggestion: "useCustomHook",
-          },
-        },
-      ],
-    },
-    {
-      code: `export function getData() {}
-export function fetchItems() {}`,
-      filename: "data.hook.ts",
-      name: "should report multiple functions without use prefix",
-      errors: [
-        {
-          messageId: "missingUsePrefix",
-          data: {
-            name: "getData",
-            suggestion: "useGetData",
-          },
-        },
-        {
-          messageId: "missingUsePrefix",
-          data: {
-            name: "fetchItems",
-            suggestion: "useFetchItems",
-          },
-        },
-      ],
-    },
-  ],
-});
+describe("enforce-hook-naming", () => {
+  it("should have meta property", () => {
+    expect(enforceHookNaming.meta).toBeDefined();
+  });
 
-describe("enforce-hook-naming rule structure", () => {
-  it("should have correct rule structure", () => {
-    expect(enforceHookNaming).toHaveProperty("meta");
-    expect(enforceHookNaming).toHaveProperty("create");
+  it("should have create method", () => {
     expect(typeof enforceHookNaming.create).toBe("function");
+  });
+
+  ruleTester.run("enforce-hook-naming", enforceHookNaming, {
+    valid: [
+      {
+        code: `export function useSearchParamsHandler() {}`,
+        filename: "search-params.hook.ts",
+        name: "should allow use prefix in hook file",
+      },
+      {
+        code: `export default useSearchParamsHandler;`,
+        filename: "search-params.hook.ts",
+        name: "should allow default export with use prefix",
+      },
+      {
+        code: `export function useAuth() { return useState(); }`,
+        filename: "auth.hook.ts",
+        name: "should allow use prefix for auth hook",
+      },
+      {
+        code: `export const useModal = () => {}`,
+        filename: "modal.hook.ts",
+        name: "should allow use prefix with arrow function",
+      },
+      {
+        code: `export default function useCustomHook() {}`,
+        filename: "custom.hook.ts",
+        name: "should allow default function export with use prefix",
+      },
+      {
+        code: `export function useData() {}`,
+        filename: "data.hooks.ts",
+        name: "should allow use prefix in .hooks.ts file",
+      },
+      {
+        code: `export function searchHandler() {}`,
+        filename: "search.ts",
+        name: "should allow any name in non-hook files",
+      },
+      {
+        code: `export function handleSearch() {}`,
+        filename: "search.utils.ts",
+        name: "should allow any name in utility files",
+      },
+      {
+        code: `export default handleSearch;`,
+        filename: "search.ts",
+        name: "should allow default export without use prefix in non-hook files",
+      },
+    ],
+    invalid: [
+      {
+        code: `export function searchParamsHandler() {}`,
+        filename: "search-params.hook.ts",
+        name: "should disallow missing use prefix in named export",
+        errors: [
+          {
+            messageId: "missingUsePrefix",
+            data: {
+              name: "searchParamsHandler",
+              suggestion: "useSearchParamsHandler",
+            },
+          },
+        ],
+      },
+      {
+        code: `export default handleSearch;`,
+        filename: "search.hook.ts",
+        name: "should disallow default export without use prefix",
+        errors: [
+          {
+            messageId: "defaultExportMissingUsePrefix",
+            data: {
+              name: "handleSearch",
+              suggestion: "useHandleSearch",
+            },
+          },
+        ],
+      },
+      {
+        code: `export const modalHandler = () => {}`,
+        filename: "modal.hook.ts",
+        name: "should disallow arrow function without use prefix",
+        errors: [
+          {
+            messageId: "missingUsePrefix",
+            data: {
+              name: "modalHandler",
+              suggestion: "useModalHandler",
+            },
+          },
+        ],
+      },
+      {
+        code: `export function authManager() {}`,
+        filename: "auth.hooks.ts",
+        name: "should disallow missing use prefix in .hooks.ts file",
+        errors: [
+          {
+            messageId: "missingUsePrefix",
+            data: {
+              name: "authManager",
+              suggestion: "useAuthManager",
+            },
+          },
+        ],
+      },
+      {
+        code: `export default function customHook() {}`,
+        filename: "custom.hook.ts",
+        name: "should disallow default function export without use prefix",
+        errors: [
+          {
+            messageId: "defaultExportMissingUsePrefix",
+            data: {
+              name: "customHook",
+              suggestion: "useCustomHook",
+            },
+          },
+        ],
+      },
+      {
+        code: `export function getData() {}
+export function fetchItems() {}`,
+        filename: "data.hook.ts",
+        name: "should report multiple functions without use prefix",
+        errors: [
+          {
+            messageId: "missingUsePrefix",
+            data: {
+              name: "getData",
+              suggestion: "useGetData",
+            },
+          },
+          {
+            messageId: "missingUsePrefix",
+            data: {
+              name: "fetchItems",
+              suggestion: "useFetchItems",
+            },
+          },
+        ],
+      },
+    ],
   });
 });

--- a/src/rules/__tests__/enforce-props-suffix.test.ts
+++ b/src/rules/__tests__/enforce-props-suffix.test.ts
@@ -1,151 +1,152 @@
 import { RuleTester } from "@typescript-eslint/rule-tester";
-import { afterAll, describe, it, expect } from "@jest/globals";
+import { afterAll, describe, it } from "@jest/globals";
 
 import enforcePropsSuffix from "../enforce-props-suffix";
 
 RuleTester.afterAll = afterAll;
-RuleTester.it = it;
-RuleTester.itOnly = it.only;
 RuleTester.describe = describe;
+RuleTester.it = it;
 
 const ruleTester = new RuleTester();
 
-ruleTester.run("enforce-props-suffix", enforcePropsSuffix, {
-  valid: [
-    {
-      code: `interface ButtonProps {}`,
-      filename: "Button.tsx",
-      name: "should allow interface with Props suffix",
-    },
-    {
-      code: `interface ButtonStylesProps {}`,
-      filename: "Button.tsx",
-      name: "should allow interface with StylesProps suffix",
-    },
-    {
-      code: `type CardProps = { title: string }`,
-      filename: "Card.tsx",
-      name: "should allow type with Props suffix",
-    },
-    {
-      code: `interface HeaderProps { title: string }`,
-      filename: "Header.tsx",
-      name: "should allow interface with properties",
-    },
-    {
-      code: `interface Button {}`,
-      filename: "button.ts",
-      name: "should allow any name in non-component files",
-    },
-    {
-      code: `type ButtonType = {}`,
-      filename: "types.ts",
-      name: "should allow any type name in .ts files",
-    },
-    {
-      code: `type Status = "active" | "inactive"`,
-      filename: "Button.tsx",
-      name: "should allow union types without Props suffix",
-    },
-    {
-      code: `type ButtonState = SomeOtherType`,
-      filename: "Button.tsx",
-      name: "should allow type aliases that reference other types",
-    },
-    {
-      code: `type Callback = () => void`,
-      filename: "Button.tsx",
-      name: "should allow function type aliases",
-    },
-  ],
-  invalid: [
-    {
-      code: `interface Button {}`,
-      filename: "Button.tsx",
-      name: "should disallow interface without Props suffix",
-      errors: [
-        {
-          messageId: "missingPropsSuffix",
-          data: {
-            name: "Button",
-            suggestion: "ButtonProps",
+describe("enforce-props-suffix", () => {
+  it("should have meta property", () => {
+    expect(enforcePropsSuffix.meta).toBeDefined();
+  });
+
+  it("should have create method", () => {
+    expect(typeof enforcePropsSuffix.create).toBe("function");
+  });
+
+  ruleTester.run("enforce-props-suffix", enforcePropsSuffix, {
+    valid: [
+      {
+        code: `interface ButtonProps {}`,
+        filename: "Button.tsx",
+        name: "should allow interface with Props suffix",
+      },
+      {
+        code: `interface ButtonStylesProps {}`,
+        filename: "Button.tsx",
+        name: "should allow interface with StylesProps suffix",
+      },
+      {
+        code: `type CardProps = { title: string }`,
+        filename: "Card.tsx",
+        name: "should allow type with Props suffix",
+      },
+      {
+        code: `interface HeaderProps { title: string }`,
+        filename: "Header.tsx",
+        name: "should allow interface with properties",
+      },
+      {
+        code: `interface Button {}`,
+        filename: "button.ts",
+        name: "should allow any name in non-component files",
+      },
+      {
+        code: `type ButtonType = {}`,
+        filename: "types.ts",
+        name: "should allow any type name in .ts files",
+      },
+      {
+        code: `type Status = "active" | "inactive"`,
+        filename: "Button.tsx",
+        name: "should allow union types without Props suffix",
+      },
+      {
+        code: `type ButtonState = SomeOtherType`,
+        filename: "Button.tsx",
+        name: "should allow type aliases that reference other types",
+      },
+      {
+        code: `type Callback = () => void`,
+        filename: "Button.tsx",
+        name: "should allow function type aliases",
+      },
+    ],
+    invalid: [
+      {
+        code: `interface Button {}`,
+        filename: "Button.tsx",
+        name: "should disallow interface without Props suffix",
+        errors: [
+          {
+            messageId: "missingPropsSuffix",
+            data: {
+              name: "Button",
+              suggestion: "ButtonProps",
+            },
           },
-        },
-      ],
-    },
-    {
-      code: `interface Card { title: string }`,
-      filename: "Card.tsx",
-      name: "should disallow interface with properties but no Props suffix",
-      errors: [
-        {
-          messageId: "missingPropsSuffix",
-          data: {
-            name: "Card",
-            suggestion: "CardProps",
+        ],
+      },
+      {
+        code: `interface Card { title: string }`,
+        filename: "Card.tsx",
+        name: "should disallow interface with properties but no Props suffix",
+        errors: [
+          {
+            messageId: "missingPropsSuffix",
+            data: {
+              name: "Card",
+              suggestion: "CardProps",
+            },
           },
-        },
-      ],
-    },
-    {
-      code: `type ButtonType = { disabled: boolean }`,
-      filename: "Button.tsx",
-      name: "should disallow type literal without Props suffix",
-      errors: [
-        {
-          messageId: "missingPropsSuffix",
-          data: {
-            name: "ButtonType",
-            suggestion: "ButtonTypeProps",
+        ],
+      },
+      {
+        code: `type ButtonType = { disabled: boolean }`,
+        filename: "Button.tsx",
+        name: "should disallow type literal without Props suffix",
+        errors: [
+          {
+            messageId: "missingPropsSuffix",
+            data: {
+              name: "ButtonType",
+              suggestion: "ButtonTypeProps",
+            },
           },
-        },
-      ],
-    },
-    {
-      code: `interface Header {}`,
-      filename: "Header.jsx",
-      name: "should apply to JSX files too",
-      errors: [
-        {
-          messageId: "missingPropsSuffix",
-          data: {
-            name: "Header",
-            suggestion: "HeaderProps",
+        ],
+      },
+      {
+        code: `interface Header {}`,
+        filename: "Header.jsx",
+        name: "should apply to JSX files too",
+        errors: [
+          {
+            messageId: "missingPropsSuffix",
+            data: {
+              name: "Header",
+              suggestion: "HeaderProps",
+            },
           },
-        },
-      ],
-    },
-    {
-      code: `
+        ],
+      },
+      {
+        code: `
 interface Button {}
 interface Card {}
       `,
-      filename: "Components.tsx",
-      name: "should report multiple interfaces",
-      errors: [
-        {
-          messageId: "missingPropsSuffix",
-          data: {
-            name: "Button",
-            suggestion: "ButtonProps",
+        filename: "Components.tsx",
+        name: "should report multiple interfaces",
+        errors: [
+          {
+            messageId: "missingPropsSuffix",
+            data: {
+              name: "Button",
+              suggestion: "ButtonProps",
+            },
           },
-        },
-        {
-          messageId: "missingPropsSuffix",
-          data: {
-            name: "Card",
-            suggestion: "CardProps",
+          {
+            messageId: "missingPropsSuffix",
+            data: {
+              name: "Card",
+              suggestion: "CardProps",
+            },
           },
-        },
-      ],
-    },
-  ],
-});
-
-describe("enforce-props-suffix rule structure", () => {
-  it("should have correct rule structure", () => {
-    expect(enforcePropsSuffix).toHaveProperty("meta");
-    expect(enforcePropsSuffix).toHaveProperty("create");
-    expect(typeof enforcePropsSuffix.create).toBe("function");
+        ],
+      },
+    ],
   });
 });

--- a/src/rules/__tests__/enforce-readonly-component-props.test.ts
+++ b/src/rules/__tests__/enforce-readonly-component-props.test.ts
@@ -10,8 +10,6 @@ RuleTester.it = it;
 const ruleTester = new RuleTester({
   languageOptions: {
     parserOptions: {
-      ecmaVersion: 2020,
-      sourceType: "module",
       ecmaFeatures: {
         jsx: true,
       },
@@ -20,8 +18,12 @@ const ruleTester = new RuleTester({
 });
 
 describe("enforce-readonly-component-props", () => {
-  it("should be defined", () => {
-    expect(enforceReadonlyComponentProps).toBeDefined();
+  it("should have meta property", () => {
+    expect(enforceReadonlyComponentProps.meta).toBeDefined();
+  });
+
+  it("should have create method", () => {
+    expect(typeof enforceReadonlyComponentProps.create).toBe("function");
   });
 
   ruleTester.run("enforce-readonly-component-props", enforceReadonlyComponentProps, {

--- a/src/rules/__tests__/enforce-service-naming.test.ts
+++ b/src/rules/__tests__/enforce-service-naming.test.ts
@@ -1,176 +1,177 @@
 import { RuleTester } from "@typescript-eslint/rule-tester";
-import { afterAll, describe, it, expect } from "@jest/globals";
+import { afterAll, describe, it } from "@jest/globals";
 
 import enforceServiceNaming from "../enforce-service-naming";
 
 RuleTester.afterAll = afterAll;
-RuleTester.it = it;
-RuleTester.itOnly = it.only;
 RuleTester.describe = describe;
+RuleTester.it = it;
 
 const ruleTester = new RuleTester();
 
-ruleTester.run("enforce-service-naming", enforceServiceNaming, {
-  valid: [
-    {
-      code: `export async function fetchArticleList() {}`,
-      filename: "article.service.ts",
-      name: "should allow fetch prefix in service file",
-    },
-    {
-      code: `export async function fetchFaqList() {}`,
-      filename: "faq.service.ts",
-      name: "should allow fetch prefix for FAQ service",
-    },
-    {
-      code: `export async function fetchUserById() {}`,
-      filename: "user.service.ts",
-      name: "should allow fetch prefix with different naming",
-    },
-    {
-      code: `export async function createUser() {}`,
-      filename: "user.service.ts",
-      name: "should allow create prefix",
-    },
-    {
-      code: `export async function updateArticle() {}`,
-      filename: "article.service.ts",
-      name: "should allow update prefix",
-    },
-    {
-      code: `export async function deleteComment() {}`,
-      filename: "comment.service.ts",
-      name: "should allow delete prefix",
-    },
-    {
-      code: `export async function getArticles() {}`,
-      filename: "article.ts",
-      name: "should allow get prefix in non-service files",
-    },
-    {
-      code: `export async function loadData() {}`,
-      filename: "utils.ts",
-      name: "should allow load prefix in non-service files",
-    },
-    {
-      code: `export function getArticles() {}`,
-      filename: "article.service.ts",
-      name: "should allow get prefix for non-async functions",
-    },
-    {
-      code: `function getArticles() {}`,
-      filename: "article.service.ts",
-      name: "should allow get prefix for non-exported functions",
-    },
-    {
-      code: `export const fetchUsers = async () => {}`,
-      filename: "user.service.ts",
-      name: "should allow fetch prefix with arrow function",
-    },
-    {
-      code: `export async function get() {}`,
-      filename: "article.service.ts",
-      name: "should allow 'get' as full function name (not prefix)",
-    },
-  ],
-  invalid: [
-    {
-      code: `export async function getArticles() {}`,
-      filename: "article.service.ts",
-      name: "should disallow get prefix in service file",
-      errors: [
-        {
-          messageId: "usesFetchPrefix",
-          data: {
-            prefix: "get",
-            name: "getArticles",
-            suggestion: "fetchArticles",
-          },
-        },
-      ],
-    },
-    {
-      code: `export async function loadFaq() {}`,
-      filename: "faq.service.ts",
-      name: "should disallow load prefix in service file",
-      errors: [
-        {
-          messageId: "usesFetchPrefix",
-          data: {
-            prefix: "load",
-            name: "loadFaq",
-            suggestion: "fetchFaq",
-          },
-        },
-      ],
-    },
-    {
-      code: `export async function getUserById() {}`,
-      filename: "user.service.ts",
-      name: "should disallow get prefix with camelCase",
-      errors: [
-        {
-          messageId: "usesFetchPrefix",
-          data: {
-            prefix: "get",
-            name: "getUserById",
-            suggestion: "fetchUserById",
-          },
-        },
-      ],
-    },
-    {
-      code: `export async function loadAllUsers() {}`,
-      filename: "user.service.ts",
-      name: "should disallow load prefix with longer name",
-      errors: [
-        {
-          messageId: "usesFetchPrefix",
-          data: {
-            prefix: "load",
-            name: "loadAllUsers",
-            suggestion: "fetchAllUsers",
-          },
-        },
-      ],
-    },
-    {
-      code: `export const getUsers = async () => {}`,
-      filename: "user.service.ts",
-      name: "should disallow get prefix with arrow function",
-      errors: [
-        {
-          messageId: "usesFetchPrefix",
-          data: {
-            prefix: "get",
-            name: "getUsers",
-            suggestion: "fetchUsers",
-          },
-        },
-      ],
-    },
-    {
-      code: `export const loadItems = async () => {}`,
-      filename: "item.service.ts",
-      name: "should disallow load prefix with arrow function",
-      errors: [
-        {
-          messageId: "usesFetchPrefix",
-          data: {
-            prefix: "load",
-            name: "loadItems",
-            suggestion: "fetchItems",
-          },
-        },
-      ],
-    },
-  ],
-});
+describe("enforce-service-naming", () => {
+  it("should have meta property", () => {
+    expect(enforceServiceNaming.meta).toBeDefined();
+  });
 
-describe("enforce-service-naming rule structure", () => {
-  it("should have correct rule structure", () => {
-    expect(enforceServiceNaming).toHaveProperty("meta");
-    expect(enforceServiceNaming).toHaveProperty("create");
+  it("should have create method", () => {
     expect(typeof enforceServiceNaming.create).toBe("function");
+  });
+
+  ruleTester.run("enforce-service-naming", enforceServiceNaming, {
+    valid: [
+      {
+        code: `export async function fetchArticleList() {}`,
+        filename: "article.service.ts",
+        name: "should allow fetch prefix in service file",
+      },
+      {
+        code: `export async function fetchFaqList() {}`,
+        filename: "faq.service.ts",
+        name: "should allow fetch prefix for FAQ service",
+      },
+      {
+        code: `export async function fetchUserById() {}`,
+        filename: "user.service.ts",
+        name: "should allow fetch prefix with different naming",
+      },
+      {
+        code: `export async function createUser() {}`,
+        filename: "user.service.ts",
+        name: "should allow create prefix",
+      },
+      {
+        code: `export async function updateArticle() {}`,
+        filename: "article.service.ts",
+        name: "should allow update prefix",
+      },
+      {
+        code: `export async function deleteComment() {}`,
+        filename: "comment.service.ts",
+        name: "should allow delete prefix",
+      },
+      {
+        code: `export async function getArticles() {}`,
+        filename: "article.ts",
+        name: "should allow get prefix in non-service files",
+      },
+      {
+        code: `export async function loadData() {}`,
+        filename: "utils.ts",
+        name: "should allow load prefix in non-service files",
+      },
+      {
+        code: `export function getArticles() {}`,
+        filename: "article.service.ts",
+        name: "should allow get prefix for non-async functions",
+      },
+      {
+        code: `function getArticles() {}`,
+        filename: "article.service.ts",
+        name: "should allow get prefix for non-exported functions",
+      },
+      {
+        code: `export const fetchUsers = async () => {}`,
+        filename: "user.service.ts",
+        name: "should allow fetch prefix with arrow function",
+      },
+      {
+        code: `export async function get() {}`,
+        filename: "article.service.ts",
+        name: "should allow 'get' as full function name (not prefix)",
+      },
+    ],
+    invalid: [
+      {
+        code: `export async function getArticles() {}`,
+        filename: "article.service.ts",
+        name: "should disallow get prefix in service file",
+        errors: [
+          {
+            messageId: "usesFetchPrefix",
+            data: {
+              prefix: "get",
+              name: "getArticles",
+              suggestion: "fetchArticles",
+            },
+          },
+        ],
+      },
+      {
+        code: `export async function loadFaq() {}`,
+        filename: "faq.service.ts",
+        name: "should disallow load prefix in service file",
+        errors: [
+          {
+            messageId: "usesFetchPrefix",
+            data: {
+              prefix: "load",
+              name: "loadFaq",
+              suggestion: "fetchFaq",
+            },
+          },
+        ],
+      },
+      {
+        code: `export async function getUserById() {}`,
+        filename: "user.service.ts",
+        name: "should disallow get prefix with camelCase",
+        errors: [
+          {
+            messageId: "usesFetchPrefix",
+            data: {
+              prefix: "get",
+              name: "getUserById",
+              suggestion: "fetchUserById",
+            },
+          },
+        ],
+      },
+      {
+        code: `export async function loadAllUsers() {}`,
+        filename: "user.service.ts",
+        name: "should disallow load prefix with longer name",
+        errors: [
+          {
+            messageId: "usesFetchPrefix",
+            data: {
+              prefix: "load",
+              name: "loadAllUsers",
+              suggestion: "fetchAllUsers",
+            },
+          },
+        ],
+      },
+      {
+        code: `export const getUsers = async () => {}`,
+        filename: "user.service.ts",
+        name: "should disallow get prefix with arrow function",
+        errors: [
+          {
+            messageId: "usesFetchPrefix",
+            data: {
+              prefix: "get",
+              name: "getUsers",
+              suggestion: "fetchUsers",
+            },
+          },
+        ],
+      },
+      {
+        code: `export const loadItems = async () => {}`,
+        filename: "item.service.ts",
+        name: "should disallow load prefix with arrow function",
+        errors: [
+          {
+            messageId: "usesFetchPrefix",
+            data: {
+              prefix: "load",
+              name: "loadItems",
+              suggestion: "fetchItems",
+            },
+          },
+        ],
+      },
+    ],
   });
 });

--- a/src/rules/__tests__/enforce-sorted-destructuring.test.ts
+++ b/src/rules/__tests__/enforce-sorted-destructuring.test.ts
@@ -4,22 +4,18 @@ import { afterAll, describe, it } from "@jest/globals";
 import enforceSortedDestructuring from "../enforce-sorted-destructuring";
 
 RuleTester.afterAll = afterAll;
-RuleTester.it = it;
-RuleTester.itOnly = it.only;
 RuleTester.describe = describe;
+RuleTester.it = it;
 
-const ruleTester = new RuleTester({
-  languageOptions: {
-    parserOptions: {
-      ecmaVersion: 2020,
-      sourceType: "module",
-    },
-  },
-});
+const ruleTester = new RuleTester();
 
 describe("enforce-sorted-destructuring", () => {
-  it("should be defined", () => {
-    expect(enforceSortedDestructuring).toBeDefined();
+  it("should have meta property", () => {
+    expect(enforceSortedDestructuring.meta).toBeDefined();
+  });
+
+  it("should have create method", () => {
+    expect(typeof enforceSortedDestructuring.create).toBe("function");
   });
 
   ruleTester.run("enforce-sorted-destructuring", enforceSortedDestructuring, {

--- a/src/rules/__tests__/enforce-type-declaration-order.test.ts
+++ b/src/rules/__tests__/enforce-type-declaration-order.test.ts
@@ -7,14 +7,7 @@ RuleTester.afterAll = afterAll;
 RuleTester.describe = describe;
 RuleTester.it = it;
 
-const ruleTester = new RuleTester({
-  languageOptions: {
-    parserOptions: {
-      ecmaVersion: 2020,
-      sourceType: "module",
-    },
-  },
-});
+const ruleTester = new RuleTester();
 
 describe("enforce-type-declaration-order", () => {
   it("should have meta property", () => {

--- a/src/rules/__tests__/file-kebab-case.test.ts
+++ b/src/rules/__tests__/file-kebab-case.test.ts
@@ -4,235 +4,236 @@ import { afterAll, describe, it } from "@jest/globals";
 import fileKebabCase from "../file-kebab-case";
 
 RuleTester.afterAll = afterAll;
-RuleTester.it = it;
-RuleTester.itOnly = it.only;
 RuleTester.describe = describe;
+RuleTester.it = it;
 
 const ruleTester = new RuleTester();
 
-ruleTester.run("file-kebab-case", fileKebabCase, {
-  valid: [
-    {
-      code: `const test = true;`,
-      filename: "my-component.ts",
-      name: "should allow kebab-case .ts files",
-    },
-    {
-      code: `export default function() {}`,
-      filename: "utils-helper.js",
-      name: "should allow kebab-case .js files",
-    },
-    {
-      code: `const config = {};`,
-      filename: "app-config.ts",
-      name: "should allow kebab-case with multiple hyphens",
-    },
-    {
-      code: `console.log("test");`,
-      filename: "test.ts",
-      name: "should allow single word kebab-case",
-    },
-    {
-      code: `const data = [];`,
-      filename: "user-profile-settings.ts",
-      name: "should allow long kebab-case names",
-    },
-    {
-      code: `export const value = 123;`,
-      filename: "api-v2-client.js",
-      name: "should allow kebab-case with numbers",
-    },
-    {
-      code: `const style = {};`,
-      filename: "styles.css",
-      name: "should ignore non-.ts/.js files",
-    },
-    {
-      code: `const html = "";`,
-      filename: "InvalidName.html",
-      name: "should ignore non-.ts/.js files even with invalid names",
-    },
-    {
-      code: `const config = {};`,
-      filename: "webpack.config.js",
-      name: "should allow common config file patterns",
-    },
-    {
-      code: `export interface GreetingProps {}`,
-      filename: "greeting.interfaces.ts",
-      name: "should allow [name].[type] pattern with interfaces",
-    },
-    {
-      code: `export type UserType = {};`,
-      filename: "greeting.types.ts",
-      name: "should allow [name].[type] pattern with types",
-    },
-    {
-      code: `export class GreetingService {}`,
-      filename: "greeting.service.ts",
-      name: "should allow [name].[type] pattern with service",
-    },
-    {
-      code: `export const fooBar = {};`,
-      filename: "foo.bar.ts",
-      name: "should allow [name].[type] pattern with simple names",
-    },
-    {
-      code: `export const utils = {};`,
-      filename: "foo.bar.js",
-      name: "should allow [name].[type] pattern with .js files",
-    },
-    {
-      code: `export const api = {};`,
-      filename: "user-profile.service.ts",
-      name: "should allow [name].[type] pattern with kebab-case names",
-    },
-    {
-      code: `export const data = {};`,
-      filename: "api-v2.client.ts",
-      name: "should allow [name].[type] pattern with numbers in kebab-case",
-    },
-  ],
-  invalid: [
-    {
-      code: `const test = true;`,
-      filename: "MyComponent.ts",
-      name: "should disallow PascalCase .ts files",
-      errors: [
-        {
-          messageId: "fileKebabCase",
-          line: 1,
-          column: 1,
-        },
-      ],
-    },
-    {
-      code: `export default function() {}`,
-      filename: "myComponent.js",
-      name: "should disallow camelCase .js files",
-      errors: [
-        {
-          messageId: "fileKebabCase",
-          line: 1,
-          column: 1,
-        },
-      ],
-    },
-    {
-      code: `const config = {};`,
-      filename: "app_config.ts",
-      name: "should disallow snake_case files",
-      errors: [
-        {
-          messageId: "fileKebabCase",
-          line: 1,
-          column: 1,
-        },
-      ],
-    },
-    {
-      code: `console.log("test");`,
-      filename: "TEST.ts",
-      name: "should disallow UPPERCASE files",
-      errors: [
-        {
-          messageId: "fileKebabCase",
-          line: 1,
-          column: 1,
-        },
-      ],
-    },
-    {
-      code: `const data = [];`,
-      filename: "User Profile Settings.ts",
-      name: "should disallow files with spaces",
-      errors: [
-        {
-          messageId: "fileKebabCase",
-          line: 1,
-          column: 1,
-        },
-      ],
-    },
-    {
-      code: `export const value = 123;`,
-      filename: "api.V2.client.js",
-      name: "should disallow files with dots in middle",
-      errors: [
-        {
-          messageId: "fileKebabCase",
-          line: 1,
-          column: 1,
-        },
-      ],
-    },
-    {
-      code: `const mixed = {};`,
-      filename: "some-File_Name.ts",
-      name: "should disallow mixed naming conventions",
-      errors: [
-        {
-          messageId: "fileKebabCase",
-          line: 1,
-          column: 1,
-        },
-      ],
-    },
-    {
-      code: `const numbers = [];`,
-      filename: "file123Name.js",
-      name: "should disallow camelCase with numbers",
-      errors: [
-        {
-          messageId: "fileKebabCase",
-          line: 1,
-          column: 1,
-        },
-      ],
-    },
-    {
-      code: `export interface Props {}`,
-      filename: "Greeting.Interfaces.ts",
-      name: "should disallow PascalCase in [name].[type] pattern",
-      errors: [
-        {
-          messageId: "fileKebabCase",
-          line: 1,
-          column: 1,
-        },
-      ],
-    },
-    {
-      code: `export const service = {};`,
-      filename: "greeting_service.ts",
-      name: "should disallow snake_case in [name].[type] pattern",
-      errors: [
-        {
-          messageId: "fileKebabCase",
-          line: 1,
-          column: 1,
-        },
-      ],
-    },
-    {
-      code: `export const data = {};`,
-      filename: "foo.Bar.ts",
-      name: "should disallow PascalCase in type part of [name].[type] pattern",
-      errors: [
-        {
-          messageId: "fileKebabCase",
-          line: 1,
-          column: 1,
-        },
-      ],
-    },
-  ],
-});
+describe("file-kebab-case", () => {
+  it("should have meta property", () => {
+    expect(fileKebabCase.meta).toBeDefined();
+  });
 
-describe("file-kebab-case rule structure", () => {
-  it("should have correct rule structure", () => {
-    expect(fileKebabCase).toHaveProperty("meta");
-    expect(fileKebabCase).toHaveProperty("create");
+  it("should have create method", () => {
     expect(typeof fileKebabCase.create).toBe("function");
+  });
+
+  ruleTester.run("file-kebab-case", fileKebabCase, {
+    valid: [
+      {
+        code: `const test = true;`,
+        filename: "my-component.ts",
+        name: "should allow kebab-case .ts files",
+      },
+      {
+        code: `export default function() {}`,
+        filename: "utils-helper.js",
+        name: "should allow kebab-case .js files",
+      },
+      {
+        code: `const config = {};`,
+        filename: "app-config.ts",
+        name: "should allow kebab-case with multiple hyphens",
+      },
+      {
+        code: `console.log("test");`,
+        filename: "test.ts",
+        name: "should allow single word kebab-case",
+      },
+      {
+        code: `const data = [];`,
+        filename: "user-profile-settings.ts",
+        name: "should allow long kebab-case names",
+      },
+      {
+        code: `export const value = 123;`,
+        filename: "api-v2-client.js",
+        name: "should allow kebab-case with numbers",
+      },
+      {
+        code: `const style = {};`,
+        filename: "styles.css",
+        name: "should ignore non-.ts/.js files",
+      },
+      {
+        code: `const html = "";`,
+        filename: "InvalidName.html",
+        name: "should ignore non-.ts/.js files even with invalid names",
+      },
+      {
+        code: `const config = {};`,
+        filename: "webpack.config.js",
+        name: "should allow common config file patterns",
+      },
+      {
+        code: `export interface GreetingProps {}`,
+        filename: "greeting.interfaces.ts",
+        name: "should allow [name].[type] pattern with interfaces",
+      },
+      {
+        code: `export type UserType = {};`,
+        filename: "greeting.types.ts",
+        name: "should allow [name].[type] pattern with types",
+      },
+      {
+        code: `export class GreetingService {}`,
+        filename: "greeting.service.ts",
+        name: "should allow [name].[type] pattern with service",
+      },
+      {
+        code: `export const fooBar = {};`,
+        filename: "foo.bar.ts",
+        name: "should allow [name].[type] pattern with simple names",
+      },
+      {
+        code: `export const utils = {};`,
+        filename: "foo.bar.js",
+        name: "should allow [name].[type] pattern with .js files",
+      },
+      {
+        code: `export const api = {};`,
+        filename: "user-profile.service.ts",
+        name: "should allow [name].[type] pattern with kebab-case names",
+      },
+      {
+        code: `export const data = {};`,
+        filename: "api-v2.client.ts",
+        name: "should allow [name].[type] pattern with numbers in kebab-case",
+      },
+    ],
+    invalid: [
+      {
+        code: `const test = true;`,
+        filename: "MyComponent.ts",
+        name: "should disallow PascalCase .ts files",
+        errors: [
+          {
+            messageId: "fileKebabCase",
+            line: 1,
+            column: 1,
+          },
+        ],
+      },
+      {
+        code: `export default function() {}`,
+        filename: "myComponent.js",
+        name: "should disallow camelCase .js files",
+        errors: [
+          {
+            messageId: "fileKebabCase",
+            line: 1,
+            column: 1,
+          },
+        ],
+      },
+      {
+        code: `const config = {};`,
+        filename: "app_config.ts",
+        name: "should disallow snake_case files",
+        errors: [
+          {
+            messageId: "fileKebabCase",
+            line: 1,
+            column: 1,
+          },
+        ],
+      },
+      {
+        code: `console.log("test");`,
+        filename: "TEST.ts",
+        name: "should disallow UPPERCASE files",
+        errors: [
+          {
+            messageId: "fileKebabCase",
+            line: 1,
+            column: 1,
+          },
+        ],
+      },
+      {
+        code: `const data = [];`,
+        filename: "User Profile Settings.ts",
+        name: "should disallow files with spaces",
+        errors: [
+          {
+            messageId: "fileKebabCase",
+            line: 1,
+            column: 1,
+          },
+        ],
+      },
+      {
+        code: `export const value = 123;`,
+        filename: "api.V2.client.js",
+        name: "should disallow files with dots in middle",
+        errors: [
+          {
+            messageId: "fileKebabCase",
+            line: 1,
+            column: 1,
+          },
+        ],
+      },
+      {
+        code: `const mixed = {};`,
+        filename: "some-File_Name.ts",
+        name: "should disallow mixed naming conventions",
+        errors: [
+          {
+            messageId: "fileKebabCase",
+            line: 1,
+            column: 1,
+          },
+        ],
+      },
+      {
+        code: `const numbers = [];`,
+        filename: "file123Name.js",
+        name: "should disallow camelCase with numbers",
+        errors: [
+          {
+            messageId: "fileKebabCase",
+            line: 1,
+            column: 1,
+          },
+        ],
+      },
+      {
+        code: `export interface Props {}`,
+        filename: "Greeting.Interfaces.ts",
+        name: "should disallow PascalCase in [name].[type] pattern",
+        errors: [
+          {
+            messageId: "fileKebabCase",
+            line: 1,
+            column: 1,
+          },
+        ],
+      },
+      {
+        code: `export const service = {};`,
+        filename: "greeting_service.ts",
+        name: "should disallow snake_case in [name].[type] pattern",
+        errors: [
+          {
+            messageId: "fileKebabCase",
+            line: 1,
+            column: 1,
+          },
+        ],
+      },
+      {
+        code: `export const data = {};`,
+        filename: "foo.Bar.ts",
+        name: "should disallow PascalCase in type part of [name].[type] pattern",
+        errors: [
+          {
+            messageId: "fileKebabCase",
+            line: 1,
+            column: 1,
+          },
+        ],
+      },
+    ],
   });
 });

--- a/src/rules/__tests__/jsx-newline-between-elements.test.ts
+++ b/src/rules/__tests__/jsx-newline-between-elements.test.ts
@@ -4,15 +4,12 @@ import { afterAll, describe, it } from "@jest/globals";
 import jsxNewlineBetweenElements from "../jsx-newline-between-elements";
 
 RuleTester.afterAll = afterAll;
-RuleTester.it = it;
-RuleTester.itOnly = it.only;
 RuleTester.describe = describe;
+RuleTester.it = it;
 
 const ruleTester = new RuleTester({
   languageOptions: {
     parserOptions: {
-      ecmaVersion: 2020,
-      sourceType: "module",
       ecmaFeatures: {
         jsx: true,
       },
@@ -21,8 +18,12 @@ const ruleTester = new RuleTester({
 });
 
 describe("jsx-newline-between-elements", () => {
-  it("should be defined", () => {
-    expect(jsxNewlineBetweenElements).toBeDefined();
+  it("should have meta property", () => {
+    expect(jsxNewlineBetweenElements.meta).toBeDefined();
+  });
+
+  it("should have create method", () => {
+    expect(typeof jsxNewlineBetweenElements.create).toBe("function");
   });
 
   ruleTester.run("jsx-newline-between-elements", jsxNewlineBetweenElements, {

--- a/src/rules/__tests__/jsx-no-inline-object-prop.test.ts
+++ b/src/rules/__tests__/jsx-no-inline-object-prop.test.ts
@@ -1,12 +1,11 @@
 import { RuleTester } from "@typescript-eslint/rule-tester";
-import { afterAll, describe, it, expect } from "@jest/globals";
+import { afterAll, describe, it } from "@jest/globals";
 
 import jsxNoInlineObjectProp from "../jsx-no-inline-object-prop";
 
 RuleTester.afterAll = afterAll;
-RuleTester.it = it;
-RuleTester.itOnly = it.only;
 RuleTester.describe = describe;
+RuleTester.it = it;
 
 const ruleTester = new RuleTester({
   languageOptions: {
@@ -18,118 +17,120 @@ const ruleTester = new RuleTester({
   },
 });
 
-ruleTester.run("jsx-no-inline-object-prop", jsxNoInlineObjectProp, {
-  valid: [
-    {
-      code: `const style = { color: "red" }; <Component style={style} />`,
-      name: "should allow variable reference for style",
-    },
-    {
-      code: `const data = { id: 1 }; <Component data={data} />`,
-      name: "should allow variable reference for data",
-    },
-    {
-      code: `<Component onClick={handleClick} />`,
-      name: "should allow function reference",
-    },
-    {
-      code: `<Component disabled={true} />`,
-      name: "should allow boolean values",
-    },
-    {
-      code: `<Component count={42} />`,
-      name: "should allow number values",
-    },
-    {
-      code: `<Component name="test" />`,
-      name: "should allow string literals",
-    },
-    {
-      code: `<Component name={"test"} />`,
-      name: "should allow string in expression container",
-    },
-    {
-      code: `<Component items={[1, 2, 3]} />`,
-      name: "should allow inline arrays",
-    },
-    {
-      code: `<Component callback={() => {}} />`,
-      name: "should allow arrow functions",
-    },
-    {
-      code: `<Component value={someObject.property} />`,
-      name: "should allow member expressions",
-    },
-    {
-      code: `<Component {...props} />`,
-      name: "should allow spread attributes",
-    },
-  ],
-  invalid: [
-    {
-      code: `<Component style={{ color: "red" }} />`,
-      name: "should disallow inline object for style",
-      errors: [
-        {
-          messageId: "noInlineObject",
-        },
-      ],
-    },
-    {
-      code: `<Component data={{ id: 1 }} />`,
-      name: "should disallow inline object for data",
-      errors: [
-        {
-          messageId: "noInlineObject",
-        },
-      ],
-    },
-    {
-      code: `<Component config={{ enabled: true, timeout: 1000 }} />`,
-      name: "should disallow inline object with multiple properties",
-      errors: [
-        {
-          messageId: "noInlineObject",
-        },
-      ],
-    },
-    {
-      code: `<Component options={{}} />`,
-      name: "should disallow empty inline object",
-      errors: [
-        {
-          messageId: "noInlineObject",
-        },
-      ],
-    },
-    {
-      code: `<Component nested={{ outer: { inner: "value" } }} />`,
-      name: "should disallow nested inline objects",
-      errors: [
-        {
-          messageId: "noInlineObject",
-        },
-      ],
-    },
-    {
-      code: `<div style={{ margin: 0 }}><span style={{ padding: 0 }} /></div>`,
-      name: "should report multiple inline objects",
-      errors: [
-        {
-          messageId: "noInlineObject",
-        },
-        {
-          messageId: "noInlineObject",
-        },
-      ],
-    },
-  ],
-});
+describe("jsx-no-inline-object-prop", () => {
+  it("should have meta property", () => {
+    expect(jsxNoInlineObjectProp.meta).toBeDefined();
+  });
 
-describe("jsx-no-inline-object-prop rule structure", () => {
-  it("should have correct rule structure", () => {
-    expect(jsxNoInlineObjectProp).toHaveProperty("meta");
-    expect(jsxNoInlineObjectProp).toHaveProperty("create");
+  it("should have create method", () => {
     expect(typeof jsxNoInlineObjectProp.create).toBe("function");
+  });
+
+  ruleTester.run("jsx-no-inline-object-prop", jsxNoInlineObjectProp, {
+    valid: [
+      {
+        code: `const style = { color: "red" }; <Component style={style} />`,
+        name: "should allow variable reference for style",
+      },
+      {
+        code: `const data = { id: 1 }; <Component data={data} />`,
+        name: "should allow variable reference for data",
+      },
+      {
+        code: `<Component onClick={handleClick} />`,
+        name: "should allow function reference",
+      },
+      {
+        code: `<Component disabled={true} />`,
+        name: "should allow boolean values",
+      },
+      {
+        code: `<Component count={42} />`,
+        name: "should allow number values",
+      },
+      {
+        code: `<Component name="test" />`,
+        name: "should allow string literals",
+      },
+      {
+        code: `<Component name={"test"} />`,
+        name: "should allow string in expression container",
+      },
+      {
+        code: `<Component items={[1, 2, 3]} />`,
+        name: "should allow inline arrays",
+      },
+      {
+        code: `<Component callback={() => {}} />`,
+        name: "should allow arrow functions",
+      },
+      {
+        code: `<Component value={someObject.property} />`,
+        name: "should allow member expressions",
+      },
+      {
+        code: `<Component {...props} />`,
+        name: "should allow spread attributes",
+      },
+    ],
+    invalid: [
+      {
+        code: `<Component style={{ color: "red" }} />`,
+        name: "should disallow inline object for style",
+        errors: [
+          {
+            messageId: "noInlineObject",
+          },
+        ],
+      },
+      {
+        code: `<Component data={{ id: 1 }} />`,
+        name: "should disallow inline object for data",
+        errors: [
+          {
+            messageId: "noInlineObject",
+          },
+        ],
+      },
+      {
+        code: `<Component config={{ enabled: true, timeout: 1000 }} />`,
+        name: "should disallow inline object with multiple properties",
+        errors: [
+          {
+            messageId: "noInlineObject",
+          },
+        ],
+      },
+      {
+        code: `<Component options={{}} />`,
+        name: "should disallow empty inline object",
+        errors: [
+          {
+            messageId: "noInlineObject",
+          },
+        ],
+      },
+      {
+        code: `<Component nested={{ outer: { inner: "value" } }} />`,
+        name: "should disallow nested inline objects",
+        errors: [
+          {
+            messageId: "noInlineObject",
+          },
+        ],
+      },
+      {
+        code: `<div style={{ margin: 0 }}><span style={{ padding: 0 }} /></div>`,
+        name: "should report multiple inline objects",
+        errors: [
+          {
+            messageId: "noInlineObject",
+          },
+          {
+            messageId: "noInlineObject",
+          },
+        ],
+      },
+    ],
   });
 });

--- a/src/rules/__tests__/jsx-no-newline-single-line-elements.test.ts
+++ b/src/rules/__tests__/jsx-no-newline-single-line-elements.test.ts
@@ -4,15 +4,12 @@ import { afterAll, describe, it } from "@jest/globals";
 import jsxNoNewlineSingleLineElements from "../jsx-no-newline-single-line-elements";
 
 RuleTester.afterAll = afterAll;
-RuleTester.it = it;
-RuleTester.itOnly = it.only;
 RuleTester.describe = describe;
+RuleTester.it = it;
 
 const ruleTester = new RuleTester({
   languageOptions: {
     parserOptions: {
-      ecmaVersion: 2020,
-      sourceType: "module",
       ecmaFeatures: {
         jsx: true,
       },
@@ -22,11 +19,11 @@ const ruleTester = new RuleTester({
 
 describe("jsx-no-newline-single-line-elements", () => {
   it("should have meta property", () => {
-    expect(jsxNoNewlineSingleLineElements).toHaveProperty("meta");
+    expect(jsxNoNewlineSingleLineElements.meta).toBeDefined();
   });
 
-  it("should have create property", () => {
-    expect(jsxNoNewlineSingleLineElements).toHaveProperty("create");
+  it("should have create method", () => {
+    expect(typeof jsxNoNewlineSingleLineElements.create).toBe("function");
   });
 
   ruleTester.run("jsx-no-newline-single-line-elements", jsxNoNewlineSingleLineElements, {

--- a/src/rules/__tests__/jsx-no-non-component-function.test.ts
+++ b/src/rules/__tests__/jsx-no-non-component-function.test.ts
@@ -4,15 +4,12 @@ import { afterAll, describe, it } from "@jest/globals";
 import jsxNoNonComponentFunction from "../jsx-no-non-component-function";
 
 RuleTester.afterAll = afterAll;
-RuleTester.it = it;
-RuleTester.itOnly = it.only;
 RuleTester.describe = describe;
+RuleTester.it = it;
 
 const ruleTester = new RuleTester({
   languageOptions: {
     parserOptions: {
-      ecmaVersion: 2020,
-      sourceType: "module",
       ecmaFeatures: {
         jsx: true,
       },
@@ -21,8 +18,12 @@ const ruleTester = new RuleTester({
 });
 
 describe("jsx-no-non-component-function", () => {
-  it("should be defined", () => {
-    expect(jsxNoNonComponentFunction).toBeDefined();
+  it("should have meta property", () => {
+    expect(jsxNoNonComponentFunction.meta).toBeDefined();
+  });
+
+  it("should have create method", () => {
+    expect(typeof jsxNoNonComponentFunction.create).toBe("function");
   });
 
   ruleTester.run("jsx-no-non-component-function", jsxNoNonComponentFunction, {

--- a/src/rules/__tests__/jsx-no-variable-in-callback.test.ts
+++ b/src/rules/__tests__/jsx-no-variable-in-callback.test.ts
@@ -4,15 +4,12 @@ import { afterAll, describe, it } from "@jest/globals";
 import jsxNoVariableInCallback from "../jsx-no-variable-in-callback";
 
 RuleTester.afterAll = afterAll;
-RuleTester.it = it;
-RuleTester.itOnly = it.only;
 RuleTester.describe = describe;
+RuleTester.it = it;
 
 const ruleTester = new RuleTester({
   languageOptions: {
     parserOptions: {
-      ecmaVersion: 2020,
-      sourceType: "module",
       ecmaFeatures: {
         jsx: true,
       },
@@ -21,8 +18,12 @@ const ruleTester = new RuleTester({
 });
 
 describe("jsx-no-variable-in-callback", () => {
-  it("should be defined", () => {
-    expect(jsxNoVariableInCallback).toBeDefined();
+  it("should have meta property", () => {
+    expect(jsxNoVariableInCallback.meta).toBeDefined();
+  });
+
+  it("should have create method", () => {
+    expect(typeof jsxNoVariableInCallback.create).toBe("function");
   });
 
   ruleTester.run("jsx-no-variable-in-callback", jsxNoVariableInCallback, {

--- a/src/rules/__tests__/jsx-pascal-case.test.ts
+++ b/src/rules/__tests__/jsx-pascal-case.test.ts
@@ -4,169 +4,170 @@ import { afterAll, describe, it } from "@jest/globals";
 import jsxPascalCase from "../jsx-pascal-case";
 
 RuleTester.afterAll = afterAll;
-RuleTester.it = it;
-RuleTester.itOnly = it.only;
 RuleTester.describe = describe;
+RuleTester.it = it;
 
 const ruleTester = new RuleTester();
 
-ruleTester.run("jsx-pascal-case", jsxPascalCase, {
-  valid: [
-    {
-      code: `const Component = () => <div>Hello</div>;`,
-      filename: "MyComponent.jsx",
-      name: "should allow PascalCase .jsx files",
-    },
-    {
-      code: `export default function Component() { return <div>Hello</div>; }`,
-      filename: "UserProfile.tsx",
-      name: "should allow PascalCase .tsx files",
-    },
-    {
-      code: `const App = () => <div>App</div>;`,
-      filename: "App.jsx",
-      name: "should allow single word PascalCase",
-    },
-    {
-      code: `export const Header = () => <header>Header</header>;`,
-      filename: "Header.tsx",
-      name: "should allow single word PascalCase tsx",
-    },
-    {
-      code: `const LoginForm = () => <form>Login</form>;`,
-      filename: "LoginFormComponent.jsx",
-      name: "should allow long PascalCase names",
-    },
-    {
-      code: `const UserProfile2 = () => <div>Profile</div>;`,
-      filename: "UserProfile2.tsx",
-      name: "should allow PascalCase with numbers",
-    },
-    {
-      code: `const style = {};`,
-      filename: "styles.css",
-      name: "should ignore non-.jsx/.tsx files",
-    },
-    {
-      code: `const html = "";`,
-      filename: "invalid-name.html",
-      name: "should ignore non-.jsx/.tsx files even with invalid names",
-    },
-    {
-      code: `const config = {};`,
-      filename: "invalid-name.js",
-      name: "should ignore .js files",
-    },
-    {
-      code: `const config = {};`,
-      filename: "invalid-name.ts",
-      name: "should ignore .ts files",
-    },
-  ],
-  invalid: [
-    {
-      code: `const component = () => <div>Hello</div>;`,
-      filename: "myComponent.jsx",
-      name: "should disallow camelCase .jsx files",
-      errors: [
-        {
-          messageId: "jsxPascalCase",
-          line: 1,
-          column: 1,
-        },
-      ],
-    },
-    {
-      code: `export default function() { return <div>Hello</div>; }`,
-      filename: "user-profile.tsx",
-      name: "should disallow kebab-case .tsx files",
-      errors: [
-        {
-          messageId: "jsxPascalCase",
-          line: 1,
-          column: 1,
-        },
-      ],
-    },
-    {
-      code: `const component = () => <div>Hello</div>;`,
-      filename: "my_component.jsx",
-      name: "should disallow snake_case .jsx files",
-      errors: [
-        {
-          messageId: "jsxPascalCase",
-          line: 1,
-          column: 1,
-        },
-      ],
-    },
-    {
-      code: `const app = () => <div>App</div>;`,
-      filename: "app.jsx",
-      name: "should disallow lowercase .jsx files",
-      errors: [
-        {
-          messageId: "jsxPascalCase",
-          line: 1,
-          column: 1,
-        },
-      ],
-    },
-    {
-      code: `const component = () => <div>Hello</div>;`,
-      filename: "MYCOMPONENT.tsx",
-      name: "should disallow UPPERCASE .tsx files",
-      errors: [
-        {
-          messageId: "jsxPascalCase",
-          line: 1,
-          column: 1,
-        },
-      ],
-    },
-    {
-      code: `const component = () => <div>Hello</div>;`,
-      filename: "My Component.jsx",
-      name: "should disallow files with spaces",
-      errors: [
-        {
-          messageId: "jsxPascalCase",
-          line: 1,
-          column: 1,
-        },
-      ],
-    },
-    {
-      code: `const component = () => <div>Hello</div>;`,
-      filename: "My.Component.tsx",
-      name: "should disallow files with dots in middle",
-      errors: [
-        {
-          messageId: "jsxPascalCase",
-          line: 1,
-          column: 1,
-        },
-      ],
-    },
-    {
-      code: `const component = () => <div>Hello</div>;`,
-      filename: "myComponent123Name.jsx",
-      name: "should disallow camelCase with numbers",
-      errors: [
-        {
-          messageId: "jsxPascalCase",
-          line: 1,
-          column: 1,
-        },
-      ],
-    },
-  ],
-});
+describe("jsx-pascal-case", () => {
+  it("should have meta property", () => {
+    expect(jsxPascalCase.meta).toBeDefined();
+  });
 
-describe("jsx-pascal-case rule structure", () => {
-  it("should have correct rule structure", () => {
-    expect(jsxPascalCase).toHaveProperty("meta");
-    expect(jsxPascalCase).toHaveProperty("create");
+  it("should have create method", () => {
     expect(typeof jsxPascalCase.create).toBe("function");
+  });
+
+  ruleTester.run("jsx-pascal-case", jsxPascalCase, {
+    valid: [
+      {
+        code: `const Component = () => <div>Hello</div>;`,
+        filename: "MyComponent.jsx",
+        name: "should allow PascalCase .jsx files",
+      },
+      {
+        code: `export default function Component() { return <div>Hello</div>; }`,
+        filename: "UserProfile.tsx",
+        name: "should allow PascalCase .tsx files",
+      },
+      {
+        code: `const App = () => <div>App</div>;`,
+        filename: "App.jsx",
+        name: "should allow single word PascalCase",
+      },
+      {
+        code: `export const Header = () => <header>Header</header>;`,
+        filename: "Header.tsx",
+        name: "should allow single word PascalCase tsx",
+      },
+      {
+        code: `const LoginForm = () => <form>Login</form>;`,
+        filename: "LoginFormComponent.jsx",
+        name: "should allow long PascalCase names",
+      },
+      {
+        code: `const UserProfile2 = () => <div>Profile</div>;`,
+        filename: "UserProfile2.tsx",
+        name: "should allow PascalCase with numbers",
+      },
+      {
+        code: `const style = {};`,
+        filename: "styles.css",
+        name: "should ignore non-.jsx/.tsx files",
+      },
+      {
+        code: `const html = "";`,
+        filename: "invalid-name.html",
+        name: "should ignore non-.jsx/.tsx files even with invalid names",
+      },
+      {
+        code: `const config = {};`,
+        filename: "invalid-name.js",
+        name: "should ignore .js files",
+      },
+      {
+        code: `const config = {};`,
+        filename: "invalid-name.ts",
+        name: "should ignore .ts files",
+      },
+    ],
+    invalid: [
+      {
+        code: `const component = () => <div>Hello</div>;`,
+        filename: "myComponent.jsx",
+        name: "should disallow camelCase .jsx files",
+        errors: [
+          {
+            messageId: "jsxPascalCase",
+            line: 1,
+            column: 1,
+          },
+        ],
+      },
+      {
+        code: `export default function() { return <div>Hello</div>; }`,
+        filename: "user-profile.tsx",
+        name: "should disallow kebab-case .tsx files",
+        errors: [
+          {
+            messageId: "jsxPascalCase",
+            line: 1,
+            column: 1,
+          },
+        ],
+      },
+      {
+        code: `const component = () => <div>Hello</div>;`,
+        filename: "my_component.jsx",
+        name: "should disallow snake_case .jsx files",
+        errors: [
+          {
+            messageId: "jsxPascalCase",
+            line: 1,
+            column: 1,
+          },
+        ],
+      },
+      {
+        code: `const app = () => <div>App</div>;`,
+        filename: "app.jsx",
+        name: "should disallow lowercase .jsx files",
+        errors: [
+          {
+            messageId: "jsxPascalCase",
+            line: 1,
+            column: 1,
+          },
+        ],
+      },
+      {
+        code: `const component = () => <div>Hello</div>;`,
+        filename: "MYCOMPONENT.tsx",
+        name: "should disallow UPPERCASE .tsx files",
+        errors: [
+          {
+            messageId: "jsxPascalCase",
+            line: 1,
+            column: 1,
+          },
+        ],
+      },
+      {
+        code: `const component = () => <div>Hello</div>;`,
+        filename: "My Component.jsx",
+        name: "should disallow files with spaces",
+        errors: [
+          {
+            messageId: "jsxPascalCase",
+            line: 1,
+            column: 1,
+          },
+        ],
+      },
+      {
+        code: `const component = () => <div>Hello</div>;`,
+        filename: "My.Component.tsx",
+        name: "should disallow files with dots in middle",
+        errors: [
+          {
+            messageId: "jsxPascalCase",
+            line: 1,
+            column: 1,
+          },
+        ],
+      },
+      {
+        code: `const component = () => <div>Hello</div>;`,
+        filename: "myComponent123Name.jsx",
+        name: "should disallow camelCase with numbers",
+        errors: [
+          {
+            messageId: "jsxPascalCase",
+            line: 1,
+            column: 1,
+          },
+        ],
+      },
+    ],
   });
 });

--- a/src/rules/__tests__/jsx-require-suspense.test.ts
+++ b/src/rules/__tests__/jsx-require-suspense.test.ts
@@ -1,12 +1,11 @@
 import { RuleTester } from "@typescript-eslint/rule-tester";
-import { afterAll, describe, it, expect } from "@jest/globals";
+import { afterAll, describe, it } from "@jest/globals";
 
 import jsxRequireSuspense from "../jsx-require-suspense";
 
 RuleTester.afterAll = afterAll;
-RuleTester.it = it;
-RuleTester.itOnly = it.only;
 RuleTester.describe = describe;
+RuleTester.it = it;
 
 const ruleTester = new RuleTester({
   languageOptions: {
@@ -18,28 +17,37 @@ const ruleTester = new RuleTester({
   },
 });
 
-ruleTester.run("jsx-require-suspense", jsxRequireSuspense, {
-  valid: [
-    {
-      code: `
+describe("jsx-require-suspense", () => {
+  it("should have meta property", () => {
+    expect(jsxRequireSuspense.meta).toBeDefined();
+  });
+
+  it("should have create method", () => {
+    expect(typeof jsxRequireSuspense.create).toBe("function");
+  });
+
+  ruleTester.run("jsx-require-suspense", jsxRequireSuspense, {
+    valid: [
+      {
+        code: `
         const LazyComponent = lazy(() => import("./Component"));
         <Suspense fallback={<Skeleton />}>
           <LazyComponent />
         </Suspense>
       `,
-      name: "should allow lazy component wrapped in Suspense",
-    },
-    {
-      code: `
+        name: "should allow lazy component wrapped in Suspense",
+      },
+      {
+        code: `
         const AsyncComponent = React.lazy(() => import("./Component"));
         <Suspense fallback={<Loading />}>
           <AsyncComponent />
         </Suspense>
       `,
-      name: "should allow React.lazy component wrapped in Suspense",
-    },
-    {
-      code: `
+        name: "should allow React.lazy component wrapped in Suspense",
+      },
+      {
+        code: `
         const LazyModal = lazy(() => import("./Modal"));
         <Suspense fallback={null}>
           <div>
@@ -47,23 +55,23 @@ ruleTester.run("jsx-require-suspense", jsxRequireSuspense, {
           </div>
         </Suspense>
       `,
-      name: "should allow lazy component nested inside Suspense",
-    },
-    {
-      code: `
+        name: "should allow lazy component nested inside Suspense",
+      },
+      {
+        code: `
         <RegularComponent />
       `,
-      name: "should allow regular components without Suspense",
-    },
-    {
-      code: `
+        name: "should allow regular components without Suspense",
+      },
+      {
+        code: `
         const Component = () => <div />;
         <Component />
       `,
-      name: "should allow non-lazy function components",
-    },
-    {
-      code: `
+        name: "should allow non-lazy function components",
+      },
+      {
+        code: `
         const LazyA = lazy(() => import("./A"));
         const LazyB = lazy(() => import("./B"));
         <Suspense fallback={<div />}>
@@ -71,59 +79,59 @@ ruleTester.run("jsx-require-suspense", jsxRequireSuspense, {
           <LazyB />
         </Suspense>
       `,
-      name: "should allow multiple lazy components in same Suspense",
-    },
-  ],
-  invalid: [
-    {
-      code: `
+        name: "should allow multiple lazy components in same Suspense",
+      },
+    ],
+    invalid: [
+      {
+        code: `
         const AsyncComponent = lazy(() => import("./Component"));
         <AsyncComponent />
       `,
-      name: "should disallow lazy component without Suspense",
-      errors: [
-        {
-          messageId: "requireSuspense",
-          data: {
-            name: "AsyncComponent",
+        name: "should disallow lazy component without Suspense",
+        errors: [
+          {
+            messageId: "requireSuspense",
+            data: {
+              name: "AsyncComponent",
+            },
           },
-        },
-      ],
-    },
-    {
-      code: `
+        ],
+      },
+      {
+        code: `
         const LazyModal = React.lazy(() => import("./Modal"));
         <LazyModal />
       `,
-      name: "should disallow React.lazy component without Suspense",
-      errors: [
-        {
-          messageId: "requireSuspense",
-          data: {
-            name: "LazyModal",
+        name: "should disallow React.lazy component without Suspense",
+        errors: [
+          {
+            messageId: "requireSuspense",
+            data: {
+              name: "LazyModal",
+            },
           },
-        },
-      ],
-    },
-    {
-      code: `
+        ],
+      },
+      {
+        code: `
         const LazyComponent = lazy(() => import("./Component"));
         <div>
           <LazyComponent />
         </div>
       `,
-      name: "should disallow lazy component nested in non-Suspense element",
-      errors: [
-        {
-          messageId: "requireSuspense",
-          data: {
-            name: "LazyComponent",
+        name: "should disallow lazy component nested in non-Suspense element",
+        errors: [
+          {
+            messageId: "requireSuspense",
+            data: {
+              name: "LazyComponent",
+            },
           },
-        },
-      ],
-    },
-    {
-      code: `
+        ],
+      },
+      {
+        code: `
         const LazyA = lazy(() => import("./A"));
         const LazyB = lazy(() => import("./B"));
         <div>
@@ -131,29 +139,22 @@ ruleTester.run("jsx-require-suspense", jsxRequireSuspense, {
           <LazyB />
         </div>
       `,
-      name: "should report multiple lazy components without Suspense",
-      errors: [
-        {
-          messageId: "requireSuspense",
-          data: {
-            name: "LazyA",
+        name: "should report multiple lazy components without Suspense",
+        errors: [
+          {
+            messageId: "requireSuspense",
+            data: {
+              name: "LazyA",
+            },
           },
-        },
-        {
-          messageId: "requireSuspense",
-          data: {
-            name: "LazyB",
+          {
+            messageId: "requireSuspense",
+            data: {
+              name: "LazyB",
+            },
           },
-        },
-      ],
-    },
-  ],
-});
-
-describe("jsx-require-suspense rule structure", () => {
-  it("should have correct rule structure", () => {
-    expect(jsxRequireSuspense).toHaveProperty("meta");
-    expect(jsxRequireSuspense).toHaveProperty("create");
-    expect(typeof jsxRequireSuspense.create).toBe("function");
+        ],
+      },
+    ],
   });
 });

--- a/src/rules/__tests__/jsx-simple-props.test.ts
+++ b/src/rules/__tests__/jsx-simple-props.test.ts
@@ -1,14 +1,13 @@
 import { RuleTester } from "@typescript-eslint/rule-tester";
-import { afterAll, describe, it, expect } from "@jest/globals";
+import { afterAll, describe, it } from "@jest/globals";
 
 import jsxSimpleProps from "../jsx-simple-props";
 
 const DOLLAR = "$";
 
 RuleTester.afterAll = afterAll;
-RuleTester.it = it;
-RuleTester.itOnly = it.only;
 RuleTester.describe = describe;
+RuleTester.it = it;
 
 const ruleTester = new RuleTester({
   languageOptions: {
@@ -20,142 +19,144 @@ const ruleTester = new RuleTester({
   },
 });
 
-ruleTester.run("jsx-simple-props", jsxSimpleProps, {
-  valid: [
-    {
-      code: `<Component name="test" />`,
-      name: "should allow string literal",
-    },
-    {
-      code: `<Component name={'test'} />`,
-      name: "should allow string in expression container",
-    },
-    {
-      code: `<Component value={foo} />`,
-      name: "should allow simple variable",
-    },
-    {
-      code: `<Component icon={<Icon />} />`,
-      name: "should allow JSX element",
-    },
-    {
-      code: `<Component icon={<><span>test</span></>} />`,
-      name: "should allow JSX fragment",
-    },
-    {
-      code: `<Component value={foo.bar} />`,
-      name: "should allow member expression",
-    },
-    {
-      code: `<Component value={foo.bar.baz} />`,
-      name: "should allow nested member expression",
-    },
-    {
-      code: `<Component disabled />`,
-      name: "should allow boolean shorthand",
-    },
-    {
-      code: `<Component count={42} />`,
-      name: "should allow number literal",
-    },
-    {
-      code: `<Component disabled={true} />`,
-      name: "should allow boolean literal",
-    },
-    {
-      code: `<Component value={null} />`,
-      name: "should allow null literal",
-    },
-    {
-      code: `<Component {...props} />`,
-      name: "should allow spread attributes",
-    },
-    {
-      code: `<Component value={undefined} />`,
-      name: "should allow undefined identifier",
-    },
-    {
-      code: `<Component callback={() => {}} />`,
-      name: "should allow arrow function",
-    },
-    {
-      code: `<Component callback={function() {}} />`,
-      name: "should allow function expression",
-    },
-  ],
-  invalid: [
-    {
-      code: `<Component onClick={handleClick()} />`,
-      name: "should disallow function call",
-      errors: [{ messageId: "noComplexProp" }],
-    },
-    {
-      code: `<Component data={bar(baz({ aaa, bbb, ccc }), eee)} />`,
-      name: "should disallow complex nested function call",
-      errors: [{ messageId: "noComplexProp" }],
-    },
-    {
-      code: `<Component style={{}} />`,
-      name: "should disallow empty inline object",
-      errors: [{ messageId: "noComplexProp" }],
-    },
-    {
-      code: `<Component style={{ color: "red" }} />`,
-      name: "should disallow inline object",
-      errors: [{ messageId: "noComplexProp" }],
-    },
-    {
-      code: `<Component items={[]} />`,
-      name: "should disallow empty inline array",
-      errors: [{ messageId: "noComplexProp" }],
-    },
-    {
-      code: `<Component items={[1, 2, 3]} />`,
-      name: "should disallow inline array",
-      errors: [{ messageId: "noComplexProp" }],
-    },
-    {
-      code: `<Component value={a + b} />`,
-      name: "should disallow binary expression",
-      errors: [{ messageId: "noComplexProp" }],
-    },
-    {
-      code: `<Component value={!flag} />`,
-      name: "should disallow unary expression",
-      errors: [{ messageId: "noComplexProp" }],
-    },
-    {
-      code: `<Component value={condition ? a : b} />`,
-      name: "should disallow ternary expression",
-      errors: [{ messageId: "noComplexProp" }],
-    },
-    {
-      code: `<Component value={a && b} />`,
-      name: "should disallow logical expression",
-      errors: [{ messageId: "noComplexProp" }],
-    },
-    {
-      code: `<Component value={\`template ${DOLLAR}{name}\`} />`,
-      name: "should disallow template literal with expressions",
-      errors: [{ messageId: "noComplexProp" }],
-    },
-    {
-      code: `<Component value={new Date()} />`,
-      name: "should disallow new expression",
-      errors: [{ messageId: "noComplexProp" }],
-    },
-    {
-      code: `<><Foo a={fn()} /><Bar b={{}} /></>`,
-      name: "should report multiple violations",
-      errors: [{ messageId: "noComplexProp" }, { messageId: "noComplexProp" }],
-    },
-  ],
-});
+describe("jsx-simple-props", () => {
+  it("should have meta property", () => {
+    expect(jsxSimpleProps.meta).toBeDefined();
+  });
 
-describe("jsx-simple-props rule structure", () => {
-  it("should have correct rule structure", () => {
-    expect(jsxSimpleProps).toHaveProperty("meta");
-    expect(jsxSimpleProps).toHaveProperty("create");
+  it("should have create method", () => {
     expect(typeof jsxSimpleProps.create).toBe("function");
+  });
+
+  ruleTester.run("jsx-simple-props", jsxSimpleProps, {
+    valid: [
+      {
+        code: `<Component name="test" />`,
+        name: "should allow string literal",
+      },
+      {
+        code: `<Component name={'test'} />`,
+        name: "should allow string in expression container",
+      },
+      {
+        code: `<Component value={foo} />`,
+        name: "should allow simple variable",
+      },
+      {
+        code: `<Component icon={<Icon />} />`,
+        name: "should allow JSX element",
+      },
+      {
+        code: `<Component icon={<><span>test</span></>} />`,
+        name: "should allow JSX fragment",
+      },
+      {
+        code: `<Component value={foo.bar} />`,
+        name: "should allow member expression",
+      },
+      {
+        code: `<Component value={foo.bar.baz} />`,
+        name: "should allow nested member expression",
+      },
+      {
+        code: `<Component disabled />`,
+        name: "should allow boolean shorthand",
+      },
+      {
+        code: `<Component count={42} />`,
+        name: "should allow number literal",
+      },
+      {
+        code: `<Component disabled={true} />`,
+        name: "should allow boolean literal",
+      },
+      {
+        code: `<Component value={null} />`,
+        name: "should allow null literal",
+      },
+      {
+        code: `<Component {...props} />`,
+        name: "should allow spread attributes",
+      },
+      {
+        code: `<Component value={undefined} />`,
+        name: "should allow undefined identifier",
+      },
+      {
+        code: `<Component callback={() => {}} />`,
+        name: "should allow arrow function",
+      },
+      {
+        code: `<Component callback={function() {}} />`,
+        name: "should allow function expression",
+      },
+    ],
+    invalid: [
+      {
+        code: `<Component onClick={handleClick()} />`,
+        name: "should disallow function call",
+        errors: [{ messageId: "noComplexProp" }],
+      },
+      {
+        code: `<Component data={bar(baz({ aaa, bbb, ccc }), eee)} />`,
+        name: "should disallow complex nested function call",
+        errors: [{ messageId: "noComplexProp" }],
+      },
+      {
+        code: `<Component style={{}} />`,
+        name: "should disallow empty inline object",
+        errors: [{ messageId: "noComplexProp" }],
+      },
+      {
+        code: `<Component style={{ color: "red" }} />`,
+        name: "should disallow inline object",
+        errors: [{ messageId: "noComplexProp" }],
+      },
+      {
+        code: `<Component items={[]} />`,
+        name: "should disallow empty inline array",
+        errors: [{ messageId: "noComplexProp" }],
+      },
+      {
+        code: `<Component items={[1, 2, 3]} />`,
+        name: "should disallow inline array",
+        errors: [{ messageId: "noComplexProp" }],
+      },
+      {
+        code: `<Component value={a + b} />`,
+        name: "should disallow binary expression",
+        errors: [{ messageId: "noComplexProp" }],
+      },
+      {
+        code: `<Component value={!flag} />`,
+        name: "should disallow unary expression",
+        errors: [{ messageId: "noComplexProp" }],
+      },
+      {
+        code: `<Component value={condition ? a : b} />`,
+        name: "should disallow ternary expression",
+        errors: [{ messageId: "noComplexProp" }],
+      },
+      {
+        code: `<Component value={a && b} />`,
+        name: "should disallow logical expression",
+        errors: [{ messageId: "noComplexProp" }],
+      },
+      {
+        code: `<Component value={\`template ${DOLLAR}{name}\`} />`,
+        name: "should disallow template literal with expressions",
+        errors: [{ messageId: "noComplexProp" }],
+      },
+      {
+        code: `<Component value={new Date()} />`,
+        name: "should disallow new expression",
+        errors: [{ messageId: "noComplexProp" }],
+      },
+      {
+        code: `<><Foo a={fn()} /><Bar b={{}} /></>`,
+        name: "should report multiple violations",
+        errors: [{ messageId: "noComplexProp" }, { messageId: "noComplexProp" }],
+      },
+    ],
   });
 });

--- a/src/rules/__tests__/jsx-sort-props.test.ts
+++ b/src/rules/__tests__/jsx-sort-props.test.ts
@@ -1,12 +1,11 @@
 import { RuleTester } from "@typescript-eslint/rule-tester";
-import { afterAll, describe, it, expect } from "@jest/globals";
+import { afterAll, describe, it } from "@jest/globals";
 
 import jsxSortProps from "../jsx-sort-props";
 
 RuleTester.afterAll = afterAll;
-RuleTester.it = it;
-RuleTester.itOnly = it.only;
 RuleTester.describe = describe;
+RuleTester.it = it;
 
 const ruleTester = new RuleTester({
   languageOptions: {
@@ -18,121 +17,123 @@ const ruleTester = new RuleTester({
   },
 });
 
-ruleTester.run("jsx-sort-props", jsxSortProps, {
-  valid: [
-    {
-      code: `<Component title="hello" count={100} style={{ color: "red" }} onClick={() => {}} icon={<Icon />} disabled />`,
-      name: "should allow correctly ordered props (all 6 groups)",
-    },
-    {
-      code: `<Component title="hello" />`,
-      name: "should allow single prop",
-    },
-    {
-      code: `<Component title="hello" name="world" />`,
-      name: "should allow multiple props of the same type",
-    },
-    {
-      code: `<Component count={42} enabled={true} value={null} />`,
-      name: "should allow multiple number/boolean/null props",
-    },
-    {
-      code: `<Component title="hello" value={someVar} count={42} />`,
-      name: "should allow unknown types mixed in without affecting order",
-    },
-    {
-      code: `<Component onClick={() => {}} disabled {...props} title="hello" />`,
-      name: "should reset ordering after spread attribute",
-    },
-    {
-      code: `<Component {...props} />`,
-      name: "should allow spread-only element",
-    },
-    {
-      code: `<Component title="hello" name={\`template\`} />`,
-      name: "should treat template literals as strings",
-    },
-    {
-      code: `<Component value={undefined} />`,
-      name: "should allow undefined as number/boolean/null group",
-    },
-    {
-      code: `<Component items={[1, 2]} data={{ key: "val" }} />`,
-      name: "should allow array before object in same group",
-    },
-    {
-      code: `<Component onClick={() => {}} onChange={function() {}} />`,
-      name: "should allow multiple functions in same group",
-    },
-    {
-      code: `<Component icon={<Icon />} extra={<><span /></>} />`,
-      name: "should allow JSX element and fragment in same group",
-    },
-    {
-      code: `<Component value={someVar} handler={someHandler} />`,
-      name: "should allow all-unknown props (identifiers)",
-    },
-    {
-      code: `<Component title="hello" value={someVar} disabled />`,
-      name: "should skip unknown and check remaining order",
-    },
-    {
-      code: `<Component disabled {...overrides} title="hello" count={42} />`,
-      name: "should allow shorthand before spread then string after spread",
-    },
-    {
-      code: `<Component title="hello" count={42} items={[1]} onClick={() => {}} icon={<A />} active />`,
-      name: "should allow all six groups in order",
-    },
-  ],
-  invalid: [
-    {
-      code: `<Component disabled title="hello" />`,
-      name: "should disallow shorthand before string",
-      errors: [{ messageId: "unsortedProps" }],
-    },
-    {
-      code: `<Component onClick={() => {}} count={42} />`,
-      name: "should disallow function before number",
-      errors: [{ messageId: "unsortedProps" }],
-    },
-    {
-      code: `<Component icon={<Icon />} style={{ color: "red" }} />`,
-      name: "should disallow JSX before object",
-      errors: [{ messageId: "unsortedProps" }],
-    },
-    {
-      code: `<Component disabled title="hello" count={42} />`,
-      name: "should disallow shorthand before string and number",
-      errors: [{ messageId: "unsortedProps" }],
-    },
-    {
-      code: `<Component onClick={() => {}} title="hello" />`,
-      name: "should disallow function before string",
-      errors: [{ messageId: "unsortedProps" }],
-    },
-    {
-      code: `<Component title="hello" {...props} disabled name="world" />`,
-      name: "should report error after spread when order is wrong",
-      errors: [{ messageId: "unsortedProps" }],
-    },
-    {
-      code: `<Component active onClick={() => {}} />`,
-      name: "should disallow shorthand before function",
-      errors: [{ messageId: "unsortedProps" }],
-    },
-    {
-      code: `<Component items={[1, 2]} count={42} />`,
-      name: "should disallow array before number",
-      errors: [{ messageId: "unsortedProps" }],
-    },
-  ],
-});
+describe("jsx-sort-props", () => {
+  it("should have meta property", () => {
+    expect(jsxSortProps.meta).toBeDefined();
+  });
 
-describe("jsx-sort-props rule structure", () => {
-  it("should have correct rule structure", () => {
-    expect(jsxSortProps).toHaveProperty("meta");
-    expect(jsxSortProps).toHaveProperty("create");
+  it("should have create method", () => {
     expect(typeof jsxSortProps.create).toBe("function");
+  });
+
+  ruleTester.run("jsx-sort-props", jsxSortProps, {
+    valid: [
+      {
+        code: `<Component title="hello" count={100} style={{ color: "red" }} onClick={() => {}} icon={<Icon />} disabled />`,
+        name: "should allow correctly ordered props (all 6 groups)",
+      },
+      {
+        code: `<Component title="hello" />`,
+        name: "should allow single prop",
+      },
+      {
+        code: `<Component title="hello" name="world" />`,
+        name: "should allow multiple props of the same type",
+      },
+      {
+        code: `<Component count={42} enabled={true} value={null} />`,
+        name: "should allow multiple number/boolean/null props",
+      },
+      {
+        code: `<Component title="hello" value={someVar} count={42} />`,
+        name: "should allow unknown types mixed in without affecting order",
+      },
+      {
+        code: `<Component onClick={() => {}} disabled {...props} title="hello" />`,
+        name: "should reset ordering after spread attribute",
+      },
+      {
+        code: `<Component {...props} />`,
+        name: "should allow spread-only element",
+      },
+      {
+        code: `<Component title="hello" name={\`template\`} />`,
+        name: "should treat template literals as strings",
+      },
+      {
+        code: `<Component value={undefined} />`,
+        name: "should allow undefined as number/boolean/null group",
+      },
+      {
+        code: `<Component items={[1, 2]} data={{ key: "val" }} />`,
+        name: "should allow array before object in same group",
+      },
+      {
+        code: `<Component onClick={() => {}} onChange={function() {}} />`,
+        name: "should allow multiple functions in same group",
+      },
+      {
+        code: `<Component icon={<Icon />} extra={<><span /></>} />`,
+        name: "should allow JSX element and fragment in same group",
+      },
+      {
+        code: `<Component value={someVar} handler={someHandler} />`,
+        name: "should allow all-unknown props (identifiers)",
+      },
+      {
+        code: `<Component title="hello" value={someVar} disabled />`,
+        name: "should skip unknown and check remaining order",
+      },
+      {
+        code: `<Component disabled {...overrides} title="hello" count={42} />`,
+        name: "should allow shorthand before spread then string after spread",
+      },
+      {
+        code: `<Component title="hello" count={42} items={[1]} onClick={() => {}} icon={<A />} active />`,
+        name: "should allow all six groups in order",
+      },
+    ],
+    invalid: [
+      {
+        code: `<Component disabled title="hello" />`,
+        name: "should disallow shorthand before string",
+        errors: [{ messageId: "unsortedProps" }],
+      },
+      {
+        code: `<Component onClick={() => {}} count={42} />`,
+        name: "should disallow function before number",
+        errors: [{ messageId: "unsortedProps" }],
+      },
+      {
+        code: `<Component icon={<Icon />} style={{ color: "red" }} />`,
+        name: "should disallow JSX before object",
+        errors: [{ messageId: "unsortedProps" }],
+      },
+      {
+        code: `<Component disabled title="hello" count={42} />`,
+        name: "should disallow shorthand before string and number",
+        errors: [{ messageId: "unsortedProps" }],
+      },
+      {
+        code: `<Component onClick={() => {}} title="hello" />`,
+        name: "should disallow function before string",
+        errors: [{ messageId: "unsortedProps" }],
+      },
+      {
+        code: `<Component title="hello" {...props} disabled name="world" />`,
+        name: "should report error after spread when order is wrong",
+        errors: [{ messageId: "unsortedProps" }],
+      },
+      {
+        code: `<Component active onClick={() => {}} />`,
+        name: "should disallow shorthand before function",
+        errors: [{ messageId: "unsortedProps" }],
+      },
+      {
+        code: `<Component items={[1, 2]} count={42} />`,
+        name: "should disallow array before number",
+        errors: [{ messageId: "unsortedProps" }],
+      },
+    ],
   });
 });

--- a/src/rules/__tests__/md-filename-case-restriction.test.ts
+++ b/src/rules/__tests__/md-filename-case-restriction.test.ts
@@ -4,103 +4,104 @@ import { afterAll, describe, it } from "@jest/globals";
 import mdFilenameCaseRestriction from "../md-filename-case-restriction";
 
 RuleTester.afterAll = afterAll;
-RuleTester.it = it;
-RuleTester.itOnly = it.only;
 RuleTester.describe = describe;
+RuleTester.it = it;
 
 const ruleTester = new RuleTester();
 
-ruleTester.run("md-filename-case-restriction", mdFilenameCaseRestriction, {
-  valid: [
-    {
-      name: "SNAKE_CASE filename",
-      code: "const test = 'hello';",
-      filename: "README.md",
-    },
-    {
-      name: "SNAKE_CASE filename with underscores",
-      code: "const test = 'hello';",
-      filename: "CHANGELOG.md",
-    },
-    {
-      name: "Non-markdown file should be ignored",
-      code: "const test = 'hello';",
-      filename: "test-file.js",
-    },
-    {
-      name: "SNAKE_CASE with numbers",
-      code: "const test = 'hello';",
-      filename: "GUIDE_2024.md",
-    },
-    {
-      name: "SNAKE_CASE with underscores",
-      code: "const test = 'hello';",
-      filename: "LICENSE_MIT.md",
-    },
-  ],
-  invalid: [
-    {
-      name: "kebab-case filename should fail",
-      code: "const test = 'hello';",
-      filename: "test-file.md",
-      errors: [
-        {
-          messageId: "invalidFilenameCase",
-          data: { filename: "test-file" },
-        },
-      ],
-    },
-    {
-      name: "PascalCase filename should fail",
-      code: "const test = 'hello';",
-      filename: "TestFile.md",
-      errors: [
-        {
-          messageId: "invalidFilenameCase",
-          data: { filename: "TestFile" },
-        },
-      ],
-    },
-    {
-      name: "camelCase filename should fail",
-      code: "const test = 'hello';",
-      filename: "testFile.md",
-      errors: [
-        {
-          messageId: "invalidFilenameCase",
-          data: { filename: "testFile" },
-        },
-      ],
-    },
-    {
-      name: "lowercase filename should fail",
-      code: "const test = 'hello';",
-      filename: "readme.md",
-      errors: [
-        {
-          messageId: "invalidFilenameCase",
-          data: { filename: "readme" },
-        },
-      ],
-    },
-    {
-      name: "mixed case should fail",
-      code: "const test = 'hello';",
-      filename: "MyFile.md",
-      errors: [
-        {
-          messageId: "invalidFilenameCase",
-          data: { filename: "MyFile" },
-        },
-      ],
-    },
-  ],
-});
+describe("md-filename-case-restriction", () => {
+  it("should have meta property", () => {
+    expect(mdFilenameCaseRestriction.meta).toBeDefined();
+  });
 
-describe("md-filename-case-restriction rule structure", () => {
-  it("should have correct rule structure", () => {
-    expect(mdFilenameCaseRestriction).toHaveProperty("meta");
-    expect(mdFilenameCaseRestriction).toHaveProperty("create");
+  it("should have create method", () => {
     expect(typeof mdFilenameCaseRestriction.create).toBe("function");
+  });
+
+  ruleTester.run("md-filename-case-restriction", mdFilenameCaseRestriction, {
+    valid: [
+      {
+        name: "SNAKE_CASE filename",
+        code: "const test = 'hello';",
+        filename: "README.md",
+      },
+      {
+        name: "SNAKE_CASE filename with underscores",
+        code: "const test = 'hello';",
+        filename: "CHANGELOG.md",
+      },
+      {
+        name: "Non-markdown file should be ignored",
+        code: "const test = 'hello';",
+        filename: "test-file.js",
+      },
+      {
+        name: "SNAKE_CASE with numbers",
+        code: "const test = 'hello';",
+        filename: "GUIDE_2024.md",
+      },
+      {
+        name: "SNAKE_CASE with underscores",
+        code: "const test = 'hello';",
+        filename: "LICENSE_MIT.md",
+      },
+    ],
+    invalid: [
+      {
+        name: "kebab-case filename should fail",
+        code: "const test = 'hello';",
+        filename: "test-file.md",
+        errors: [
+          {
+            messageId: "invalidFilenameCase",
+            data: { filename: "test-file" },
+          },
+        ],
+      },
+      {
+        name: "PascalCase filename should fail",
+        code: "const test = 'hello';",
+        filename: "TestFile.md",
+        errors: [
+          {
+            messageId: "invalidFilenameCase",
+            data: { filename: "TestFile" },
+          },
+        ],
+      },
+      {
+        name: "camelCase filename should fail",
+        code: "const test = 'hello';",
+        filename: "testFile.md",
+        errors: [
+          {
+            messageId: "invalidFilenameCase",
+            data: { filename: "testFile" },
+          },
+        ],
+      },
+      {
+        name: "lowercase filename should fail",
+        code: "const test = 'hello';",
+        filename: "readme.md",
+        errors: [
+          {
+            messageId: "invalidFilenameCase",
+            data: { filename: "readme" },
+          },
+        ],
+      },
+      {
+        name: "mixed case should fail",
+        code: "const test = 'hello';",
+        filename: "MyFile.md",
+        errors: [
+          {
+            messageId: "invalidFilenameCase",
+            data: { filename: "MyFile" },
+          },
+        ],
+      },
+    ],
   });
 });

--- a/src/rules/__tests__/newline-after-multiline-block.test.ts
+++ b/src/rules/__tests__/newline-after-multiline-block.test.ts
@@ -4,22 +4,18 @@ import { afterAll, describe, it } from "@jest/globals";
 import newlineAfterMultilineBlock from "../newline-after-multiline-block";
 
 RuleTester.afterAll = afterAll;
-RuleTester.it = it;
-RuleTester.itOnly = it.only;
 RuleTester.describe = describe;
+RuleTester.it = it;
 
-const ruleTester = new RuleTester({
-  languageOptions: {
-    parserOptions: {
-      ecmaVersion: 2020,
-      sourceType: "module",
-    },
-  },
-});
+const ruleTester = new RuleTester();
 
 describe("newline-after-multiline-block", () => {
-  it("should be defined", () => {
-    expect(newlineAfterMultilineBlock).toBeDefined();
+  it("should have meta property", () => {
+    expect(newlineAfterMultilineBlock.meta).toBeDefined();
+  });
+
+  it("should have create method", () => {
+    expect(typeof newlineAfterMultilineBlock.create).toBe("function");
   });
 
   ruleTester.run("newline-after-multiline-block", newlineAfterMultilineBlock, {

--- a/src/rules/__tests__/newline-before-return.test.ts
+++ b/src/rules/__tests__/newline-before-return.test.ts
@@ -4,22 +4,18 @@ import { afterAll, describe, it } from "@jest/globals";
 import newlineBeforeReturn from "../newline-before-return";
 
 RuleTester.afterAll = afterAll;
-RuleTester.it = it;
-RuleTester.itOnly = it.only;
 RuleTester.describe = describe;
+RuleTester.it = it;
 
-const ruleTester = new RuleTester({
-  languageOptions: {
-    parserOptions: {
-      ecmaVersion: 2020,
-      sourceType: "module",
-    },
-  },
-});
+const ruleTester = new RuleTester();
 
 describe("newline-before-return", () => {
-  it("should be defined", () => {
-    expect(newlineBeforeReturn).toBeDefined();
+  it("should have meta property", () => {
+    expect(newlineBeforeReturn.meta).toBeDefined();
+  });
+
+  it("should have create method", () => {
+    expect(typeof newlineBeforeReturn.create).toBe("function");
   });
 
   ruleTester.run("newline-before-return", newlineBeforeReturn, {

--- a/src/rules/__tests__/nextjs-require-public-env.test.ts
+++ b/src/rules/__tests__/nextjs-require-public-env.test.ts
@@ -1,135 +1,136 @@
 import { RuleTester } from "@typescript-eslint/rule-tester";
-import { afterAll, describe, it, expect } from "@jest/globals";
+import { afterAll, describe, it } from "@jest/globals";
 
 import nextjsRequirePublicEnv from "../nextjs-require-public-env";
 
 RuleTester.afterAll = afterAll;
-RuleTester.it = it;
-RuleTester.itOnly = it.only;
 RuleTester.describe = describe;
+RuleTester.it = it;
 
 const ruleTester = new RuleTester();
 
-ruleTester.run("nextjs-require-public-env", nextjsRequirePublicEnv, {
-  valid: [
-    {
-      code: `
+describe("nextjs-require-public-env", () => {
+  it("should have meta property", () => {
+    expect(nextjsRequirePublicEnv.meta).toBeDefined();
+  });
+
+  it("should have create method", () => {
+    expect(typeof nextjsRequirePublicEnv.create).toBe("function");
+  });
+
+  ruleTester.run("nextjs-require-public-env", nextjsRequirePublicEnv, {
+    valid: [
+      {
+        code: `
         "use client";
         const url = process.env.NEXT_PUBLIC_API_URL;
       `,
-      name: "should allow NEXT_PUBLIC_ prefixed env in client component",
-    },
-    {
-      code: `
+        name: "should allow NEXT_PUBLIC_ prefixed env in client component",
+      },
+      {
+        code: `
         "use client";
         const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;
         const apiKey = process.env.NEXT_PUBLIC_API_KEY;
       `,
-      name: "should allow multiple NEXT_PUBLIC_ env vars",
-    },
-    {
-      code: `
+        name: "should allow multiple NEXT_PUBLIC_ env vars",
+      },
+      {
+        code: `
         "use client";
         const nodeEnv = process.env.NODE_ENV;
       `,
-      name: "should allow NODE_ENV in client components",
-    },
-    {
-      code: `
+        name: "should allow NODE_ENV in client components",
+      },
+      {
+        code: `
         const url = process.env.API_URL;
       `,
-      name: "should allow non-public env in server components",
-    },
-    {
-      code: `
+        name: "should allow non-public env in server components",
+      },
+      {
+        code: `
         const secret = process.env.DATABASE_SECRET;
         const key = process.env.PRIVATE_KEY;
       `,
-      name: "should allow any env var without 'use client'",
-    },
-    {
-      code: `
+        name: "should allow any env var without 'use client'",
+      },
+      {
+        code: `
         "use client";
         const config = { url: process.env.NEXT_PUBLIC_URL };
       `,
-      name: "should allow NEXT_PUBLIC_ in object property",
-    },
-  ],
-  invalid: [
-    {
-      code: `
+        name: "should allow NEXT_PUBLIC_ in object property",
+      },
+    ],
+    invalid: [
+      {
+        code: `
         "use client";
         const url = process.env.API_URL;
       `,
-      name: "should disallow non-public env in client component",
-      errors: [
-        {
-          messageId: "requirePublicPrefix",
-          data: {
-            name: "API_URL",
+        name: "should disallow non-public env in client component",
+        errors: [
+          {
+            messageId: "requirePublicPrefix",
+            data: {
+              name: "API_URL",
+            },
           },
-        },
-      ],
-    },
-    {
-      code: `
+        ],
+      },
+      {
+        code: `
         "use client";
         const secret = process.env.DATABASE_SECRET;
       `,
-      name: "should disallow secret env in client component",
-      errors: [
-        {
-          messageId: "requirePublicPrefix",
-          data: {
-            name: "DATABASE_SECRET",
+        name: "should disallow secret env in client component",
+        errors: [
+          {
+            messageId: "requirePublicPrefix",
+            data: {
+              name: "DATABASE_SECRET",
+            },
           },
-        },
-      ],
-    },
-    {
-      code: `
+        ],
+      },
+      {
+        code: `
         "use client";
         const key = process.env.PRIVATE_API_KEY;
       `,
-      name: "should disallow private key env in client component",
-      errors: [
-        {
-          messageId: "requirePublicPrefix",
-          data: {
-            name: "PRIVATE_API_KEY",
+        name: "should disallow private key env in client component",
+        errors: [
+          {
+            messageId: "requirePublicPrefix",
+            data: {
+              name: "PRIVATE_API_KEY",
+            },
           },
-        },
-      ],
-    },
-    {
-      code: `
+        ],
+      },
+      {
+        code: `
         "use client";
         const url = process.env.API_URL;
         const key = process.env.SECRET_KEY;
       `,
-      name: "should report multiple non-public env vars",
-      errors: [
-        {
-          messageId: "requirePublicPrefix",
-          data: {
-            name: "API_URL",
+        name: "should report multiple non-public env vars",
+        errors: [
+          {
+            messageId: "requirePublicPrefix",
+            data: {
+              name: "API_URL",
+            },
           },
-        },
-        {
-          messageId: "requirePublicPrefix",
-          data: {
-            name: "SECRET_KEY",
+          {
+            messageId: "requirePublicPrefix",
+            data: {
+              name: "SECRET_KEY",
+            },
           },
-        },
-      ],
-    },
-  ],
-});
-
-describe("nextjs-require-public-env rule structure", () => {
-  it("should have correct rule structure", () => {
-    expect(nextjsRequirePublicEnv).toHaveProperty("meta");
-    expect(nextjsRequirePublicEnv).toHaveProperty("create");
-    expect(typeof nextjsRequirePublicEnv.create).toBe("function");
+        ],
+      },
+    ],
   });
 });

--- a/src/rules/__tests__/no-complex-inline-return.test.ts
+++ b/src/rules/__tests__/no-complex-inline-return.test.ts
@@ -1,27 +1,21 @@
 import { RuleTester } from "@typescript-eslint/rule-tester";
 import { afterAll, describe, it } from "@jest/globals";
-import parser from "@typescript-eslint/parser";
 
 import noComplexInlineReturn from "../no-complex-inline-return";
 
 RuleTester.afterAll = afterAll;
-RuleTester.it = it;
-RuleTester.itOnly = it.only;
 RuleTester.describe = describe;
+RuleTester.it = it;
 
-const ruleTester = new RuleTester({
-  languageOptions: {
-    parser,
-    parserOptions: {
-      ecmaVersion: 2020,
-      sourceType: "module",
-    },
-  },
-});
+const ruleTester = new RuleTester();
 
 describe("no-complex-inline-return", () => {
-  it("should be defined", () => {
-    expect(noComplexInlineReturn).toBeDefined();
+  it("should have meta property", () => {
+    expect(noComplexInlineReturn.meta).toBeDefined();
+  });
+
+  it("should have create method", () => {
+    expect(typeof noComplexInlineReturn.create).toBe("function");
   });
 
   ruleTester.run("no-complex-inline-return", noComplexInlineReturn, {

--- a/src/rules/__tests__/no-direct-date.test.ts
+++ b/src/rules/__tests__/no-direct-date.test.ts
@@ -1,27 +1,21 @@
 import { RuleTester } from "@typescript-eslint/rule-tester";
-import { afterAll, describe, it, expect } from "@jest/globals";
-import parser from "@typescript-eslint/parser";
+import { afterAll, describe, it } from "@jest/globals";
 
 import noDirectDate from "../no-direct-date";
 
 RuleTester.afterAll = afterAll;
-RuleTester.it = it;
-RuleTester.itOnly = it.only;
 RuleTester.describe = describe;
+RuleTester.it = it;
 
-const ruleTester = new RuleTester({
-  languageOptions: {
-    parser,
-    parserOptions: {
-      ecmaVersion: 2020,
-      sourceType: "module",
-    },
-  },
-});
+const ruleTester = new RuleTester();
 
 describe("no-direct-date", () => {
-  it("should be defined", () => {
-    expect(noDirectDate).toBeDefined();
+  it("should have meta property", () => {
+    expect(noDirectDate.meta).toBeDefined();
+  });
+
+  it("should have create method", () => {
+    expect(typeof noDirectDate.create).toBe("function");
   });
 
   ruleTester.run("no-direct-date", noDirectDate, {

--- a/src/rules/__tests__/no-emoji.test.ts
+++ b/src/rules/__tests__/no-emoji.test.ts
@@ -4,118 +4,119 @@ import { afterAll, describe, it } from "@jest/globals";
 import noEmoji from "../no-emoji";
 
 RuleTester.afterAll = afterAll;
-RuleTester.it = it;
-RuleTester.itOnly = it.only;
 RuleTester.describe = describe;
+RuleTester.it = it;
 
 const ruleTester = new RuleTester();
 
-ruleTester.run("no-emoji", noEmoji, {
-  valid: [
-    {
-      code: `const message = "Hello World";`,
-      name: "should allow regular text without emoji",
-    },
-    {
-      code: `console.log("Testing functionality");`,
-      name: "should allow console logs without emoji",
-    },
-    {
-      code: `function test() { return "success"; }`,
-      name: "should allow functions without emoji",
-    },
-    {
-      code: `// This is a comment without emoji`,
-      name: "should allow comments without emoji",
-    },
-    {
-      code: `const obj = { key: "value" };`,
-      name: "should allow objects without emoji",
-    },
-  ],
-  invalid: [
-    {
-      code: `const message = "Hello 😀 World";`,
-      name: "should disallow string with grinning face emoji",
-      errors: [
-        {
-          messageId: "noEmoji",
-          line: 1,
-          column: 24,
-        },
-      ],
-    },
-    {
-      code: `console.log("Testing 🚀 functionality");`,
-      name: "should disallow console log with rocket emoji",
-      errors: [
-        {
-          messageId: "noEmoji",
-          line: 1,
-          column: 22,
-        },
-      ],
-    },
-    {
-      code: `// This is a comment with 💯 emoji`,
-      name: "should disallow comments with emoji",
-      errors: [
-        {
-          messageId: "noEmoji",
-          line: 1,
-          column: 27,
-        },
-      ],
-    },
-    {
-      code: `const obj = { key: "🔑 value" };`,
-      name: "should disallow object values with emoji",
-      errors: [
-        {
-          messageId: "noEmoji",
-          line: 1,
-          column: 21,
-        },
-      ],
-    },
-    {
-      code: `const multiline = \`
+describe("no-emoji", () => {
+  it("should have meta property", () => {
+    expect(noEmoji.meta).toBeDefined();
+  });
+
+  it("should have create method", () => {
+    expect(typeof noEmoji.create).toBe("function");
+  });
+
+  ruleTester.run("no-emoji", noEmoji, {
+    valid: [
+      {
+        code: `const message = "Hello World";`,
+        name: "should allow regular text without emoji",
+      },
+      {
+        code: `console.log("Testing functionality");`,
+        name: "should allow console logs without emoji",
+      },
+      {
+        code: `function test() { return "success"; }`,
+        name: "should allow functions without emoji",
+      },
+      {
+        code: `// This is a comment without emoji`,
+        name: "should allow comments without emoji",
+      },
+      {
+        code: `const obj = { key: "value" };`,
+        name: "should allow objects without emoji",
+      },
+    ],
+    invalid: [
+      {
+        code: `const message = "Hello 😀 World";`,
+        name: "should disallow string with grinning face emoji",
+        errors: [
+          {
+            messageId: "noEmoji",
+            line: 1,
+            column: 24,
+          },
+        ],
+      },
+      {
+        code: `console.log("Testing 🚀 functionality");`,
+        name: "should disallow console log with rocket emoji",
+        errors: [
+          {
+            messageId: "noEmoji",
+            line: 1,
+            column: 22,
+          },
+        ],
+      },
+      {
+        code: `// This is a comment with 💯 emoji`,
+        name: "should disallow comments with emoji",
+        errors: [
+          {
+            messageId: "noEmoji",
+            line: 1,
+            column: 27,
+          },
+        ],
+      },
+      {
+        code: `const obj = { key: "🔑 value" };`,
+        name: "should disallow object values with emoji",
+        errors: [
+          {
+            messageId: "noEmoji",
+            line: 1,
+            column: 21,
+          },
+        ],
+      },
+      {
+        code: `const multiline = \`
         Line 1 without emoji
         Line 2 with 🎉 emoji
         Line 3 without emoji
       \`;`,
-      name: "should disallow multiline strings with emoji",
-      errors: [
-        {
-          messageId: "noEmoji",
-          line: 3,
-          column: 21,
-        },
-      ],
-    },
-    {
-      code: `const multiple = "First 🚀 Second 🎯 Third";`,
-      name: "should detect multiple emojis in single string",
-      errors: [
-        {
-          messageId: "noEmoji",
-          line: 1,
-          column: 25,
-        },
-        {
-          messageId: "noEmoji",
-          line: 1,
-          column: 35,
-        },
-      ],
-    },
-  ],
-});
-
-describe("no-emoji rule structure", () => {
-  it("should have correct rule structure", () => {
-    expect(noEmoji).toHaveProperty("meta");
-    expect(noEmoji).toHaveProperty("create");
-    expect(typeof noEmoji.create).toBe("function");
+        name: "should disallow multiline strings with emoji",
+        errors: [
+          {
+            messageId: "noEmoji",
+            line: 3,
+            column: 21,
+          },
+        ],
+      },
+      {
+        code: `const multiple = "First 🚀 Second 🎯 Third";`,
+        name: "should detect multiple emojis in single string",
+        errors: [
+          {
+            messageId: "noEmoji",
+            line: 1,
+            column: 25,
+          },
+          {
+            messageId: "noEmoji",
+            line: 1,
+            column: 35,
+          },
+        ],
+      },
+    ],
   });
 });

--- a/src/rules/__tests__/no-env-fallback.test.ts
+++ b/src/rules/__tests__/no-env-fallback.test.ts
@@ -4,147 +4,148 @@ import { afterAll, describe, it } from "@jest/globals";
 import noEnvFallback from "../no-env-fallback";
 
 RuleTester.afterAll = afterAll;
-RuleTester.it = it;
-RuleTester.itOnly = it.only;
 RuleTester.describe = describe;
+RuleTester.it = it;
 
 const ruleTester = new RuleTester();
 
-ruleTester.run("no-env-fallback", noEnvFallback, {
-  valid: [
-    {
-      code: `const apiKey = process.env.API_KEY;`,
-      name: "should allow environment variable without fallback",
-    },
-    {
-      code: `const port = process.env.PORT;`,
-      name: "should allow direct environment variable access",
-    },
-    {
-      code: `if (process.env.NODE_ENV) { console.log("dev mode"); }`,
-      name: "should allow environment variable in conditional",
-    },
-    {
-      code: `const config = { apiKey: process.env.API_KEY };`,
-      name: "should allow environment variable in object",
-    },
-    {
-      code: `const fallback = "default" || "value";`,
-      name: "should allow logical OR without process.env",
-    },
-    {
-      code: `const value = someVariable ?? "default";`,
-      name: "should allow nullish coalescing without process.env",
-    },
-    {
-      code: `const result = someCondition ? "yes" : "no";`,
-      name: "should allow ternary without process.env",
-    },
-    {
-      code: `const envObj = process.env;`,
-      name: "should allow accessing process.env directly",
-    },
-  ],
-  invalid: [
-    {
-      code: `const apiKey = process.env.API_KEY || "default-key";`,
-      name: "should disallow logical OR operator with process.env",
-      errors: [
-        {
-          messageId: "noEnvFallback",
-          line: 1,
-          column: 16,
-        },
-      ],
-    },
-    {
-      code: `const dbUrl = process.env.DATABASE_URL ?? "localhost";`,
-      name: "should disallow nullish coalescing operator with process.env",
-      errors: [
-        {
-          messageId: "noEnvFallback",
-          line: 1,
-          column: 15,
-        },
-      ],
-    },
-    {
-      code: `const port = process.env.PORT ? "8080" : "3000";`,
-      name: "should disallow ternary operator with process.env",
-      errors: [
-        {
-          messageId: "noEnvFallback",
-          line: 1,
-          column: 14,
-        },
-      ],
-    },
-    {
-      code: `const token = process.env.AUTH_TOKEN || "abc123";`,
-      name: "should disallow string literal fallback with OR",
-      errors: [
-        {
-          messageId: "noEnvFallback",
-          line: 1,
-          column: 15,
-        },
-      ],
-    },
-    {
-      code: `const config = {
+describe("no-env-fallback", () => {
+  it("should have meta property", () => {
+    expect(noEnvFallback.meta).toBeDefined();
+  });
+
+  it("should have create method", () => {
+    expect(typeof noEnvFallback.create).toBe("function");
+  });
+
+  ruleTester.run("no-env-fallback", noEnvFallback, {
+    valid: [
+      {
+        code: `const apiKey = process.env.API_KEY;`,
+        name: "should allow environment variable without fallback",
+      },
+      {
+        code: `const port = process.env.PORT;`,
+        name: "should allow direct environment variable access",
+      },
+      {
+        code: `if (process.env.NODE_ENV) { console.log("dev mode"); }`,
+        name: "should allow environment variable in conditional",
+      },
+      {
+        code: `const config = { apiKey: process.env.API_KEY };`,
+        name: "should allow environment variable in object",
+      },
+      {
+        code: `const fallback = "default" || "value";`,
+        name: "should allow logical OR without process.env",
+      },
+      {
+        code: `const value = someVariable ?? "default";`,
+        name: "should allow nullish coalescing without process.env",
+      },
+      {
+        code: `const result = someCondition ? "yes" : "no";`,
+        name: "should allow ternary without process.env",
+      },
+      {
+        code: `const envObj = process.env;`,
+        name: "should allow accessing process.env directly",
+      },
+    ],
+    invalid: [
+      {
+        code: `const apiKey = process.env.API_KEY || "default-key";`,
+        name: "should disallow logical OR operator with process.env",
+        errors: [
+          {
+            messageId: "noEnvFallback",
+            line: 1,
+            column: 16,
+          },
+        ],
+      },
+      {
+        code: `const dbUrl = process.env.DATABASE_URL ?? "localhost";`,
+        name: "should disallow nullish coalescing operator with process.env",
+        errors: [
+          {
+            messageId: "noEnvFallback",
+            line: 1,
+            column: 15,
+          },
+        ],
+      },
+      {
+        code: `const port = process.env.PORT ? "8080" : "3000";`,
+        name: "should disallow ternary operator with process.env",
+        errors: [
+          {
+            messageId: "noEnvFallback",
+            line: 1,
+            column: 14,
+          },
+        ],
+      },
+      {
+        code: `const token = process.env.AUTH_TOKEN || "abc123";`,
+        name: "should disallow string literal fallback with OR",
+        errors: [
+          {
+            messageId: "noEnvFallback",
+            line: 1,
+            column: 15,
+          },
+        ],
+      },
+      {
+        code: `const config = {
         apiUrl: process.env.API_URL ?? "https://api.example.com",
       };`,
-      name: "should disallow fallback in object property",
-      errors: [
-        {
-          messageId: "noEnvFallback",
-          line: 2,
-          column: 17,
-        },
-      ],
-    },
-    {
-      code: `const region = process.env.AWS_REGION ? "us-east-1" : "us-west-2";`,
-      name: "should disallow ternary with different fallback values",
-      errors: [
-        {
-          messageId: "noEnvFallback",
-          line: 1,
-          column: 16,
-        },
-      ],
-    },
-    {
-      code: `function getConfig() {
+        name: "should disallow fallback in object property",
+        errors: [
+          {
+            messageId: "noEnvFallback",
+            line: 2,
+            column: 17,
+          },
+        ],
+      },
+      {
+        code: `const region = process.env.AWS_REGION ? "us-east-1" : "us-west-2";`,
+        name: "should disallow ternary with different fallback values",
+        errors: [
+          {
+            messageId: "noEnvFallback",
+            line: 1,
+            column: 16,
+          },
+        ],
+      },
+      {
+        code: `function getConfig() {
         return process.env.CONFIG_PATH || "/default/path";
       }`,
-      name: "should disallow fallback in return statement",
-      errors: [
-        {
-          messageId: "noEnvFallback",
-          line: 2,
-          column: 16,
-        },
-      ],
-    },
-    {
-      code: `const secret = process.env.SECRET_KEY ?? "";`,
-      name: "should disallow empty string as fallback",
-      errors: [
-        {
-          messageId: "noEnvFallback",
-          line: 1,
-          column: 16,
-        },
-      ],
-    },
-  ],
-});
-
-describe("no-env-fallback rule structure", () => {
-  it("should have correct rule structure", () => {
-    expect(noEnvFallback).toHaveProperty("meta");
-    expect(noEnvFallback).toHaveProperty("create");
-    expect(typeof noEnvFallback.create).toBe("function");
+        name: "should disallow fallback in return statement",
+        errors: [
+          {
+            messageId: "noEnvFallback",
+            line: 2,
+            column: 16,
+          },
+        ],
+      },
+      {
+        code: `const secret = process.env.SECRET_KEY ?? "";`,
+        name: "should disallow empty string as fallback",
+        errors: [
+          {
+            messageId: "noEnvFallback",
+            line: 1,
+            column: 16,
+          },
+        ],
+      },
+    ],
   });
 });

--- a/src/rules/__tests__/no-inline-default-export.test.ts
+++ b/src/rules/__tests__/no-inline-default-export.test.ts
@@ -1,27 +1,21 @@
 import { RuleTester } from "@typescript-eslint/rule-tester";
-import { afterAll, describe, it, expect } from "@jest/globals";
-import parser from "@typescript-eslint/parser";
+import { afterAll, describe, it } from "@jest/globals";
 
 import noInlineDefaultExport from "../no-inline-default-export";
 
 RuleTester.afterAll = afterAll;
-RuleTester.it = it;
-RuleTester.itOnly = it.only;
 RuleTester.describe = describe;
+RuleTester.it = it;
 
-const ruleTester = new RuleTester({
-  languageOptions: {
-    parser,
-    parserOptions: {
-      ecmaVersion: 2020,
-      sourceType: "module",
-    },
-  },
-});
+const ruleTester = new RuleTester();
 
 describe("no-inline-default-export", () => {
-  it("should be defined", () => {
-    expect(noInlineDefaultExport).toBeDefined();
+  it("should have meta property", () => {
+    expect(noInlineDefaultExport.meta).toBeDefined();
+  });
+
+  it("should have create method", () => {
+    expect(typeof noInlineDefaultExport.create).toBe("function");
   });
 
   ruleTester.run("no-inline-default-export", noInlineDefaultExport, {

--- a/src/rules/__tests__/no-inline-nested-object.test.ts
+++ b/src/rules/__tests__/no-inline-nested-object.test.ts
@@ -4,22 +4,18 @@ import { afterAll, describe, it } from "@jest/globals";
 import noInlineNestedObject from "../no-inline-nested-object";
 
 RuleTester.afterAll = afterAll;
-RuleTester.it = it;
-RuleTester.itOnly = it.only;
 RuleTester.describe = describe;
+RuleTester.it = it;
 
-const ruleTester = new RuleTester({
-  languageOptions: {
-    parserOptions: {
-      ecmaVersion: 2020,
-      sourceType: "module",
-    },
-  },
-});
+const ruleTester = new RuleTester();
 
 describe("no-inline-nested-object", () => {
-  it("should be defined", () => {
-    expect(noInlineNestedObject).toBeDefined();
+  it("should have meta property", () => {
+    expect(noInlineNestedObject.meta).toBeDefined();
+  });
+
+  it("should have create method", () => {
+    expect(typeof noInlineNestedObject.create).toBe("function");
   });
 
   ruleTester.run("no-inline-nested-object", noInlineNestedObject, {

--- a/src/rules/__tests__/no-lazy-identifiers.test.ts
+++ b/src/rules/__tests__/no-lazy-identifiers.test.ts
@@ -1,27 +1,21 @@
 import { RuleTester } from "@typescript-eslint/rule-tester";
-import { afterAll, describe, it, expect } from "@jest/globals";
-import parser from "@typescript-eslint/parser";
+import { afterAll, describe, it } from "@jest/globals";
 
 import noLazyIdentifiers from "../no-lazy-identifiers";
 
 RuleTester.afterAll = afterAll;
-RuleTester.it = it;
-RuleTester.itOnly = it.only;
 RuleTester.describe = describe;
+RuleTester.it = it;
 
-const ruleTester = new RuleTester({
-  languageOptions: {
-    parser,
-    parserOptions: {
-      ecmaVersion: 2020,
-      sourceType: "module",
-    },
-  },
-});
+const ruleTester = new RuleTester();
 
 describe("no-lazy-identifiers", () => {
-  it("should be defined", () => {
-    expect(noLazyIdentifiers).toBeDefined();
+  it("should have meta property", () => {
+    expect(noLazyIdentifiers.meta).toBeDefined();
+  });
+
+  it("should have create method", () => {
+    expect(typeof noLazyIdentifiers.create).toBe("function");
   });
 
   ruleTester.run("no-lazy-identifiers", noLazyIdentifiers, {

--- a/src/rules/__tests__/no-logic-in-params.test.ts
+++ b/src/rules/__tests__/no-logic-in-params.test.ts
@@ -1,27 +1,21 @@
 import { RuleTester } from "@typescript-eslint/rule-tester";
 import { afterAll, describe, it } from "@jest/globals";
-import parser from "@typescript-eslint/parser";
 
 import noLogicInParams from "../no-logic-in-params";
 
 RuleTester.afterAll = afterAll;
-RuleTester.it = it;
-RuleTester.itOnly = it.only;
 RuleTester.describe = describe;
+RuleTester.it = it;
 
-const ruleTester = new RuleTester({
-  languageOptions: {
-    parser,
-    parserOptions: {
-      ecmaVersion: 2020,
-      sourceType: "module",
-    },
-  },
-});
+const ruleTester = new RuleTester();
 
 describe("no-logic-in-params", () => {
-  it("should be defined", () => {
-    expect(noLogicInParams).toBeDefined();
+  it("should have meta property", () => {
+    expect(noLogicInParams.meta).toBeDefined();
+  });
+
+  it("should have create method", () => {
+    expect(typeof noLogicInParams.create).toBe("function");
   });
 
   ruleTester.run("no-logic-in-params", noLogicInParams, {

--- a/src/rules/__tests__/no-nested-interface-declaration.test.ts
+++ b/src/rules/__tests__/no-nested-interface-declaration.test.ts
@@ -7,14 +7,7 @@ RuleTester.afterAll = afterAll;
 RuleTester.describe = describe;
 RuleTester.it = it;
 
-const ruleTester = new RuleTester({
-  languageOptions: {
-    parserOptions: {
-      ecmaVersion: 2020,
-      sourceType: "module",
-    },
-  },
-});
+const ruleTester = new RuleTester();
 
 describe("no-nested-interface-declaration", () => {
   it("should have meta property", () => {

--- a/src/rules/__tests__/no-nested-ternary.test.ts
+++ b/src/rules/__tests__/no-nested-ternary.test.ts
@@ -1,68 +1,69 @@
 import { RuleTester } from "@typescript-eslint/rule-tester";
-import { afterAll, describe, it, expect } from "@jest/globals";
+import { afterAll, describe, it } from "@jest/globals";
 
 import noNestedTernary from "../no-nested-ternary";
 
 RuleTester.afterAll = afterAll;
-RuleTester.it = it;
-RuleTester.itOnly = it.only;
 RuleTester.describe = describe;
+RuleTester.it = it;
 
 const ruleTester = new RuleTester();
 
-ruleTester.run("no-nested-ternary", noNestedTernary, {
-  valid: [
-    {
-      code: `const status = isLoading ? "loading" : "success";`,
-      name: "simple ternary - allowed",
-    },
-    {
-      code: `const value = condition ? a : b;`,
-      name: "basic ternary - allowed",
-    },
-    {
-      code: `
+describe("no-nested-ternary", () => {
+  it("should have meta property", () => {
+    expect(noNestedTernary.meta).toBeDefined();
+  });
+
+  it("should have create method", () => {
+    expect(typeof noNestedTernary.create).toBe("function");
+  });
+
+  ruleTester.run("no-nested-ternary", noNestedTernary, {
+    valid: [
+      {
+        code: `const status = isLoading ? "loading" : "success";`,
+        name: "simple ternary - allowed",
+      },
+      {
+        code: `const value = condition ? a : b;`,
+        name: "basic ternary - allowed",
+      },
+      {
+        code: `
 const getStatus = () => {
   if (isLoading) return "loading";
   if (isError) return "error";
   return "success";
 };
       `.trim(),
-      name: "function with early returns - allowed",
-    },
-    {
-      code: `const result = arr.map(x => x > 0 ? x : 0);`,
-      name: "ternary inside map - allowed",
-    },
-  ],
-  invalid: [
-    {
-      code: `const status = isLoading ? "loading" : isError ? "error" : "success";`,
-      name: "nested ternary in alternate - disallowed",
-      errors: [{ messageId: "noNestedTernary" }],
-    },
-    {
-      code: `const value = a ? (b ? 1 : 2) : 3;`,
-      name: "nested ternary in consequent - disallowed",
-      errors: [{ messageId: "noNestedTernary" }],
-    },
-    {
-      code: `const x = a ? b ? c : d : e;`,
-      name: "nested ternary without parens - disallowed",
-      errors: [{ messageId: "noNestedTernary" }],
-    },
-    {
-      code: `const result = a ? 1 : b ? 2 : c ? 3 : 4;`,
-      name: "deeply nested ternary - disallowed",
-      errors: [{ messageId: "noNestedTernary" }, { messageId: "noNestedTernary" }],
-    },
-  ],
-});
-
-describe("no-nested-ternary rule structure", () => {
-  it("should have correct rule structure", () => {
-    expect(noNestedTernary).toHaveProperty("meta");
-    expect(noNestedTernary).toHaveProperty("create");
-    expect(typeof noNestedTernary.create).toBe("function");
+        name: "function with early returns - allowed",
+      },
+      {
+        code: `const result = arr.map(x => x > 0 ? x : 0);`,
+        name: "ternary inside map - allowed",
+      },
+    ],
+    invalid: [
+      {
+        code: `const status = isLoading ? "loading" : isError ? "error" : "success";`,
+        name: "nested ternary in alternate - disallowed",
+        errors: [{ messageId: "noNestedTernary" }],
+      },
+      {
+        code: `const value = a ? (b ? 1 : 2) : 3;`,
+        name: "nested ternary in consequent - disallowed",
+        errors: [{ messageId: "noNestedTernary" }],
+      },
+      {
+        code: `const x = a ? b ? c : d : e;`,
+        name: "nested ternary without parens - disallowed",
+        errors: [{ messageId: "noNestedTernary" }],
+      },
+      {
+        code: `const result = a ? 1 : b ? 2 : c ? 3 : 4;`,
+        name: "deeply nested ternary - disallowed",
+        errors: [{ messageId: "noNestedTernary" }, { messageId: "noNestedTernary" }],
+      },
+    ],
   });
 });

--- a/src/rules/__tests__/no-relative-imports.test.ts
+++ b/src/rules/__tests__/no-relative-imports.test.ts
@@ -1,143 +1,144 @@
 import { RuleTester } from "@typescript-eslint/rule-tester";
-import { afterAll, describe, it, expect } from "@jest/globals";
+import { afterAll, describe, it } from "@jest/globals";
 
 import noRelativeImports from "../no-relative-imports";
 
 RuleTester.afterAll = afterAll;
-RuleTester.it = it;
-RuleTester.itOnly = it.only;
 RuleTester.describe = describe;
+RuleTester.it = it;
 
 const ruleTester = new RuleTester();
 
-ruleTester.run("no-relative-imports", noRelativeImports, {
-  valid: [
-    {
-      code: `import { Button } from "src/components/base/button";`,
-      name: "should allow absolute imports",
-    },
-    {
-      code: `import { mapper } from "./article.mapper";`,
-      name: "should allow sibling imports with ./",
-    },
-    {
-      code: `import { utils } from "./utils";`,
-      name: "should allow same directory imports",
-    },
-    {
-      code: `import React from "react";`,
-      name: "should allow package imports",
-    },
-    {
-      code: `import { useState } from "react";`,
-      name: "should allow named package imports",
-    },
-    {
-      code: `import type { FC } from "react";`,
-      name: "should allow type imports from packages",
-    },
-    {
-      code: `import { helper } from "@/utils/helper";`,
-      name: "should allow alias imports with @",
-    },
-    {
-      code: `import { config } from "~/config";`,
-      name: "should allow alias imports with ~",
-    },
-    {
-      code: `export { foo } from "./local";`,
-      name: "should allow re-exports from sibling",
-    },
-    {
-      code: `const module = await import("./dynamic");`,
-      name: "should allow dynamic imports from sibling",
-    },
-  ],
-  invalid: [
-    {
-      code: `import { Button } from "../../../components/base/button";`,
-      name: "should disallow deep relative imports",
-      errors: [
-        {
-          messageId: "noRelativeImport",
-          line: 1,
-          column: 1,
-        },
-      ],
-    },
-    {
-      code: `import { Header } from "../components/Header";`,
-      name: "should disallow parent directory imports",
-      errors: [
-        {
-          messageId: "noRelativeImport",
-          line: 1,
-          column: 1,
-        },
-      ],
-    },
-    {
-      code: `import { utils } from "../utils";`,
-      name: "should disallow single parent traversal",
-      errors: [
-        {
-          messageId: "noRelativeImport",
-          line: 1,
-          column: 1,
-        },
-      ],
-    },
-    {
-      code: `import type { Props } from "../types";`,
-      name: "should disallow type imports with parent traversal",
-      errors: [
-        {
-          messageId: "noRelativeImport",
-          line: 1,
-          column: 1,
-        },
-      ],
-    },
-    {
-      code: `export { foo } from "../shared";`,
-      name: "should disallow re-exports from parent directory",
-      errors: [
-        {
-          messageId: "noRelativeImport",
-          line: 1,
-          column: 1,
-        },
-      ],
-    },
-    {
-      code: `export * from "../index";`,
-      name: "should disallow export all from parent directory",
-      errors: [
-        {
-          messageId: "noRelativeImport",
-          line: 1,
-          column: 1,
-        },
-      ],
-    },
-    {
-      code: `const module = await import("../lazy-module");`,
-      name: "should disallow dynamic imports from parent directory",
-      errors: [
-        {
-          messageId: "noRelativeImport",
-          line: 1,
-          column: 22,
-        },
-      ],
-    },
-  ],
-});
+describe("no-relative-imports", () => {
+  it("should have meta property", () => {
+    expect(noRelativeImports.meta).toBeDefined();
+  });
 
-describe("no-relative-imports rule structure", () => {
-  it("should have correct rule structure", () => {
-    expect(noRelativeImports).toHaveProperty("meta");
-    expect(noRelativeImports).toHaveProperty("create");
+  it("should have create method", () => {
     expect(typeof noRelativeImports.create).toBe("function");
+  });
+
+  ruleTester.run("no-relative-imports", noRelativeImports, {
+    valid: [
+      {
+        code: `import { Button } from "src/components/base/button";`,
+        name: "should allow absolute imports",
+      },
+      {
+        code: `import { mapper } from "./article.mapper";`,
+        name: "should allow sibling imports with ./",
+      },
+      {
+        code: `import { utils } from "./utils";`,
+        name: "should allow same directory imports",
+      },
+      {
+        code: `import React from "react";`,
+        name: "should allow package imports",
+      },
+      {
+        code: `import { useState } from "react";`,
+        name: "should allow named package imports",
+      },
+      {
+        code: `import type { FC } from "react";`,
+        name: "should allow type imports from packages",
+      },
+      {
+        code: `import { helper } from "@/utils/helper";`,
+        name: "should allow alias imports with @",
+      },
+      {
+        code: `import { config } from "~/config";`,
+        name: "should allow alias imports with ~",
+      },
+      {
+        code: `export { foo } from "./local";`,
+        name: "should allow re-exports from sibling",
+      },
+      {
+        code: `const module = await import("./dynamic");`,
+        name: "should allow dynamic imports from sibling",
+      },
+    ],
+    invalid: [
+      {
+        code: `import { Button } from "../../../components/base/button";`,
+        name: "should disallow deep relative imports",
+        errors: [
+          {
+            messageId: "noRelativeImport",
+            line: 1,
+            column: 1,
+          },
+        ],
+      },
+      {
+        code: `import { Header } from "../components/Header";`,
+        name: "should disallow parent directory imports",
+        errors: [
+          {
+            messageId: "noRelativeImport",
+            line: 1,
+            column: 1,
+          },
+        ],
+      },
+      {
+        code: `import { utils } from "../utils";`,
+        name: "should disallow single parent traversal",
+        errors: [
+          {
+            messageId: "noRelativeImport",
+            line: 1,
+            column: 1,
+          },
+        ],
+      },
+      {
+        code: `import type { Props } from "../types";`,
+        name: "should disallow type imports with parent traversal",
+        errors: [
+          {
+            messageId: "noRelativeImport",
+            line: 1,
+            column: 1,
+          },
+        ],
+      },
+      {
+        code: `export { foo } from "../shared";`,
+        name: "should disallow re-exports from parent directory",
+        errors: [
+          {
+            messageId: "noRelativeImport",
+            line: 1,
+            column: 1,
+          },
+        ],
+      },
+      {
+        code: `export * from "../index";`,
+        name: "should disallow export all from parent directory",
+        errors: [
+          {
+            messageId: "noRelativeImport",
+            line: 1,
+            column: 1,
+          },
+        ],
+      },
+      {
+        code: `const module = await import("../lazy-module");`,
+        name: "should disallow dynamic imports from parent directory",
+        errors: [
+          {
+            messageId: "noRelativeImport",
+            line: 1,
+            column: 22,
+          },
+        ],
+      },
+    ],
   });
 });

--- a/src/rules/__tests__/no-single-char-variables.test.ts
+++ b/src/rules/__tests__/no-single-char-variables.test.ts
@@ -1,27 +1,21 @@
 import { RuleTester } from "@typescript-eslint/rule-tester";
-import { afterAll, describe, it, expect } from "@jest/globals";
-import parser from "@typescript-eslint/parser";
+import { afterAll, describe, it } from "@jest/globals";
 
 import noSingleCharVariables from "../no-single-char-variables";
 
 RuleTester.afterAll = afterAll;
-RuleTester.it = it;
-RuleTester.itOnly = it.only;
 RuleTester.describe = describe;
+RuleTester.it = it;
 
-const ruleTester = new RuleTester({
-  languageOptions: {
-    parser,
-    parserOptions: {
-      ecmaVersion: 2020,
-      sourceType: "module",
-    },
-  },
-});
+const ruleTester = new RuleTester();
 
 describe("no-single-char-variables", () => {
-  it("should be defined", () => {
-    expect(noSingleCharVariables).toBeDefined();
+  it("should have meta property", () => {
+    expect(noSingleCharVariables.meta).toBeDefined();
+  });
+
+  it("should have create method", () => {
+    expect(typeof noSingleCharVariables.create).toBe("function");
   });
 
   ruleTester.run("no-single-char-variables", noSingleCharVariables, {

--- a/src/rules/__tests__/prefer-async-await.test.ts
+++ b/src/rules/__tests__/prefer-async-await.test.ts
@@ -1,35 +1,43 @@
 import { RuleTester } from "@typescript-eslint/rule-tester";
-import { afterAll, describe, it, expect } from "@jest/globals";
+import { afterAll, describe, it } from "@jest/globals";
 
 import preferAsyncAwait from "../prefer-async-await";
 
 RuleTester.afterAll = afterAll;
-RuleTester.it = it;
-RuleTester.itOnly = it.only;
 RuleTester.describe = describe;
+RuleTester.it = it;
 
 const ruleTester = new RuleTester();
 
-ruleTester.run("prefer-async-await", preferAsyncAwait, {
-  valid: [
-    {
-      code: `
+describe("prefer-async-await", () => {
+  it("should have meta property", () => {
+    expect(preferAsyncAwait.meta).toBeDefined();
+  });
+
+  it("should have create method", () => {
+    expect(typeof preferAsyncAwait.create).toBe("function");
+  });
+
+  ruleTester.run("prefer-async-await", preferAsyncAwait, {
+    valid: [
+      {
+        code: `
         async function fetchData() {
           const res = await fetch(url);
           const data = await res.json();
           setData(data);
         }
       `,
-      name: "should allow async/await pattern",
-    },
-    {
-      code: `
+        name: "should allow async/await pattern",
+      },
+      {
+        code: `
         const data = await fetch(url);
       `,
-      name: "should allow simple await",
-    },
-    {
-      code: `
+        name: "should allow simple await",
+      },
+      {
+        code: `
         async function getData() {
           try {
             const response = await api.get("/users");
@@ -39,101 +47,94 @@ ruleTester.run("prefer-async-await", preferAsyncAwait, {
           }
         }
       `,
-      name: "should allow async/await with try/catch",
-    },
-    {
-      code: `
+        name: "should allow async/await with try/catch",
+      },
+      {
+        code: `
         const result = await Promise.all([fetchA(), fetchB()]);
       `,
-      name: "should allow Promise.all with await",
-    },
-  ],
-  invalid: [
-    {
-      code: `fetch(url).then(res => res.json()).then(data => setData(data));`,
-      name: "should disallow chained .then()",
-      errors: [
-        {
-          messageId: "preferAsyncAwait",
-        },
-        {
-          messageId: "preferAsyncAwait",
-        },
-      ],
-    },
-    {
-      code: `fetch(url).then(res => res.json());`,
-      name: "should disallow single .then()",
-      errors: [
-        {
-          messageId: "preferAsyncAwait",
-        },
-      ],
-    },
-    {
-      code: `
+        name: "should allow Promise.all with await",
+      },
+    ],
+    invalid: [
+      {
+        code: `fetch(url).then(res => res.json()).then(data => setData(data));`,
+        name: "should disallow chained .then()",
+        errors: [
+          {
+            messageId: "preferAsyncAwait",
+          },
+          {
+            messageId: "preferAsyncAwait",
+          },
+        ],
+      },
+      {
+        code: `fetch(url).then(res => res.json());`,
+        name: "should disallow single .then()",
+        errors: [
+          {
+            messageId: "preferAsyncAwait",
+          },
+        ],
+      },
+      {
+        code: `
         api.get("/users").then(response => {
           return response.data;
         });
       `,
-      name: "should disallow .then() with block body",
-      errors: [
-        {
-          messageId: "preferAsyncAwait",
-        },
-      ],
-    },
-    {
-      code: `
+        name: "should disallow .then() with block body",
+        errors: [
+          {
+            messageId: "preferAsyncAwait",
+          },
+        ],
+      },
+      {
+        code: `
         fetchData()
           .then(handleSuccess)
           .catch(handleError);
       `,
-      name: "should disallow .then().catch() pattern",
-      errors: [
-        {
-          messageId: "preferAsyncAwait",
-        },
-      ],
-    },
-    {
-      code: `
+        name: "should disallow .then().catch() pattern",
+        errors: [
+          {
+            messageId: "preferAsyncAwait",
+          },
+        ],
+      },
+      {
+        code: `
         promise
           .then(step1)
           .then(step2)
           .then(step3);
       `,
-      name: "should disallow long promise chains",
-      errors: [
-        {
-          messageId: "preferAsyncAwait",
-        },
-        {
-          messageId: "preferAsyncAwait",
-        },
-        {
-          messageId: "preferAsyncAwait",
-        },
-      ],
-    },
-    {
-      code: `
+        name: "should disallow long promise chains",
+        errors: [
+          {
+            messageId: "preferAsyncAwait",
+          },
+          {
+            messageId: "preferAsyncAwait",
+          },
+          {
+            messageId: "preferAsyncAwait",
+          },
+        ],
+      },
+      {
+        code: `
         Promise.resolve(value).then(callback);
       `,
-      name: "should disallow Promise.resolve().then()",
-      errors: [
-        {
-          messageId: "preferAsyncAwait",
-        },
-      ],
-    },
-  ],
-});
-
-describe("prefer-async-await rule structure", () => {
-  it("should have correct rule structure", () => {
-    expect(preferAsyncAwait).toHaveProperty("meta");
-    expect(preferAsyncAwait).toHaveProperty("create");
-    expect(typeof preferAsyncAwait.create).toBe("function");
+        name: "should disallow Promise.resolve().then()",
+        errors: [
+          {
+            messageId: "preferAsyncAwait",
+          },
+        ],
+      },
+    ],
   });
 });

--- a/src/rules/__tests__/prefer-destructuring-params.test.ts
+++ b/src/rules/__tests__/prefer-destructuring-params.test.ts
@@ -4,220 +4,221 @@ import { afterAll, describe, it } from "@jest/globals";
 import preferDestructuringParams from "../prefer-destructuring-params";
 
 RuleTester.afterAll = afterAll;
-RuleTester.it = it;
-RuleTester.itOnly = it.only;
 RuleTester.describe = describe;
+RuleTester.it = it;
 
 const ruleTester = new RuleTester();
 
-ruleTester.run("prefer-destructuring-params", preferDestructuringParams, {
-  valid: [
-    {
-      code: `function foo() {}`,
-      name: "should allow functions with no parameters",
-    },
-    {
-      code: `function foo(oneParam) {}`,
-      name: "should allow functions with one parameter",
-    },
-    {
-      code: `function foo({oneParam, twoParam}) {}`,
-      name: "should allow functions with destructured parameters",
-    },
-    {
-      code: `const foo = (oneParam) => {}`,
-      name: "should allow arrow functions with one parameter",
-    },
-    {
-      code: `const foo = ({oneParam, twoParam}) => {}`,
-      name: "should allow arrow functions with destructured parameters",
-    },
-    {
-      code: `const obj = { foo(oneParam) {} }`,
-      name: "should allow methods with one parameter",
-    },
-    {
-      code: `const obj = { foo({oneParam, twoParam}) {} }`,
-      name: "should allow methods with destructured parameters",
-    },
-    {
-      code: `class MyClass { foo(oneParam) {} }`,
-      name: "should allow class methods with one parameter",
-    },
-    {
-      code: `class MyClass { foo({oneParam, twoParam}) {} }`,
-      name: "should allow class methods with destructured parameters",
-    },
-    {
-      code: `function foo({oneParam}, ...rest) {}`,
-      name: "should allow destructuring with rest parameters",
-    },
-    {
-      code: `const foo = ({a, b}, {c, d}) => {}`,
-      name: "should allow multiple destructured parameters",
-    },
-    {
-      code: `function foo({a: {nested}}, {b}) {}`,
-      name: "should allow nested destructuring",
-    },
-    {
-      code: `function _internalFunction(param1, param2) {}`,
-      name: "should skip functions starting with underscore",
-    },
-    {
-      code: `function $libraryFunction(param1, param2) {}`,
-      name: "should skip functions containing dollar sign",
-    },
-    {
-      code: `function Component(props, context) {}`,
-      name: "should skip constructor-like functions",
-    },
-    {
-      code: `words.forEach((word, wordIndex) => {})`,
-      name: "should allow forEach callbacks with multiple parameters",
-    },
-    {
-      code: `items.map((item, index) => {})`,
-      name: "should allow map callbacks with multiple parameters",
-    },
-    {
-      code: `items.filter((item, index) => {})`,
-      name: "should allow filter callbacks with multiple parameters",
-    },
-    {
-      code: `items.reduce((acc, curr, index) => {})`,
-      name: "should allow reduce callbacks with multiple parameters",
-    },
-    {
-      code: `items.find((item, index) => {})`,
-      name: "should allow find callbacks with multiple parameters",
-    },
-    {
-      code: `items.findIndex((item, index) => {})`,
-      name: "should allow findIndex callbacks with multiple parameters",
-    },
-    {
-      code: `items.some((item, index) => {})`,
-      name: "should allow some callbacks with multiple parameters",
-    },
-    {
-      code: `items.every((item, index) => {})`,
-      name: "should allow every callbacks with multiple parameters",
-    },
-    {
-      code: `items.forEach(function(item, index) {})`,
-      name: "should allow forEach function expressions with multiple parameters",
-    },
-    {
-      code: `promise.then((result, error) => {})`,
-      name: "should allow Promise then callbacks with multiple parameters",
-    },
-    {
-      code: `element.addEventListener('click', (event, data) => {})`,
-      name: "should allow event listener callbacks with multiple parameters",
-    },
-    {
-      code: `setTimeout((arg1, arg2) => {}, 1000)`,
-      name: "should allow setTimeout callbacks with multiple parameters",
-    },
-    {
-      code: `customFunction((param1, param2) => {})`,
-      name: "should allow any callback function with multiple parameters",
-    },
-    {
-      code: `obj.method((a, b) => {})`,
-      name: "should allow method callbacks with multiple parameters",
-    },
-  ],
-  invalid: [
-    {
-      code: `function foo(oneParam, twoParam) {}`,
-      name: "should disallow functions with multiple non-destructured parameters",
-      errors: [
-        {
-          messageId: "preferDestructuring",
-        },
-      ],
-    },
-    {
-      code: `const foo = (oneParam, twoParam) => {}`,
-      name: "should disallow arrow functions with multiple non-destructured parameters",
-      errors: [
-        {
-          messageId: "preferDestructuring",
-        },
-      ],
-    },
-    {
-      code: `function foo(oneParam, twoParam, threeParam) {}`,
-      name: "should disallow functions with three non-destructured parameters",
-      errors: [
-        {
-          messageId: "preferDestructuring",
-        },
-      ],
-    },
-    {
-      code: `const obj = { foo(oneParam, twoParam) {} }`,
-      name: "should disallow methods with multiple non-destructured parameters",
-      errors: [
-        {
-          messageId: "preferDestructuring",
-        },
-      ],
-    },
-    {
-      code: `class MyClass { foo(oneParam, twoParam) {} }`,
-      name: "should disallow class methods with multiple non-destructured parameters",
-      errors: [
-        {
-          messageId: "preferDestructuring",
-        },
-      ],
-    },
-    {
-      code: `const obj = { foo: (oneParam, twoParam) => {} }`,
-      name: "should disallow object property arrow functions with multiple parameters",
-      errors: [
-        {
-          messageId: "preferDestructuring",
-        },
-      ],
-    },
-    {
-      code: `const obj = { foo: function(oneParam, twoParam) {} }`,
-      name: "should disallow object property functions with multiple parameters",
-      errors: [
-        {
-          messageId: "preferDestructuring",
-        },
-      ],
-    },
-    {
-      code: `function foo({oneParam}, twoParam) {}`,
-      name: "should disallow mixed destructured and non-destructured parameters",
-      errors: [
-        {
-          messageId: "preferDestructuring",
-        },
-      ],
-    },
-    {
-      code: `function foo(oneParam, {twoParam}) {}`,
-      name: "should disallow mixed non-destructured and destructured parameters",
-      errors: [
-        {
-          messageId: "preferDestructuring",
-        },
-      ],
-    },
-  ],
-});
+describe("prefer-destructuring-params", () => {
+  it("should have meta property", () => {
+    expect(preferDestructuringParams.meta).toBeDefined();
+  });
 
-describe("prefer-destructuring-params rule structure", () => {
-  it("should have correct rule structure", () => {
-    expect(preferDestructuringParams).toHaveProperty("meta");
-    expect(preferDestructuringParams).toHaveProperty("create");
+  it("should have create method", () => {
     expect(typeof preferDestructuringParams.create).toBe("function");
+  });
+
+  ruleTester.run("prefer-destructuring-params", preferDestructuringParams, {
+    valid: [
+      {
+        code: `function foo() {}`,
+        name: "should allow functions with no parameters",
+      },
+      {
+        code: `function foo(oneParam) {}`,
+        name: "should allow functions with one parameter",
+      },
+      {
+        code: `function foo({oneParam, twoParam}) {}`,
+        name: "should allow functions with destructured parameters",
+      },
+      {
+        code: `const foo = (oneParam) => {}`,
+        name: "should allow arrow functions with one parameter",
+      },
+      {
+        code: `const foo = ({oneParam, twoParam}) => {}`,
+        name: "should allow arrow functions with destructured parameters",
+      },
+      {
+        code: `const obj = { foo(oneParam) {} }`,
+        name: "should allow methods with one parameter",
+      },
+      {
+        code: `const obj = { foo({oneParam, twoParam}) {} }`,
+        name: "should allow methods with destructured parameters",
+      },
+      {
+        code: `class MyClass { foo(oneParam) {} }`,
+        name: "should allow class methods with one parameter",
+      },
+      {
+        code: `class MyClass { foo({oneParam, twoParam}) {} }`,
+        name: "should allow class methods with destructured parameters",
+      },
+      {
+        code: `function foo({oneParam}, ...rest) {}`,
+        name: "should allow destructuring with rest parameters",
+      },
+      {
+        code: `const foo = ({a, b}, {c, d}) => {}`,
+        name: "should allow multiple destructured parameters",
+      },
+      {
+        code: `function foo({a: {nested}}, {b}) {}`,
+        name: "should allow nested destructuring",
+      },
+      {
+        code: `function _internalFunction(param1, param2) {}`,
+        name: "should skip functions starting with underscore",
+      },
+      {
+        code: `function $libraryFunction(param1, param2) {}`,
+        name: "should skip functions containing dollar sign",
+      },
+      {
+        code: `function Component(props, context) {}`,
+        name: "should skip constructor-like functions",
+      },
+      {
+        code: `words.forEach((word, wordIndex) => {})`,
+        name: "should allow forEach callbacks with multiple parameters",
+      },
+      {
+        code: `items.map((item, index) => {})`,
+        name: "should allow map callbacks with multiple parameters",
+      },
+      {
+        code: `items.filter((item, index) => {})`,
+        name: "should allow filter callbacks with multiple parameters",
+      },
+      {
+        code: `items.reduce((acc, curr, index) => {})`,
+        name: "should allow reduce callbacks with multiple parameters",
+      },
+      {
+        code: `items.find((item, index) => {})`,
+        name: "should allow find callbacks with multiple parameters",
+      },
+      {
+        code: `items.findIndex((item, index) => {})`,
+        name: "should allow findIndex callbacks with multiple parameters",
+      },
+      {
+        code: `items.some((item, index) => {})`,
+        name: "should allow some callbacks with multiple parameters",
+      },
+      {
+        code: `items.every((item, index) => {})`,
+        name: "should allow every callbacks with multiple parameters",
+      },
+      {
+        code: `items.forEach(function(item, index) {})`,
+        name: "should allow forEach function expressions with multiple parameters",
+      },
+      {
+        code: `promise.then((result, error) => {})`,
+        name: "should allow Promise then callbacks with multiple parameters",
+      },
+      {
+        code: `element.addEventListener('click', (event, data) => {})`,
+        name: "should allow event listener callbacks with multiple parameters",
+      },
+      {
+        code: `setTimeout((arg1, arg2) => {}, 1000)`,
+        name: "should allow setTimeout callbacks with multiple parameters",
+      },
+      {
+        code: `customFunction((param1, param2) => {})`,
+        name: "should allow any callback function with multiple parameters",
+      },
+      {
+        code: `obj.method((a, b) => {})`,
+        name: "should allow method callbacks with multiple parameters",
+      },
+    ],
+    invalid: [
+      {
+        code: `function foo(oneParam, twoParam) {}`,
+        name: "should disallow functions with multiple non-destructured parameters",
+        errors: [
+          {
+            messageId: "preferDestructuring",
+          },
+        ],
+      },
+      {
+        code: `const foo = (oneParam, twoParam) => {}`,
+        name: "should disallow arrow functions with multiple non-destructured parameters",
+        errors: [
+          {
+            messageId: "preferDestructuring",
+          },
+        ],
+      },
+      {
+        code: `function foo(oneParam, twoParam, threeParam) {}`,
+        name: "should disallow functions with three non-destructured parameters",
+        errors: [
+          {
+            messageId: "preferDestructuring",
+          },
+        ],
+      },
+      {
+        code: `const obj = { foo(oneParam, twoParam) {} }`,
+        name: "should disallow methods with multiple non-destructured parameters",
+        errors: [
+          {
+            messageId: "preferDestructuring",
+          },
+        ],
+      },
+      {
+        code: `class MyClass { foo(oneParam, twoParam) {} }`,
+        name: "should disallow class methods with multiple non-destructured parameters",
+        errors: [
+          {
+            messageId: "preferDestructuring",
+          },
+        ],
+      },
+      {
+        code: `const obj = { foo: (oneParam, twoParam) => {} }`,
+        name: "should disallow object property arrow functions with multiple parameters",
+        errors: [
+          {
+            messageId: "preferDestructuring",
+          },
+        ],
+      },
+      {
+        code: `const obj = { foo: function(oneParam, twoParam) {} }`,
+        name: "should disallow object property functions with multiple parameters",
+        errors: [
+          {
+            messageId: "preferDestructuring",
+          },
+        ],
+      },
+      {
+        code: `function foo({oneParam}, twoParam) {}`,
+        name: "should disallow mixed destructured and non-destructured parameters",
+        errors: [
+          {
+            messageId: "preferDestructuring",
+          },
+        ],
+      },
+      {
+        code: `function foo(oneParam, {twoParam}) {}`,
+        name: "should disallow mixed non-destructured and destructured parameters",
+        errors: [
+          {
+            messageId: "preferDestructuring",
+          },
+        ],
+      },
+    ],
   });
 });

--- a/src/rules/__tests__/prefer-function-declaration.test.ts
+++ b/src/rules/__tests__/prefer-function-declaration.test.ts
@@ -1,27 +1,21 @@
 import { RuleTester } from "@typescript-eslint/rule-tester";
-import { afterAll, describe, it, expect } from "@jest/globals";
-import parser from "@typescript-eslint/parser";
+import { afterAll, describe, it } from "@jest/globals";
 
 import preferFunctionDeclaration from "../prefer-function-declaration";
 
 RuleTester.afterAll = afterAll;
-RuleTester.it = it;
-RuleTester.itOnly = it.only;
 RuleTester.describe = describe;
+RuleTester.it = it;
 
-const ruleTester = new RuleTester({
-  languageOptions: {
-    parser,
-    parserOptions: {
-      ecmaVersion: 2020,
-      sourceType: "module",
-    },
-  },
-});
+const ruleTester = new RuleTester();
 
 describe("prefer-function-declaration", () => {
-  it("should be defined", () => {
-    expect(preferFunctionDeclaration).toBeDefined();
+  it("should have meta property", () => {
+    expect(preferFunctionDeclaration.meta).toBeDefined();
+  });
+
+  it("should have create method", () => {
+    expect(typeof preferFunctionDeclaration.create).toBe("function");
   });
 
   ruleTester.run("prefer-function-declaration", preferFunctionDeclaration, {

--- a/src/rules/__tests__/prefer-guard-clause.test.ts
+++ b/src/rules/__tests__/prefer-guard-clause.test.ts
@@ -1,29 +1,37 @@
 import { RuleTester } from "@typescript-eslint/rule-tester";
-import { afterAll, describe, it, expect } from "@jest/globals";
+import { afterAll, describe, it } from "@jest/globals";
 
 import preferGuardClause from "../prefer-guard-clause";
 
 RuleTester.afterAll = afterAll;
-RuleTester.it = it;
-RuleTester.itOnly = it.only;
 RuleTester.describe = describe;
+RuleTester.it = it;
 
 const ruleTester = new RuleTester();
 
-ruleTester.run("prefer-guard-clause", preferGuardClause, {
-  valid: [
-    {
-      code: `
+describe("prefer-guard-clause", () => {
+  it("should have meta property", () => {
+    expect(preferGuardClause.meta).toBeDefined();
+  });
+
+  it("should have create method", () => {
+    expect(typeof preferGuardClause.create).toBe("function");
+  });
+
+  ruleTester.run("prefer-guard-clause", preferGuardClause, {
+    valid: [
+      {
+        code: `
 function process(data) {
   if (!data) return [];
   if (!data.items) return [];
   return data.items.map(toItem);
 }
       `.trim(),
-      name: "guard clauses with early returns - allowed",
-    },
-    {
-      code: `
+        name: "guard clauses with early returns - allowed",
+      },
+      {
+        code: `
 function validate(input) {
   if (!input) return false;
   if (!input.name) return false;
@@ -31,19 +39,19 @@ function validate(input) {
   return true;
 }
       `.trim(),
-      name: "multiple guard clauses - allowed",
-    },
-    {
-      code: `
+        name: "multiple guard clauses - allowed",
+      },
+      {
+        code: `
 if (condition) {
   doA();
   doB();
 }
       `.trim(),
-      name: "if with multiple statements (no nested if) - allowed",
-    },
-    {
-      code: `
+        name: "if with multiple statements (no nested if) - allowed",
+      },
+      {
+        code: `
 if (a) {
   doSomething();
   if (b) {
@@ -51,16 +59,16 @@ if (a) {
   }
 }
       `.trim(),
-      name: "if with other statements before nested if - allowed",
-    },
-    {
-      code: `if (condition) doSomething();`,
-      name: "simple single-line if - allowed",
-    },
-  ],
-  invalid: [
-    {
-      code: `
+        name: "if with other statements before nested if - allowed",
+      },
+      {
+        code: `if (condition) doSomething();`,
+        name: "simple single-line if - allowed",
+      },
+    ],
+    invalid: [
+      {
+        code: `
 function process(data) {
   if (data) {
     if (data.items) {
@@ -70,38 +78,31 @@ function process(data) {
   return [];
 }
       `.trim(),
-      name: "nested if statements - disallowed",
-      errors: [{ messageId: "preferGuardClause" }],
-    },
-    {
-      code: `
+        name: "nested if statements - disallowed",
+        errors: [{ messageId: "preferGuardClause" }],
+      },
+      {
+        code: `
 if (a) {
   if (b) {
     doSomething();
   }
 }
       `.trim(),
-      name: "nested if with single statement - disallowed",
-      errors: [{ messageId: "preferGuardClause" }],
-    },
-    {
-      code: `
+        name: "nested if with single statement - disallowed",
+        errors: [{ messageId: "preferGuardClause" }],
+      },
+      {
+        code: `
 if (user) {
   if (user.isAdmin) {
     return adminDashboard();
   }
 }
       `.trim(),
-      name: "nested if checking property - disallowed",
-      errors: [{ messageId: "preferGuardClause" }],
-    },
-  ],
-});
-
-describe("prefer-guard-clause rule structure", () => {
-  it("should have correct rule structure", () => {
-    expect(preferGuardClause).toHaveProperty("meta");
-    expect(preferGuardClause).toHaveProperty("create");
-    expect(typeof preferGuardClause.create).toBe("function");
+        name: "nested if checking property - disallowed",
+        errors: [{ messageId: "preferGuardClause" }],
+      },
+    ],
   });
 });

--- a/src/rules/__tests__/prefer-import-type.test.ts
+++ b/src/rules/__tests__/prefer-import-type.test.ts
@@ -4,15 +4,12 @@ import { afterAll, describe, it } from "@jest/globals";
 import preferImportType from "../prefer-import-type";
 
 RuleTester.afterAll = afterAll;
-RuleTester.it = it;
-RuleTester.itOnly = it.only;
 RuleTester.describe = describe;
+RuleTester.it = it;
 
 const ruleTester = new RuleTester({
   languageOptions: {
     parserOptions: {
-      ecmaVersion: 2020,
-      sourceType: "module",
       ecmaFeatures: {
         jsx: true,
       },
@@ -21,8 +18,12 @@ const ruleTester = new RuleTester({
 });
 
 describe("prefer-import-type", () => {
-  it("should be defined", () => {
-    expect(preferImportType).toBeDefined();
+  it("should have meta property", () => {
+    expect(preferImportType.meta).toBeDefined();
+  });
+
+  it("should have create method", () => {
+    expect(typeof preferImportType.create).toBe("function");
   });
 
   ruleTester.run("prefer-import-type", preferImportType, {

--- a/src/rules/__tests__/prefer-inline-literal-union.test.ts
+++ b/src/rules/__tests__/prefer-inline-literal-union.test.ts
@@ -7,14 +7,7 @@ RuleTester.afterAll = afterAll;
 RuleTester.describe = describe;
 RuleTester.it = it;
 
-const ruleTester = new RuleTester({
-  languageOptions: {
-    parserOptions: {
-      ecmaVersion: 2020,
-      sourceType: "module",
-    },
-  },
-});
+const ruleTester = new RuleTester();
 
 describe("prefer-inline-literal-union", () => {
   it("should have meta property", () => {

--- a/src/rules/__tests__/prefer-interface-over-inline-types.test.ts
+++ b/src/rules/__tests__/prefer-interface-over-inline-types.test.ts
@@ -10,8 +10,6 @@ RuleTester.it = it;
 const ruleTester = new RuleTester({
   languageOptions: {
     parserOptions: {
-      ecmaVersion: 2020,
-      sourceType: "module",
       ecmaFeatures: {
         jsx: true,
       },
@@ -20,8 +18,12 @@ const ruleTester = new RuleTester({
 });
 
 describe("prefer-interface-over-inline-types", () => {
-  it("should be defined", () => {
-    expect(preferInterfaceOverInlineTypes).toBeDefined();
+  it("should have meta property", () => {
+    expect(preferInterfaceOverInlineTypes.meta).toBeDefined();
+  });
+
+  it("should have create method", () => {
+    expect(typeof preferInterfaceOverInlineTypes.create).toBe("function");
   });
 
   ruleTester.run("prefer-interface-over-inline-types", preferInterfaceOverInlineTypes, {

--- a/src/rules/__tests__/prefer-jsx-template-literals.test.ts
+++ b/src/rules/__tests__/prefer-jsx-template-literals.test.ts
@@ -4,15 +4,12 @@ import { afterAll, describe, it } from "@jest/globals";
 import preferJSXTemplateLiterals from "../prefer-jsx-template-literals";
 
 RuleTester.afterAll = afterAll;
-RuleTester.it = it;
-RuleTester.itOnly = it.only;
 RuleTester.describe = describe;
+RuleTester.it = it;
 
 const ruleTester = new RuleTester({
   languageOptions: {
     parserOptions: {
-      ecmaVersion: 2020,
-      sourceType: "module",
       ecmaFeatures: {
         jsx: true,
       },
@@ -21,8 +18,12 @@ const ruleTester = new RuleTester({
 });
 
 describe("prefer-jsx-template-literals", () => {
-  it("should be defined", () => {
-    expect(preferJSXTemplateLiterals).toBeDefined();
+  it("should have meta property", () => {
+    expect(preferJSXTemplateLiterals.meta).toBeDefined();
+  });
+
+  it("should have create method", () => {
+    expect(typeof preferJSXTemplateLiterals.create).toBe("function");
   });
 
   ruleTester.run("prefer-jsx-template-literals", preferJSXTemplateLiterals, {

--- a/src/rules/__tests__/prefer-named-param-types.test.ts
+++ b/src/rules/__tests__/prefer-named-param-types.test.ts
@@ -7,18 +7,15 @@ RuleTester.afterAll = afterAll;
 RuleTester.describe = describe;
 RuleTester.it = it;
 
-const ruleTester = new RuleTester({
-  languageOptions: {
-    parserOptions: {
-      ecmaVersion: 2020,
-      sourceType: "module",
-    },
-  },
-});
+const ruleTester = new RuleTester();
 
 describe("prefer-named-param-types", () => {
-  it("should be defined", () => {
-    expect(preferNamedParamTypes).toBeDefined();
+  it("should have meta property", () => {
+    expect(preferNamedParamTypes.meta).toBeDefined();
+  });
+
+  it("should have create method", () => {
+    expect(typeof preferNamedParamTypes.create).toBe("function");
   });
 
   ruleTester.run("prefer-named-param-types", preferNamedParamTypes, {

--- a/src/rules/__tests__/prefer-react-import-types.test.ts
+++ b/src/rules/__tests__/prefer-react-import-types.test.ts
@@ -10,8 +10,6 @@ RuleTester.it = it;
 const ruleTester = new RuleTester({
   languageOptions: {
     parserOptions: {
-      ecmaVersion: 2020,
-      sourceType: "module",
       ecmaFeatures: {
         jsx: true,
       },
@@ -20,8 +18,12 @@ const ruleTester = new RuleTester({
 });
 
 describe("prefer-react-import-types", () => {
-  it("should be defined", () => {
-    expect(preferReactImportTypes).toBeDefined();
+  it("should have meta property", () => {
+    expect(preferReactImportTypes.meta).toBeDefined();
+  });
+
+  it("should have create method", () => {
+    expect(typeof preferReactImportTypes.create).toBe("function");
   });
 
   ruleTester.run("prefer-react-import-types", preferReactImportTypes, {

--- a/src/rules/__tests__/react-props-destructure.test.ts
+++ b/src/rules/__tests__/react-props-destructure.test.ts
@@ -4,15 +4,12 @@ import { afterAll, describe, it } from "@jest/globals";
 import reactPropsDestructure from "../react-props-destructure";
 
 RuleTester.afterAll = afterAll;
-RuleTester.it = it;
-RuleTester.itOnly = it.only;
 RuleTester.describe = describe;
+RuleTester.it = it;
 
 const ruleTester = new RuleTester({
   languageOptions: {
     parserOptions: {
-      ecmaVersion: 2020,
-      sourceType: "module",
       ecmaFeatures: {
         jsx: true,
       },
@@ -21,8 +18,12 @@ const ruleTester = new RuleTester({
 });
 
 describe("react-props-destructure", () => {
-  it("should be defined", () => {
-    expect(reactPropsDestructure).toBeDefined();
+  it("should have meta property", () => {
+    expect(reactPropsDestructure.meta).toBeDefined();
+  });
+
+  it("should have create method", () => {
+    expect(typeof reactPropsDestructure.create).toBe("function");
   });
 
   ruleTester.run("react-props-destructure", reactPropsDestructure, {

--- a/src/rules/__tests__/require-explicit-return-type.test.ts
+++ b/src/rules/__tests__/require-explicit-return-type.test.ts
@@ -1,20 +1,15 @@
 import { RuleTester } from "@typescript-eslint/rule-tester";
-import { afterAll, describe, it, expect } from "@jest/globals";
-import parser from "@typescript-eslint/parser";
+import { afterAll, describe, it } from "@jest/globals";
 
 import requireExplicitReturnType from "../require-explicit-return-type";
 
 RuleTester.afterAll = afterAll;
-RuleTester.it = it;
-RuleTester.itOnly = it.only;
 RuleTester.describe = describe;
+RuleTester.it = it;
 
 const ruleTester = new RuleTester({
   languageOptions: {
-    parser,
     parserOptions: {
-      ecmaVersion: 2020,
-      sourceType: "module",
       ecmaFeatures: {
         jsx: true,
       },
@@ -23,8 +18,12 @@ const ruleTester = new RuleTester({
 });
 
 describe("require-explicit-return-type", () => {
-  it("should be defined", () => {
-    expect(requireExplicitReturnType).toBeDefined();
+  it("should have meta property", () => {
+    expect(requireExplicitReturnType.meta).toBeDefined();
+  });
+
+  it("should have create method", () => {
+    expect(typeof requireExplicitReturnType.create).toBe("function");
   });
 
   ruleTester.run("require-explicit-return-type", requireExplicitReturnType, {

--- a/src/rules/__tests__/sort-exports.test.ts
+++ b/src/rules/__tests__/sort-exports.test.ts
@@ -4,26 +4,18 @@ import { afterAll, describe, it } from "@jest/globals";
 import sortExports from "../sort-exports";
 
 RuleTester.afterAll = afterAll;
-RuleTester.it = it;
-RuleTester.itOnly = it.only;
 RuleTester.describe = describe;
+RuleTester.it = it;
 
-const ruleTester = new RuleTester({
-  languageOptions: {
-    parserOptions: {
-      ecmaVersion: 2020,
-      sourceType: "module",
-    },
-  },
-});
+const ruleTester = new RuleTester();
 
 describe("sort-exports", () => {
   it("should have meta property", () => {
-    expect(sortExports).toHaveProperty("meta");
+    expect(sortExports.meta).toBeDefined();
   });
 
-  it("should have create property", () => {
-    expect(sortExports).toHaveProperty("create");
+  it("should have create method", () => {
+    expect(typeof sortExports.create).toBe("function");
   });
 
   ruleTester.run("sort-exports", sortExports, {

--- a/src/rules/__tests__/sort-imports.test.ts
+++ b/src/rules/__tests__/sort-imports.test.ts
@@ -4,26 +4,18 @@ import { afterAll, describe, it } from "@jest/globals";
 import sortImports from "../sort-imports";
 
 RuleTester.afterAll = afterAll;
-RuleTester.it = it;
-RuleTester.itOnly = it.only;
 RuleTester.describe = describe;
+RuleTester.it = it;
 
-const ruleTester = new RuleTester({
-  languageOptions: {
-    parserOptions: {
-      ecmaVersion: 2020,
-      sourceType: "module",
-    },
-  },
-});
+const ruleTester = new RuleTester();
 
 describe("sort-imports", () => {
   it("should have meta property", () => {
-    expect(sortImports).toHaveProperty("meta");
+    expect(sortImports.meta).toBeDefined();
   });
 
-  it("should have create property", () => {
-    expect(sortImports).toHaveProperty("create");
+  it("should have create method", () => {
+    expect(typeof sortImports.create).toBe("function");
   });
 
   ruleTester.run("sort-imports", sortImports, {

--- a/src/rules/__tests__/sort-type-alphabetically.test.ts
+++ b/src/rules/__tests__/sort-type-alphabetically.test.ts
@@ -4,26 +4,18 @@ import { afterAll, describe, it } from "@jest/globals";
 import sortTypeAlphabetically from "../sort-type-alphabetically";
 
 RuleTester.afterAll = afterAll;
-RuleTester.it = it;
-RuleTester.itOnly = it.only;
 RuleTester.describe = describe;
+RuleTester.it = it;
 
-const ruleTester = new RuleTester({
-  languageOptions: {
-    parserOptions: {
-      ecmaVersion: 2020,
-      sourceType: "module",
-    },
-  },
-});
+const ruleTester = new RuleTester();
 
 describe("sort-type-alphabetically", () => {
   it("should have meta property", () => {
-    expect(sortTypeAlphabetically).toHaveProperty("meta");
+    expect(sortTypeAlphabetically.meta).toBeDefined();
   });
 
-  it("should have create property", () => {
-    expect(sortTypeAlphabetically).toHaveProperty("create");
+  it("should have create method", () => {
+    expect(typeof sortTypeAlphabetically.create).toBe("function");
   });
 
   ruleTester.run("sort-type-alphabetically", sortTypeAlphabetically, {

--- a/src/rules/__tests__/sort-type-required-first.test.ts
+++ b/src/rules/__tests__/sort-type-required-first.test.ts
@@ -4,26 +4,18 @@ import { afterAll, describe, it } from "@jest/globals";
 import sortTypeRequiredFirst from "../sort-type-required-first";
 
 RuleTester.afterAll = afterAll;
-RuleTester.it = it;
-RuleTester.itOnly = it.only;
 RuleTester.describe = describe;
+RuleTester.it = it;
 
-const ruleTester = new RuleTester({
-  languageOptions: {
-    parserOptions: {
-      ecmaVersion: 2020,
-      sourceType: "module",
-    },
-  },
-});
+const ruleTester = new RuleTester();
 
 describe("sort-type-required-first", () => {
   it("should have meta property", () => {
-    expect(sortTypeRequiredFirst).toHaveProperty("meta");
+    expect(sortTypeRequiredFirst.meta).toBeDefined();
   });
 
-  it("should have create property", () => {
-    expect(sortTypeRequiredFirst).toHaveProperty("create");
+  it("should have create method", () => {
+    expect(typeof sortTypeRequiredFirst.create).toBe("function");
   });
 
   ruleTester.run("sort-type-required-first", sortTypeRequiredFirst, {

--- a/src/rules/boolean-naming-prefix.ts
+++ b/src/rules/boolean-naming-prefix.ts
@@ -1,4 +1,6 @@
-import { ESLintUtils, AST_NODE_TYPES, type TSESTree } from "@typescript-eslint/utils";
+import { AST_NODE_TYPES, ESLintUtils } from "@typescript-eslint/utils";
+
+import type { TSESTree } from "@typescript-eslint/utils";
 
 const createRule = ESLintUtils.RuleCreator(
   (name) =>

--- a/src/rules/enforce-constant-case.ts
+++ b/src/rules/enforce-constant-case.ts
@@ -1,4 +1,4 @@
-import { ESLintUtils, AST_NODE_TYPES } from "@typescript-eslint/utils";
+import { AST_NODE_TYPES, ESLintUtils } from "@typescript-eslint/utils";
 
 const createRule = ESLintUtils.RuleCreator(
   (name) =>

--- a/src/rules/enforce-curly-newline.ts
+++ b/src/rules/enforce-curly-newline.ts
@@ -1,4 +1,4 @@
-import { ESLintUtils, AST_NODE_TYPES } from "@typescript-eslint/utils";
+import { AST_NODE_TYPES, ESLintUtils } from "@typescript-eslint/utils";
 
 const createRule = ESLintUtils.RuleCreator(
   (name) =>

--- a/src/rules/enforce-hook-naming.ts
+++ b/src/rules/enforce-hook-naming.ts
@@ -1,6 +1,8 @@
 import path from "path";
 
-import { ESLintUtils, TSESTree, AST_NODE_TYPES } from "@typescript-eslint/utils";
+import { AST_NODE_TYPES, ESLintUtils } from "@typescript-eslint/utils";
+
+import type { TSESTree } from "@typescript-eslint/utils";
 
 const createRule = ESLintUtils.RuleCreator(
   (name) =>

--- a/src/rules/enforce-props-suffix.ts
+++ b/src/rules/enforce-props-suffix.ts
@@ -1,6 +1,8 @@
 import path from "path";
 
-import { ESLintUtils, TSESTree, AST_NODE_TYPES } from "@typescript-eslint/utils";
+import { AST_NODE_TYPES, ESLintUtils } from "@typescript-eslint/utils";
+
+import type { TSESTree } from "@typescript-eslint/utils";
 
 const createRule = ESLintUtils.RuleCreator(
   (name) =>

--- a/src/rules/enforce-service-naming.ts
+++ b/src/rules/enforce-service-naming.ts
@@ -1,4 +1,6 @@
-import { ESLintUtils, TSESTree, AST_NODE_TYPES } from "@typescript-eslint/utils";
+import { AST_NODE_TYPES, ESLintUtils } from "@typescript-eslint/utils";
+
+import type { TSESTree } from "@typescript-eslint/utils";
 
 const createRule = ESLintUtils.RuleCreator(
   (name) =>

--- a/src/rules/jsx-no-inline-object-prop.ts
+++ b/src/rules/jsx-no-inline-object-prop.ts
@@ -1,4 +1,4 @@
-import { ESLintUtils, AST_NODE_TYPES } from "@typescript-eslint/utils";
+import { AST_NODE_TYPES, ESLintUtils } from "@typescript-eslint/utils";
 
 const createRule = ESLintUtils.RuleCreator(
   (name) =>

--- a/src/rules/jsx-require-suspense.ts
+++ b/src/rules/jsx-require-suspense.ts
@@ -1,4 +1,6 @@
-import { ESLintUtils, TSESTree, AST_NODE_TYPES } from "@typescript-eslint/utils";
+import { AST_NODE_TYPES, ESLintUtils } from "@typescript-eslint/utils";
+
+import type { TSESTree } from "@typescript-eslint/utils";
 
 const createRule = ESLintUtils.RuleCreator(
   (name) =>

--- a/src/rules/jsx-simple-props.ts
+++ b/src/rules/jsx-simple-props.ts
@@ -1,4 +1,4 @@
-import { ESLintUtils, AST_NODE_TYPES } from "@typescript-eslint/utils";
+import { AST_NODE_TYPES, ESLintUtils } from "@typescript-eslint/utils";
 
 const createRule = ESLintUtils.RuleCreator(
   (name) =>

--- a/src/rules/jsx-sort-props.ts
+++ b/src/rules/jsx-sort-props.ts
@@ -1,4 +1,4 @@
-import { ESLintUtils, AST_NODE_TYPES } from "@typescript-eslint/utils";
+import { AST_NODE_TYPES, ESLintUtils } from "@typescript-eslint/utils";
 
 import type { TSESTree } from "@typescript-eslint/utils";
 

--- a/src/rules/newline-after-multiline-block.ts
+++ b/src/rules/newline-after-multiline-block.ts
@@ -1,4 +1,6 @@
-import { AST_NODE_TYPES, ESLintUtils, TSESTree } from "@typescript-eslint/utils";
+import { AST_NODE_TYPES, ESLintUtils } from "@typescript-eslint/utils";
+
+import type { TSESTree } from "@typescript-eslint/utils";
 
 const createRule = ESLintUtils.RuleCreator(
   (name) =>

--- a/src/rules/newline-before-return.ts
+++ b/src/rules/newline-before-return.ts
@@ -1,4 +1,6 @@
-import { AST_NODE_TYPES, ESLintUtils, TSESTree } from "@typescript-eslint/utils";
+import { AST_NODE_TYPES, ESLintUtils } from "@typescript-eslint/utils";
+
+import type { TSESTree } from "@typescript-eslint/utils";
 
 const createRule = ESLintUtils.RuleCreator(
   (name) =>

--- a/src/rules/nextjs-require-public-env.ts
+++ b/src/rules/nextjs-require-public-env.ts
@@ -1,4 +1,4 @@
-import { ESLintUtils, AST_NODE_TYPES } from "@typescript-eslint/utils";
+import { AST_NODE_TYPES, ESLintUtils } from "@typescript-eslint/utils";
 
 const createRule = ESLintUtils.RuleCreator(
   (name) =>

--- a/src/rules/no-complex-inline-return.ts
+++ b/src/rules/no-complex-inline-return.ts
@@ -1,4 +1,6 @@
-import { ESLintUtils, TSESTree, AST_NODE_TYPES } from "@typescript-eslint/utils";
+import { AST_NODE_TYPES, ESLintUtils } from "@typescript-eslint/utils";
+
+import type { TSESTree } from "@typescript-eslint/utils";
 
 const createRule = ESLintUtils.RuleCreator(
   (name) =>

--- a/src/rules/no-direct-date.ts
+++ b/src/rules/no-direct-date.ts
@@ -1,4 +1,4 @@
-import { ESLintUtils, AST_NODE_TYPES } from "@typescript-eslint/utils";
+import { AST_NODE_TYPES, ESLintUtils } from "@typescript-eslint/utils";
 
 const createRule = ESLintUtils.RuleCreator(
   (name) =>

--- a/src/rules/no-env-fallback.ts
+++ b/src/rules/no-env-fallback.ts
@@ -1,4 +1,6 @@
-import { ESLintUtils, TSESTree, AST_NODE_TYPES } from "@typescript-eslint/utils";
+import { AST_NODE_TYPES, ESLintUtils } from "@typescript-eslint/utils";
+
+import type { TSESTree } from "@typescript-eslint/utils";
 
 const createRule = ESLintUtils.RuleCreator(
   (name) =>

--- a/src/rules/no-inline-default-export.ts
+++ b/src/rules/no-inline-default-export.ts
@@ -1,4 +1,6 @@
-import { ESLintUtils, AST_NODE_TYPES, type TSESTree } from "@typescript-eslint/utils";
+import { AST_NODE_TYPES, ESLintUtils } from "@typescript-eslint/utils";
+
+import type { TSESTree } from "@typescript-eslint/utils";
 
 const createRule = ESLintUtils.RuleCreator(
   (name) =>

--- a/src/rules/no-inline-nested-object.ts
+++ b/src/rules/no-inline-nested-object.ts
@@ -1,4 +1,6 @@
-import { AST_NODE_TYPES, ESLintUtils, TSESTree } from "@typescript-eslint/utils";
+import { AST_NODE_TYPES, ESLintUtils } from "@typescript-eslint/utils";
+
+import type { TSESTree } from "@typescript-eslint/utils";
 
 const createRule = ESLintUtils.RuleCreator(
   (name) =>

--- a/src/rules/no-lazy-identifiers.ts
+++ b/src/rules/no-lazy-identifiers.ts
@@ -1,4 +1,6 @@
-import { ESLintUtils, AST_NODE_TYPES, type TSESTree } from "@typescript-eslint/utils";
+import { AST_NODE_TYPES, ESLintUtils } from "@typescript-eslint/utils";
+
+import type { TSESTree } from "@typescript-eslint/utils";
 
 const createRule = ESLintUtils.RuleCreator(
   (name) =>

--- a/src/rules/no-logic-in-params.ts
+++ b/src/rules/no-logic-in-params.ts
@@ -1,4 +1,6 @@
-import { ESLintUtils, TSESTree, AST_NODE_TYPES } from "@typescript-eslint/utils";
+import { AST_NODE_TYPES, ESLintUtils } from "@typescript-eslint/utils";
+
+import type { TSESTree } from "@typescript-eslint/utils";
 
 const createRule = ESLintUtils.RuleCreator(
   (name) =>

--- a/src/rules/no-nested-ternary.ts
+++ b/src/rules/no-nested-ternary.ts
@@ -1,4 +1,4 @@
-import { ESLintUtils, AST_NODE_TYPES } from "@typescript-eslint/utils";
+import { AST_NODE_TYPES, ESLintUtils } from "@typescript-eslint/utils";
 
 const createRule = ESLintUtils.RuleCreator(
   (name) =>

--- a/src/rules/no-relative-imports.ts
+++ b/src/rules/no-relative-imports.ts
@@ -1,4 +1,6 @@
-import { ESLintUtils, TSESTree, AST_NODE_TYPES } from "@typescript-eslint/utils";
+import { AST_NODE_TYPES, ESLintUtils } from "@typescript-eslint/utils";
+
+import type { TSESTree } from "@typescript-eslint/utils";
 
 const createRule = ESLintUtils.RuleCreator(
   (name) =>

--- a/src/rules/no-single-char-variables.ts
+++ b/src/rules/no-single-char-variables.ts
@@ -1,4 +1,6 @@
-import { ESLintUtils, AST_NODE_TYPES, type TSESTree } from "@typescript-eslint/utils";
+import { AST_NODE_TYPES, ESLintUtils } from "@typescript-eslint/utils";
+
+import type { TSESTree } from "@typescript-eslint/utils";
 
 const createRule = ESLintUtils.RuleCreator(
   (name) =>

--- a/src/rules/prefer-async-await.ts
+++ b/src/rules/prefer-async-await.ts
@@ -1,4 +1,4 @@
-import { ESLintUtils, AST_NODE_TYPES } from "@typescript-eslint/utils";
+import { AST_NODE_TYPES, ESLintUtils } from "@typescript-eslint/utils";
 
 const createRule = ESLintUtils.RuleCreator(
   (name) =>

--- a/src/rules/prefer-function-declaration.ts
+++ b/src/rules/prefer-function-declaration.ts
@@ -1,4 +1,6 @@
-import { ESLintUtils, AST_NODE_TYPES, type TSESTree } from "@typescript-eslint/utils";
+import { AST_NODE_TYPES, ESLintUtils } from "@typescript-eslint/utils";
+
+import type { TSESTree } from "@typescript-eslint/utils";
 
 const createRule = ESLintUtils.RuleCreator(
   (name) =>

--- a/src/rules/prefer-guard-clause.ts
+++ b/src/rules/prefer-guard-clause.ts
@@ -1,4 +1,4 @@
-import { ESLintUtils, AST_NODE_TYPES } from "@typescript-eslint/utils";
+import { AST_NODE_TYPES, ESLintUtils } from "@typescript-eslint/utils";
 
 const createRule = ESLintUtils.RuleCreator(
   (name) =>

--- a/src/rules/require-explicit-return-type.ts
+++ b/src/rules/require-explicit-return-type.ts
@@ -1,4 +1,6 @@
-import { ESLintUtils, AST_NODE_TYPES, type TSESTree } from "@typescript-eslint/utils";
+import { AST_NODE_TYPES, ESLintUtils } from "@typescript-eslint/utils";
+
+import type { TSESTree } from "@typescript-eslint/utils";
 
 const createRule = ESLintUtils.RuleCreator(
   (name) =>


### PR DESCRIPTION
## Summary

- Standardize import patterns across all 51 rule files (separate `import type` for TSESTree)
- Standardize all 51 test files (consistent RuleTester hooks, structural tests, no unused imports)
- Standardize all 49 rule docs (consistent section structure, remove fluff sections like Benefits/Compatibility/Version)
- Sort all imports, rules, and rule sets alphabetically in `src/index.ts`
- Fix incorrect examples in skill docs (jsx-patterns sort order, naming-conventions lazy identifiers)
- Remove non-functional ESLint 8 legacy config section from README
- Update CLAUDE.md with standardized conventions

## Test plan

- [x] All 1160 tests pass
- [x] TypeScript type checking passes
- [x] Build succeeds (CJS + ESM + DTS)
- [x] Lint passes (pre-commit hook)