### PR TITLE
fix(rules): add expression group to jsx-sort-props

### DIFF
--- a/.changeset/jsx-sort-props-expression-group.md
+++ b/.changeset/jsx-sort-props-expression-group.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-nextfriday": minor
+---
+
+Add expression group to jsx-sort-props rule for variable references, member expressions, and other dynamic values

--- a/docs/rules/JSX_SORT_PROPS.md
+++ b/docs/rules/JSX_SORT_PROPS.md
@@ -8,12 +8,13 @@ This rule enforces a consistent ordering of JSX props based on the type of their
 
 1. **String** - String literals and template literals
 2. **Number/Boolean/Null** - Numeric literals, boolean literals, null, and undefined
-3. **Object/Array** - Inline objects and arrays
-4. **Function** - Arrow functions and function expressions
-5. **JSX Element** - JSX elements and fragments
-6. **Shorthand boolean** - Props with no value (e.g., `disabled`)
+3. **Expression** - Variable references, member expressions, call expressions, and other dynamic values
+4. **Object/Array** - Inline objects and arrays
+5. **Function** - Arrow functions and function expressions
+6. **JSX Element** - JSX elements and fragments
+7. **Shorthand boolean** - Props with no value (e.g., `disabled`, `required`)
 
-Props with values that cannot be statically determined (variables, member expressions, call expressions, etc.) are skipped and do not affect the ordering check. Spread attributes (`{...props}`) reset the ordering context.
+Spread attributes (`{...props}`) reset the ordering context.
 
 ### Why?
 
