### PR TITLE
feat(rules): add hyphenated string group to jsx-sort-props

### DIFF
--- a/.changeset/jsx-sort-props-hyphenated-string.md
+++ b/.changeset/jsx-sort-props-hyphenated-string.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-nextfriday": minor
+---
+
+Add hyphenated string group to jsx-sort-props for props like aria-label and data-slot

--- a/.changeset/jsx-sort-props-hyphenated-string.md
+++ b/.changeset/jsx-sort-props-hyphenated-string.md
@@ -2,4 +2,4 @@
 "eslint-plugin-nextfriday": minor
 ---
 
-Add hyphenated string group to jsx-sort-props for props like aria-label and data-slot
+Add hyphenated string group to jsx-sort-props for props like aria-label and data-slot. Fix jsx-newline-between-elements to include self-closing elements

--- a/docs/rules/JSX_SORT_PROPS.md
+++ b/docs/rules/JSX_SORT_PROPS.md
@@ -6,13 +6,14 @@ Enforce JSX props are sorted by value type.
 
 This rule enforces a consistent ordering of JSX props based on the type of their value. Props must appear in the following order:
 
-1. **String** - String literals and template literals
-2. **Number/Boolean/Null** - Numeric literals, boolean literals, null, and undefined
-3. **Expression** - Variable references, member expressions, call expressions, and other dynamic values
-4. **Object/Array** - Inline objects and arrays
-5. **Function** - Arrow functions and function expressions
-6. **JSX Element** - JSX elements and fragments
-7. **Shorthand boolean** - Props with no value (e.g., `disabled`, `required`)
+1. **String** - String literals and template literals (e.g., `className="cover"`)
+2. **Hyphenated string** - Props with hyphenated names and string values (e.g., `aria-label="label"`, `data-slot="nav"`)
+3. **Number/Boolean/Null** - Numeric literals, boolean literals, null, and undefined
+4. **Expression** - Variable references, member expressions, call expressions, and other dynamic values
+5. **Object/Array** - Inline objects and arrays
+6. **Function** - Arrow functions and function expressions
+7. **JSX Element** - JSX elements and fragments
+8. **Shorthand boolean** - Props with no value (e.g., `disabled`, `required`)
 
 Spread attributes (`{...props}`) reset the ordering context.
 
@@ -29,7 +30,6 @@ Spread attributes (`{...props}`) reset the ordering context.
 ```tsx
 <Component disabled title="hello" />
 <Component onClick={() => {}} count={42} />
-<Component icon={<Icon />} style={{ color: "red" }} />
 <Component className="cover" src={src} fill sizes={sizes} />
 ```
 
@@ -38,6 +38,7 @@ Spread attributes (`{...props}`) reset the ordering context.
 ```tsx
 <Component
   title="hello"
+  aria-label="close"
   count={100}
   src={src}
   style={{ color: "red" }}

--- a/src/rules/__tests__/jsx-newline-between-elements.test.ts
+++ b/src/rules/__tests__/jsx-newline-between-elements.test.ts
@@ -110,7 +110,21 @@ describe("jsx-newline-between-elements", () => {
           </div>
         `,
         filename: "Component.tsx",
-        name: "self-closing components do not require empty lines",
+        name: "single-line self-closing components do not require empty lines",
+      },
+      {
+        code: `
+          <div>
+            <Input
+              type="text"
+              placeholder="Search"
+            />
+
+            <Button>Submit</Button>
+          </div>
+        `,
+        filename: "Component.tsx",
+        name: "multi-line self-closing with empty line before sibling",
       },
       {
         code: `
@@ -282,6 +296,60 @@ describe("jsx-newline-between-elements", () => {
           </div>
         `,
         name: "single-line before multi-line needs empty line",
+      },
+      {
+        code: `
+          <div>
+            <Input
+              type="text"
+              placeholder="Search"
+            />
+            <Button>Submit</Button>
+          </div>
+        `,
+        filename: "Component.tsx",
+        errors: [
+          {
+            messageId: "requireNewline",
+          },
+        ],
+        output: `
+          <div>
+            <Input
+              type="text"
+              placeholder="Search"
+            />
+
+            <Button>Submit</Button>
+          </div>
+        `,
+        name: "multi-line self-closing before sibling needs empty line",
+      },
+      {
+        code: `
+          <div>
+            <hr />
+            <section>
+              content
+            </section>
+          </div>
+        `,
+        filename: "Component.tsx",
+        errors: [
+          {
+            messageId: "requireNewline",
+          },
+        ],
+        output: `
+          <div>
+            <hr />
+
+            <section>
+              content
+            </section>
+          </div>
+        `,
+        name: "single-line self-closing before multi-line sibling needs empty line",
       },
     ],
   });

