### PR TITLE
feat(rules): add jsx-no-ternary-null rule

### DIFF
--- a/.changeset/jsx-no-ternary-null.md
+++ b/.changeset/jsx-no-ternary-null.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-nextfriday": minor
+---
+
+Add jsx-no-ternary-null rule to enforce logical AND over ternary with null/undefined in JSX

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ pnpm changeset           # Create a changeset for version bumping
 `src/index.ts` - Main plugin export containing:
 
 - `meta` - Plugin name and version from package.json
-- `rules` - All 51 rule implementations keyed by hyphenated name
+- `rules` - All 52 rule implementations keyed by hyphenated name
 - `configs` - Eight configuration presets (six nextfriday presets via `createConfig()`, plus lazy `sonarjs` and `unicorn` getters that wrap external plugins)
 
 The plugin is exported both as default and as named exports `{ meta, configs, rules }`.
@@ -44,8 +44,8 @@ Eight configs total. Six nextfriday presets built from three rule set tiers, eac
 | Preset                          | Rules                             | Severity     |
 | ------------------------------- | --------------------------------- | ------------ |
 | `base` / `base/recommended`     | 36 base                           | warn / error |
-| `react` / `react/recommended`   | 36 base + 14 JSX                  | warn / error |
-| `nextjs` / `nextjs/recommended` | 36 base + 14 JSX + 1 nextjs       | warn / error |
+| `react` / `react/recommended`   | 36 base + 15 JSX                  | warn / error |
+| `nextjs` / `nextjs/recommended` | 36 base + 15 JSX + 1 nextjs       | warn / error |
 | `sonarjs`                       | eslint-plugin-sonarjs recommended | -            |
 | `unicorn`                       | eslint-plugin-unicorn recommended | -            |
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ export default [
       "nextfriday/jsx-no-inline-object-prop": "error",
       "nextfriday/jsx-no-newline-single-line-elements": "error",
       "nextfriday/jsx-no-non-component-function": "error",
+      "nextfriday/jsx-no-ternary-null": "error",
       "nextfriday/jsx-no-variable-in-callback": "error",
       "nextfriday/jsx-require-suspense": "error",
       "nextfriday/jsx-simple-props": "error",
@@ -217,6 +218,7 @@ export default [
 | [jsx-no-inline-object-prop](docs/rules/JSX_NO_INLINE_OBJECT_PROP.md)                     | Disallow inline object literals in JSX props                          | ❌      |
 | [jsx-no-newline-single-line-elements](docs/rules/JSX_NO_NEWLINE_SINGLE_LINE_ELEMENTS.md) | Disallow empty lines between single-line sibling JSX elements         | ✅      |
 | [jsx-no-non-component-function](docs/rules/JSX_NO_NON_COMPONENT_FUNCTION.md)             | Disallow non-component functions at top level in .tsx/.jsx files      | ❌      |
+| [jsx-no-ternary-null](docs/rules/JSX_NO_TERNARY_NULL.md)                                 | Enforce logical AND over ternary with null/undefined in JSX           | ✅      |
 | [jsx-no-variable-in-callback](docs/rules/JSX_NO_VARIABLE_IN_CALLBACK.md)                 | Disallow variable declarations inside callback functions in JSX       | ❌      |
 | [jsx-require-suspense](docs/rules/JSX_REQUIRE_SUSPENSE.md)                               | Require lazy-loaded components to be wrapped in Suspense              | ❌      |
 | [jsx-simple-props](docs/rules/JSX_SIMPLE_PROPS.md)                                       | Enforce simple prop values (strings, variables, callbacks, ReactNode) | ❌      |
@@ -240,10 +242,10 @@ export default [
 | -------------------- | -------- | ---------- | --------- | ------------- | ----------- |
 | `base`               | warn     | 36         | 0         | 0             | 36          |
 | `base/recommended`   | error    | 36         | 0         | 0             | 36          |
-| `react`              | warn     | 36         | 14        | 0             | 50          |
-| `react/recommended`  | error    | 36         | 14        | 0             | 50          |
-| `nextjs`             | warn     | 36         | 14        | 1             | 51          |
-| `nextjs/recommended` | error    | 36         | 14        | 1             | 51          |
+| `react`              | warn     | 36         | 15        | 0             | 51          |
+| `react/recommended`  | error    | 36         | 15        | 0             | 51          |
+| `nextjs`             | warn     | 36         | 15        | 1             | 52          |
+| `nextjs/recommended` | error    | 36         | 15        | 1             | 52          |
 
 ### Base Configuration Rules (36 rules)
 
@@ -286,7 +288,7 @@ Included in `base`, `base/recommended`, and all other presets:
 - `nextfriday/sort-type-alphabetically`
 - `nextfriday/sort-type-required-first`
 
-### JSX Rules (14 rules)
+### JSX Rules (15 rules)
 
 Additionally included in `react`, `react/recommended`, `nextjs`, `nextjs/recommended`:
 
@@ -296,6 +298,7 @@ Additionally included in `react`, `react/recommended`, `nextjs`, `nextjs/recomme
 - `nextfriday/jsx-no-inline-object-prop`
 - `nextfriday/jsx-no-newline-single-line-elements`
 - `nextfriday/jsx-no-non-component-function`
+- `nextfriday/jsx-no-ternary-null`
 - `nextfriday/jsx-no-variable-in-callback`
 - `nextfriday/jsx-pascal-case`
 - `nextfriday/jsx-require-suspense`
@@ -329,7 +332,7 @@ Additionally included in `nextjs`, `nextjs/recommended` only:
 
 ## Agent Skill
 
-This plugin ships with an [Agent Skill](https://github.com/anthropics/skills) that teaches AI coding assistants (Claude Code, Cursor, etc.) all 51 rules so they generate compliant code from the start.
+This plugin ships with an [Agent Skill](https://github.com/anthropics/skills) that teaches AI coding assistants (Claude Code, Cursor, etc.) all 52 rules so they generate compliant code from the start.
 
 ```bash
 npx skills add next-friday/eslint-plugin-nextfriday --skill eslint-plugin-nextfriday

--- a/docs/rules/JSX_NO_TERNARY_NULL.md
+++ b/docs/rules/JSX_NO_TERNARY_NULL.md
@@ -1,0 +1,42 @@
+# jsx-no-ternary-null
+
+Enforce logical AND over ternary with null/undefined in JSX expressions.
+
+> This rule is auto-fixable using `--fix`.
+
+## Rule Details
+
+This rule flags ternary expressions inside JSX where one branch is `null` or `undefined`. These patterns are better expressed using the logical AND (`&&`) operator, which is more concise and idiomatic in React.
+
+### Why?
+
+- **Readability**: `{condition && <Component />}` is cleaner than `{condition ? <Component /> : null}`
+- **Consistency**: Encourages a single pattern for conditional rendering
+- **Conciseness**: Removes unnecessary null/undefined branches
+
+## Examples
+
+### Incorrect
+
+```tsx
+<div>{condition ? <span>Hello</span> : null}</div>
+<div>{condition ? <Component /> : undefined}</div>
+<div>{condition ? null : <span>Fallback</span>}</div>
+```
+
+### Correct
+
+```tsx
+<div>{condition && <span>Hello</span>}</div>
+<div>{condition && <Component />}</div>
+<div>{!condition && <span>Fallback</span>}</div>
+<div>{condition ? <A /> : <B />}</div>
+```
+
+## When Not To Use It
+
+If your team prefers explicit ternary expressions for conditional rendering, even when one branch is null or undefined.
+
+## Related Rules
+
+- [no-nested-ternary](JSX_NO_TERNARY_NULL.md)

--- a/skills/eslint-plugin-nextfriday/SKILL.md
+++ b/skills/eslint-plugin-nextfriday/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: eslint-plugin-nextfriday
-description: Code patterns for projects using eslint-plugin-nextfriday (51 rules covering naming, style, types, JSX, imports, and formatting)
+description: Code patterns for projects using eslint-plugin-nextfriday (52 rules covering naming, style, types, JSX, imports, and formatting)
 user-invocable: false
 ---
 

--- a/skills/eslint-plugin-nextfriday/complete-examples.md
+++ b/skills/eslint-plugin-nextfriday/complete-examples.md
@@ -1,6 +1,6 @@
 # Complete Examples
 
-These are full file examples that pass ALL 51 eslint-plugin-nextfriday rules with zero errors. Use these as templates when generating code.
+These are full file examples that pass ALL 52 eslint-plugin-nextfriday rules with zero errors. Use these as templates when generating code.
 
 ## React Component File (`UserProfile.tsx`)
 

--- a/skills/eslint-plugin-nextfriday/jsx-patterns.md
+++ b/skills/eslint-plugin-nextfriday/jsx-patterns.md
@@ -110,6 +110,20 @@ Use template literals instead of mixing text and JSX expressions.
 <p>{`Hello ${name}, welcome!`}</p>
 ```
 
+## Logical AND Over Ternary with Null
+
+Use `&&` instead of ternary when one branch is `null` or `undefined`.
+
+```tsx
+// Bad
+<div>{condition ? <span>Hello</span> : null}</div>
+<div>{condition ? <Component /> : undefined}</div>
+
+// Good
+<div>{condition && <span>Hello</span>}</div>
+<div>{!condition && <span>Fallback</span>}</div>
+```
+
 ## JSX Props Sort Order
 
 Sort JSX props by value type in this order:

--- a/src/__tests__/rules.test.ts
+++ b/src/__tests__/rules.test.ts
@@ -96,8 +96,8 @@ describe("ESLint Plugin Rules", () => {
     expect(typeof rules["no-env-fallback"].create).toBe("function");
   });
 
-  it("should have exactly 51 rules", () => {
-    expect(Object.keys(rules)).toHaveLength(51);
+  it("should have exactly 52 rules", () => {
+    expect(Object.keys(rules)).toHaveLength(52);
   });
 
   it("should have correct rule names", () => {
@@ -111,6 +111,7 @@ describe("ESLint Plugin Rules", () => {
     expect(ruleNames).toContain("jsx-simple-props");
     expect(ruleNames).toContain("jsx-no-newline-single-line-elements");
     expect(ruleNames).toContain("jsx-no-non-component-function");
+    expect(ruleNames).toContain("jsx-no-ternary-null");
     expect(ruleNames).toContain("jsx-no-variable-in-callback");
     expect(ruleNames).toContain("md-filename-case-restriction");
     expect(ruleNames).toContain("prefer-destructuring-params");

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import jsxNewlineBetweenElements from "./rules/jsx-newline-between-elements";
 import jsxNoInlineObjectProp from "./rules/jsx-no-inline-object-prop";
 import jsxNoNewlineSingleLineElements from "./rules/jsx-no-newline-single-line-elements";
 import jsxNoNonComponentFunction from "./rules/jsx-no-non-component-function";
+import jsxNoTernaryNull from "./rules/jsx-no-ternary-null";
 import jsxNoVariableInCallback from "./rules/jsx-no-variable-in-callback";
 import jsxPascalCase from "./rules/jsx-pascal-case";
 import jsxRequireSuspense from "./rules/jsx-require-suspense";
@@ -82,6 +83,7 @@ const rules = {
   "jsx-no-inline-object-prop": jsxNoInlineObjectProp,
   "jsx-no-newline-single-line-elements": jsxNoNewlineSingleLineElements,
   "jsx-no-non-component-function": jsxNoNonComponentFunction,
+  "jsx-no-ternary-null": jsxNoTernaryNull,
   "jsx-no-variable-in-callback": jsxNoVariableInCallback,
   "jsx-pascal-case": jsxPascalCase,
   "jsx-require-suspense": jsxRequireSuspense,
@@ -211,6 +213,7 @@ const jsxRules = {
   "nextfriday/jsx-no-inline-object-prop": "warn",
   "nextfriday/jsx-no-newline-single-line-elements": "warn",
   "nextfriday/jsx-no-non-component-function": "warn",
+  "nextfriday/jsx-no-ternary-null": "warn",
   "nextfriday/jsx-no-variable-in-callback": "warn",
   "nextfriday/jsx-pascal-case": "warn",
   "nextfriday/jsx-require-suspense": "warn",
@@ -228,6 +231,7 @@ const jsxRecommendedRules = {
   "nextfriday/jsx-no-inline-object-prop": "error",
   "nextfriday/jsx-no-newline-single-line-elements": "error",
   "nextfriday/jsx-no-non-component-function": "error",
+  "nextfriday/jsx-no-ternary-null": "error",
   "nextfriday/jsx-no-variable-in-callback": "error",
   "nextfriday/jsx-pascal-case": "error",
   "nextfriday/jsx-require-suspense": "error",

--- a/src/rules/__tests__/jsx-no-ternary-null.test.ts
+++ b/src/rules/__tests__/jsx-no-ternary-null.test.ts
@@ -1,0 +1,111 @@
+import { afterAll, describe, it } from "@jest/globals";
+import { RuleTester } from "@typescript-eslint/rule-tester";
+
+import rule from "../jsx-no-ternary-null";
+
+RuleTester.afterAll = afterAll;
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parserOptions: {
+      ecmaFeatures: {
+        jsx: true,
+      },
+    },
+  },
+});
+
+describe("jsx-no-ternary-null", () => {
+  it("should have meta property", () => {
+    expect(rule.meta).toBeDefined();
+  });
+
+  it("should have create method", () => {
+    expect(typeof rule.create).toBe("function");
+  });
+
+  ruleTester.run("jsx-no-ternary-null", rule, {
+    valid: [
+      {
+        code: "<div>{isVisible && <span>Hello</span>}</div>",
+        name: "logical AND pattern",
+      },
+      {
+        code: "<div>{isActive && <Component />}</div>",
+        name: "logical AND with component",
+      },
+      {
+        code: "<div>{condition ? <A /> : <B />}</div>",
+        name: "ternary with two JSX branches",
+      },
+      {
+        code: '<div>{condition ? "yes" : "no"}</div>',
+        name: "ternary with two string branches",
+      },
+      {
+        code: "const x = condition ? value : null;",
+        name: "ternary outside JSX",
+      },
+      {
+        code: "<div>{value}</div>",
+        name: "simple expression",
+      },
+      {
+        code: "<div>{condition ? <A /> : false}</div>",
+        name: "ternary with false alternate",
+      },
+    ],
+    invalid: [
+      {
+        code: "<div>{condition ? <span>Hello</span> : null}</div>",
+        errors: [{ messageId: "preferLogicalAnd" }],
+        output: "<div>{condition && (<span>Hello</span>)}</div>",
+        name: "ternary with null alternate",
+      },
+      {
+        code: "<div>{condition ? <Component /> : null}</div>",
+        errors: [{ messageId: "preferLogicalAnd" }],
+        output: "<div>{condition && (<Component />)}</div>",
+        name: "ternary with null alternate and component",
+      },
+      {
+        code: "<div>{condition ? <span>Hello</span> : undefined}</div>",
+        errors: [{ messageId: "preferLogicalAnd" }],
+        output: "<div>{condition && (<span>Hello</span>)}</div>",
+        name: "ternary with undefined alternate",
+      },
+      {
+        code: "<div>{null ? <span>Hello</span> : null}</div>",
+        errors: [{ messageId: "preferLogicalAnd" }],
+        output: "<div>{null && (<span>Hello</span>)}</div>",
+        name: "null test with null alternate",
+      },
+      {
+        code: `<div>{branch ? (
+        <div className="flex items-center gap-x-4">
+          <span>{branch}</span>
+        </div>
+      ) : null}</div>`,
+        errors: [{ messageId: "preferLogicalAnd" }],
+        output: `<div>{branch && (<div className="flex items-center gap-x-4">
+          <span>{branch}</span>
+        </div>)}</div>`,
+        name: "multiline ternary with null alternate",
+      },
+      {
+        code: "<div>{null ? null : <span>Fallback</span>}</div>",
+        errors: [{ messageId: "preferLogicalAnd" }],
+        output: "<div>{!null && (<span>Fallback</span>)}</div>",
+        name: "null consequent with JSX alternate",
+      },
+      {
+        code: "<div>{undefined ? null : <span>Fallback</span>}</div>",
+        errors: [{ messageId: "preferLogicalAnd" }],
+        output: "<div>{!undefined && (<span>Fallback</span>)}</div>",
+        name: "undefined consequent with JSX alternate",
+      },
+    ],
+  });
+});

--- a/src/rules/jsx-no-ternary-null.ts
+++ b/src/rules/jsx-no-ternary-null.ts
@@ -1,0 +1,75 @@
+import { AST_NODE_TYPES, ESLintUtils } from "@typescript-eslint/utils";
+
+import type { TSESTree } from "@typescript-eslint/utils";
+
+const createRule = ESLintUtils.RuleCreator(
+  (name) =>
+    `https://github.com/next-friday/eslint-plugin-nextfriday/blob/main/docs/rules/${name.replaceAll("-", "_").toUpperCase()}.md`,
+);
+
+function isNullOrUndefined(node: TSESTree.Node): boolean {
+  if (node.type === AST_NODE_TYPES.Literal && node.value === null) {
+    return true;
+  }
+
+  if (node.type === AST_NODE_TYPES.Identifier && node.name === "undefined") {
+    return true;
+  }
+
+  return false;
+}
+
+const jsxNoTernaryNull = createRule({
+  name: "jsx-no-ternary-null",
+  meta: {
+    type: "suggestion",
+    docs: {
+      description: "Enforce logical AND over ternary with null/undefined in JSX expressions",
+    },
+    fixable: "code",
+    schema: [],
+    messages: {
+      preferLogicalAnd: "Use logical AND (&&) instead of ternary with null/undefined",
+    },
+  },
+  defaultOptions: [],
+  create(context) {
+    return {
+      JSXExpressionContainer(node: TSESTree.JSXExpressionContainer) {
+        const { expression } = node;
+
+        if (expression.type !== AST_NODE_TYPES.ConditionalExpression) {
+          return;
+        }
+
+        const { test, consequent, alternate } = expression;
+
+        if (isNullOrUndefined(alternate)) {
+          const testText = context.sourceCode.getText(test);
+          const consequentText = context.sourceCode.getText(consequent);
+
+          context.report({
+            node: expression,
+            messageId: "preferLogicalAnd",
+            fix(fixer) {
+              return fixer.replaceText(expression, `${testText} && (${consequentText})`);
+            },
+          });
+        } else if (isNullOrUndefined(consequent)) {
+          const testText = context.sourceCode.getText(test);
+          const alternateText = context.sourceCode.getText(alternate);
+
+          context.report({
+            node: expression,
+            messageId: "preferLogicalAnd",
+            fix(fixer) {
+              return fixer.replaceText(expression, `!${testText} && (${alternateText})`);
+            },
+          });
+        }
+      },
+    };
+  },
+});
+
+export default jsxNoTernaryNull;


### PR DESCRIPTION
## Summary

Add `jsx-no-ternary-null` rule that enforces logical AND (`&&`) over ternary expressions with `null`/`undefined` in JSX.

## Type of Change

- [x] New feature

## Changes Made

- Add `jsx-no-ternary-null` rule implementation with auto-fix support
- Add rule tests (7 valid, 7 invalid cases)
- Register rule in `src/index.ts` (rules object, jsxRules, jsxRecommendedRules)
- Add rule documentation at `docs/rules/JSX_NO_TERNARY_NULL.md`
- Update integration test (rule count 51 to 52, add rule name assertion)
- Update README (rules table, manual config, config preset counts, JSX rules list)
- Update CLAUDE.md (rule count, JSX count)
- Update agent skill files (SKILL.md, jsx-patterns.md, complete-examples.md)
- Add changeset

## Testing

- [x] Unit tests pass
- [x] Manual testing completed
- [x] Added/updated tests for new functionality