@@ -29,6 +30,7 @@ Props with values that cannot be statically determined (variables, member expres
 <Component disabled title="hello" />
 <Component onClick={() => {}} count={42} />
 <Component icon={<Icon />} style={{ color: "red" }} />
+<Component className="cover" src={src} fill sizes={sizes} />
 ```
 
 ### Correct
@@ -37,6 +39,7 @@ Props with values that cannot be statically determined (variables, member expres
 <Component
   title="hello"
   count={100}
+  src={src}
   style={{ color: "red" }}
   onClick={() => handleClick()}
   icon={<HomeIcon />}
@@ -45,7 +48,7 @@ Props with values that cannot be statically determined (variables, member expres
 
 <Component title="hello" count={42} disabled />
 
-<Component value={someVar} disabled />
+<Component className="cover" src={src} alt={alt} sizes={sizes} fill />
 ```
 
 ## When Not To Use It

--- a/src/rules/__tests__/jsx-sort-props.test.ts
+++ b/src/rules/__tests__/jsx-sort-props.test.ts
@@ -1,5 +1,5 @@
-import { RuleTester } from "@typescript-eslint/rule-tester";
 import { afterAll, describe, it } from "@jest/globals";
+import { RuleTester } from "@typescript-eslint/rule-tester";
 
 import jsxSortProps from "../jsx-sort-props";
 
@@ -29,8 +29,8 @@ describe("jsx-sort-props", () => {
   ruleTester.run("jsx-sort-props", jsxSortProps, {
     valid: [
       {
-        code: `<Component title="hello" count={100} style={{ color: "red" }} onClick={() => {}} icon={<Icon />} disabled />`,
-        name: "should allow correctly ordered props (all 6 groups)",
+        code: `<Component title="hello" count={100} value={someVar} style={{ color: "red" }} onClick={() => {}} icon={<Icon />} disabled />`,
+        name: "should allow correctly ordered props (all 7 groups)",
       },
       {
         code: `<Component title="hello" />`,
@@ -45,8 +45,8 @@ describe("jsx-sort-props", () => {
         name: "should allow multiple number/boolean/null props",
       },
       {
-        code: `<Component title="hello" value={someVar} count={42} />`,
-        name: "should allow unknown types mixed in without affecting order",
+        code: `<Component title="hello" count={42} value={someVar} />`,
+        name: "should allow string before number before expression",
       },
       {
         code: `<Component onClick={() => {}} disabled {...props} title="hello" />`,
@@ -82,15 +82,19 @@ describe("jsx-sort-props", () => {
       },
       {
         code: `<Component title="hello" value={someVar} disabled />`,
-        name: "should skip unknown and check remaining order",
+        name: "should allow string before expression before shorthand",
       },
       {
         code: `<Component disabled {...overrides} title="hello" count={42} />`,
         name: "should allow shorthand before spread then string after spread",
       },
       {
-        code: `<Component title="hello" count={42} items={[1]} onClick={() => {}} icon={<A />} active />`,
-        name: "should allow all six groups in order",
+        code: `<Component title="hello" count={42} value={ref} items={[1]} onClick={() => {}} icon={<A />} active />`,
+        name: "should allow all seven groups in order",
+      },
+      {
+        code: `<Component className="cover" src={src} alt={alt} sizes={sizes} fill />`,
+        name: "should allow expressions before shorthand",
       },
     ],
     invalid: [
@@ -132,6 +136,21 @@ describe("jsx-sort-props", () => {
       {
         code: `<Component items={[1, 2]} count={42} />`,
         name: "should disallow array before number",
+        errors: [{ messageId: "unsortedProps" }],
+      },
+      {
+        code: `<Component className="cover" fill sizes={sizes} />`,
+        name: "should disallow shorthand before expression",
+        errors: [{ messageId: "unsortedProps" }],
+      },
+      {
+        code: `<Component value={someVar} title="hello" />`,
+        name: "should disallow expression before string",
+        errors: [{ messageId: "unsortedProps" }],
+      },
+      {
+        code: `<Component className="cover" src={src} alt={alt} fill sizes={sizes} />`,
+        name: "should disallow expression after shorthand",
         errors: [{ messageId: "unsortedProps" }],
       },
     ],

--- a/src/rules/jsx-sort-props.ts
+++ b/src/rules/jsx-sort-props.ts
@@ -10,10 +10,11 @@ const createRule = ESLintUtils.RuleCreator(
 const TYPE_GROUP = {
   STRING: 1,
   NUMBER_BOOLEAN_NULL: 2,
-  OBJECT_ARRAY: 3,
-  FUNCTION: 4,
-  JSX: 5,
-  SHORTHAND: 6,
+  EXPRESSION: 3,
+  OBJECT_ARRAY: 4,
+  FUNCTION: 5,
+  JSX: 6,
+  SHORTHAND: 7,
 } as const;
 
 const EXPRESSION_TYPE_TO_GROUP = new Map<AST_NODE_TYPES, number>([
@@ -43,7 +44,7 @@ function getExpressionGroup(expression: TSESTree.Expression): number | null {
     return TYPE_GROUP.NUMBER_BOOLEAN_NULL;
   }
 
-  return EXPRESSION_TYPE_TO_GROUP.get(expression.type) ?? null;
+  return EXPRESSION_TYPE_TO_GROUP.get(expression.type) ?? TYPE_GROUP.EXPRESSION;
 }
 
 function getTypeGroup(node: TSESTree.JSXAttribute): number | null {
@@ -100,11 +101,11 @@ const jsxSortProps = createRule({
     type: "suggestion",
     docs: {
       description:
-        "Enforce JSX props are sorted by value type: strings, numbers/booleans, objects/arrays, functions, JSX elements, then shorthand booleans",
+        "Enforce JSX props are sorted by value type: strings, numbers/booleans, expressions, objects/arrays, functions, JSX elements, then shorthand booleans",
     },
     messages: {
       unsortedProps:
-        "JSX props should be sorted by value type: strings, numbers/booleans/null, objects/arrays, functions, JSX elements, then shorthand booleans.",
+        "JSX props should be sorted by value type: strings, numbers/booleans/null, expressions, objects/arrays, functions, JSX elements, then shorthand booleans.",
     },
     schema: [],
   },


### PR DESCRIPTION
## Summary
- Add new `EXPRESSION` type group (group 3) for variable references, member expressions, call expressions, and other dynamic values
- Previously these were skipped (`null`), allowing shorthand props to appear before expressions without error
- Shorthand boolean props are now correctly enforced to always be last

## Test plan
- [x] All 30 jsx-sort-props tests pass (17 valid + 11 invalid + 2 structural)
- [x] Full test suite passes (1164 tests)
- [x] Typecheck passes
- [x] Build succeeds