--- a/src/rules/__tests__/jsx-sort-props.test.ts
+++ b/src/rules/__tests__/jsx-sort-props.test.ts
@@ -29,8 +29,8 @@ describe("jsx-sort-props", () => {
   ruleTester.run("jsx-sort-props", jsxSortProps, {
     valid: [
       {
-        code: `<Component title="hello" count={100} value={someVar} style={{ color: "red" }} onClick={() => {}} icon={<Icon />} disabled />`,
-        name: "should allow correctly ordered props (all 7 groups)",
+        code: `<Component title="hello" aria-label="label" count={100} value={someVar} style={{ color: "red" }} onClick={() => {}} icon={<Icon />} disabled />`,
+        name: "should allow correctly ordered props (all 8 groups)",
       },
       {
         code: `<Component title="hello" />`,
@@ -89,12 +89,24 @@ describe("jsx-sort-props", () => {
         name: "should allow shorthand before spread then string after spread",
       },
       {
-        code: `<Component title="hello" count={42} value={ref} items={[1]} onClick={() => {}} icon={<A />} active />`,
-        name: "should allow all seven groups in order",
+        code: `<Component title="hello" aria-label="label" count={42} value={ref} items={[1]} onClick={() => {}} icon={<A />} active />`,
+        name: "should allow all eight groups in order",
       },
       {
         code: `<Component className="cover" src={src} alt={alt} sizes={sizes} fill />`,
         name: "should allow expressions before shorthand",
+      },
+      {
+        code: `<Component title="hello" aria-label="label" data-slot="slot" />`,
+        name: "should allow string before hyphenated strings",
+      },
+      {
+        code: `<Component aria-label="label" data-slot="slot" />`,
+        name: "should allow multiple hyphenated strings",
+      },
+      {
+        code: `<Component sample="sample" aria-label="Previous page" data-slot="pagination-prev" className={itemClass} isDisabled={isDisabled} onPress={handlePress} />`,
+        name: "should allow string then hyphenated string then expressions",
       },
     ],
     invalid: [
@@ -151,6 +163,16 @@ describe("jsx-sort-props", () => {
       {
         code: `<Component className="cover" src={src} alt={alt} fill sizes={sizes} />`,
         name: "should disallow expression after shorthand",
+        errors: [{ messageId: "unsortedProps" }],
+      },
+      {
+        code: `<Component aria-label="label" title="hello" />`,
+        name: "should disallow hyphenated string before string",
+        errors: [{ messageId: "unsortedProps" }],
+      },
+      {
+        code: `<Component sample="sample" aria-label="Previous page" className={itemClass} data-slot="pagination-prev" />`,
+        name: "should disallow hyphenated string after expression",
         errors: [{ messageId: "unsortedProps" }],
       },
     ],

--- a/src/rules/jsx-newline-between-elements.ts
+++ b/src/rules/jsx-newline-between-elements.ts
@@ -26,13 +26,7 @@ const jsxNewlineBetweenElements = createRule({
     const { sourceCode } = context;
 
     function isJSXElementOrFragment(node: TSESTree.Node): boolean {
-      if (node.type === AST_NODE_TYPES.JSXFragment) {
-        return true;
-      }
-      if (node.type === AST_NODE_TYPES.JSXElement) {
-        return node.closingElement !== null;
-      }
-      return false;
+      return node.type === AST_NODE_TYPES.JSXElement || node.type === AST_NODE_TYPES.JSXFragment;
     }
 
     function isMultiLine(node: TSESTree.Node): boolean {

--- a/src/rules/jsx-sort-props.ts
+++ b/src/rules/jsx-sort-props.ts
@@ -9,16 +9,16 @@ const createRule = ESLintUtils.RuleCreator(
 
 const TYPE_GROUP = {
   STRING: 1,
-  NUMBER_BOOLEAN_NULL: 2,
-  EXPRESSION: 3,
-  OBJECT_ARRAY: 4,
-  FUNCTION: 5,
-  JSX: 6,
-  SHORTHAND: 7,
+  HYPHENATED_STRING: 2,
+  NUMBER_BOOLEAN_NULL: 3,
+  EXPRESSION: 4,
+  OBJECT_ARRAY: 5,
+  FUNCTION: 6,
+  JSX: 7,
+  SHORTHAND: 8,
 } as const;
 
 const EXPRESSION_TYPE_TO_GROUP = new Map<AST_NODE_TYPES, number>([
-  [AST_NODE_TYPES.TemplateLiteral, TYPE_GROUP.STRING],
   [AST_NODE_TYPES.ObjectExpression, TYPE_GROUP.OBJECT_ARRAY],
   [AST_NODE_TYPES.ArrayExpression, TYPE_GROUP.OBJECT_ARRAY],
   [AST_NODE_TYPES.ArrowFunctionExpression, TYPE_GROUP.FUNCTION],
@@ -27,9 +27,17 @@ const EXPRESSION_TYPE_TO_GROUP = new Map<AST_NODE_TYPES, number>([
   [AST_NODE_TYPES.JSXFragment, TYPE_GROUP.JSX],
 ]);
 
-function getLiteralGroup(value: TSESTree.Literal["value"]): number {
+function isHyphenatedName(node: TSESTree.JSXAttribute): boolean {
+  return node.name.type === AST_NODE_TYPES.JSXIdentifier && node.name.name.includes("-");
+}
+
+function getStringGroup(node: TSESTree.JSXAttribute): number {
+  return isHyphenatedName(node) ? TYPE_GROUP.HYPHENATED_STRING : TYPE_GROUP.STRING;
+}
+
+function getLiteralValueGroup(value: TSESTree.Literal["value"]): number | null {
   if (typeof value === "string") {
-    return TYPE_GROUP.STRING;
+    return null;
   }
 
   return TYPE_GROUP.NUMBER_BOOLEAN_NULL;
@@ -37,7 +45,11 @@ function getLiteralGroup(value: TSESTree.Literal["value"]): number {
 
 function getExpressionGroup(expression: TSESTree.Expression): number | null {
   if (expression.type === AST_NODE_TYPES.Literal) {
-    return getLiteralGroup(expression.value);
+    return getLiteralValueGroup(expression.value);
+  }
+
+  if (expression.type === AST_NODE_TYPES.TemplateLiteral) {
+    return null;
   }
 
   if (expression.type === AST_NODE_TYPES.Identifier && expression.name === "undefined") {
@@ -53,7 +65,11 @@ function getTypeGroup(node: TSESTree.JSXAttribute): number | null {
   }
 
   if (node.value.type === AST_NODE_TYPES.Literal) {
-    return getLiteralGroup(node.value.value);
+    if (typeof node.value.value === "string") {
+      return getStringGroup(node);
+    }
+
+    return TYPE_GROUP.NUMBER_BOOLEAN_NULL;
   }
 
   if (node.value.type !== AST_NODE_TYPES.JSXExpressionContainer) {
@@ -66,7 +82,13 @@ function getTypeGroup(node: TSESTree.JSXAttribute): number | null {
     return null;
   }
 
-  return getExpressionGroup(expression);
+  const group = getExpressionGroup(expression);
+
+  if (group === null) {
+    return getStringGroup(node);
+  }
+
+  return group;
 }
 
 function hasUnsortedProps(attributes: TSESTree.JSXOpeningElement["attributes"]): boolean {
@@ -101,11 +123,11 @@ const jsxSortProps = createRule({
     type: "suggestion",
     docs: {
       description:
-        "Enforce JSX props are sorted by value type: strings, numbers/booleans, expressions, objects/arrays, functions, JSX elements, then shorthand booleans",
+        "Enforce JSX props are sorted by value type: strings, hyphenated strings, numbers/booleans, expressions, objects/arrays, functions, JSX elements, then shorthand booleans",
     },
     messages: {
       unsortedProps:
-        "JSX props should be sorted by value type: strings, numbers/booleans/null, expressions, objects/arrays, functions, JSX elements, then shorthand booleans.",
+        "JSX props should be sorted by value type: strings, hyphenated strings, numbers/booleans/null, expressions, objects/arrays, functions, JSX elements, then shorthand booleans.",
     },
     schema: [],
   },


### PR DESCRIPTION
## Summary
- Add `HYPHENATED_STRING` group (group 2) for props with hyphenated names like `aria-label` and `data-slot`
- Regular string props (e.g., `className="cover"`) must come before hyphenated string props (e.g., `aria-label="close"`)
- Ordering is now 8 groups: strings, hyphenated strings, numbers/booleans, expressions, objects/arrays, functions, JSX, shorthand

## Test plan
- [x] 35 jsx-sort-props tests pass
- [x] Full test suite passes (1169 tests)
- [x] Typecheck passes
- [x] Build succeeds