### PR TITLE
feat(rules): add new rules and improve constant case handling

### DIFF
--- a/.changeset/constant-case-improvements.md
+++ b/.changeset/constant-case-improvements.md
@@ -1,0 +1,10 @@
+---
+"eslint-plugin-nextfriday": minor
+---
+
+feat(rules): add no-misleading-constant-case rule and improve enforce-constant-case
+
+- Add `no-misleading-constant-case` rule that disallows SCREAMING_SNAKE_CASE for mutable bindings (let/var) and non-static values (function calls, objects, arrays, dynamic templates, computed expressions)
+- Add `prefer-inline-type-export` rule that requires type/interface declarations to be exported inline
+- Update `enforce-constant-case` to exempt booleans with standard prefixes (is, has, should, etc.) to resolve conflict with `boolean-naming-prefix`
+- Update existing rules: enforce-constant-case, jsx-newline-between-elements, no-lazy-identifiers

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ pnpm changeset           # Create a changeset for version bumping
 `src/index.ts` - Main plugin export containing:
 
 - `meta` - Plugin name and version from package.json
-- `rules` - All 52 rule implementations keyed by hyphenated name
+- `rules` - All 54 rule implementations keyed by hyphenated name
 - `configs` - Eight configuration presets (six nextfriday presets via `createConfig()`, plus lazy `sonarjs` and `unicorn` getters that wrap external plugins)
 
 The plugin is exported both as default and as named exports `{ meta, configs, rules }`.
@@ -43,9 +43,9 @@ Eight configs total. Six nextfriday presets built from three rule set tiers, eac
 
 | Preset                          | Rules                             | Severity     |
 | ------------------------------- | --------------------------------- | ------------ |
-| `base` / `base/recommended`     | 36 base                           | warn / error |
-| `react` / `react/recommended`   | 36 base + 15 JSX                  | warn / error |
-| `nextjs` / `nextjs/recommended` | 36 base + 15 JSX + 1 nextjs       | warn / error |
+| `base` / `base/recommended`     | 38 base                           | warn / error |
+| `react` / `react/recommended`   | 38 base + 15 JSX                  | warn / error |
+| `nextjs` / `nextjs/recommended` | 38 base + 15 JSX + 1 nextjs       | warn / error |
 | `sonarjs`                       | eslint-plugin-sonarjs recommended | -            |
 | `unicorn`                       | eslint-plugin-unicorn recommended | -            |
 
@@ -137,7 +137,7 @@ Commits are validated by commitlint (conventional commits). Requirements:
 - Subject: max 50 chars, must not start with uppercase
 - Types: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`
 
-Git hooks (husky): `pre-commit` runs lint-staged, `pre-push` runs tests + typecheck + build, `commit-msg` runs commitlint.
+Git hooks (husky): `pre-commit` runs lint-staged, `pre-push` runs `test:coverage` + typecheck + build, `commit-msg` runs commitlint.
 
 ## CI Requirements
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ export default [
       "nextfriday/no-nested-interface-declaration": "error",
       "nextfriday/prefer-named-param-types": "error",
       "nextfriday/prefer-inline-literal-union": "error",
+      "nextfriday/prefer-inline-type-export": "error",
       "nextfriday/prefer-interface-over-inline-types": "error",
       "nextfriday/sort-type-alphabetically": "error",
       "nextfriday/sort-type-required-first": "error",
@@ -149,12 +150,13 @@ export default [
 
 ### Variable Naming Rules
 
-| Rule                                                               | Description                                                           | Fixable |
-| ------------------------------------------------------------------ | --------------------------------------------------------------------- | ------- |
-| [no-single-char-variables](docs/rules/NO_SINGLE_CHAR_VARIABLES.md) | Disallow single character variable names (e.g., `d`, `u`, `l`)        | ❌      |
-| [no-lazy-identifiers](docs/rules/NO_LAZY_IDENTIFIERS.md)           | Disallow lazy identifiers like `xxx`, `asdf`, `qwerty`                | ❌      |
-| [boolean-naming-prefix](docs/rules/BOOLEAN_NAMING_PREFIX.md)       | Enforce boolean variables to have prefix (is, has, should, can, etc.) | ❌      |
-| [enforce-constant-case](docs/rules/ENFORCE_CONSTANT_CASE.md)       | Enforce SCREAMING_SNAKE_CASE for constant primitive values            | ❌      |
+| Rule                                                                     | Description                                                           | Fixable |
+| ------------------------------------------------------------------------ | --------------------------------------------------------------------- | ------- |
+| [no-single-char-variables](docs/rules/NO_SINGLE_CHAR_VARIABLES.md)       | Disallow single character variable names (e.g., `d`, `u`, `l`)        | ❌      |
+| [no-lazy-identifiers](docs/rules/NO_LAZY_IDENTIFIERS.md)                 | Disallow lazy identifiers like `xxx`, `asdf`, `qwerty`                | ❌      |
+| [boolean-naming-prefix](docs/rules/BOOLEAN_NAMING_PREFIX.md)             | Enforce boolean variables to have prefix (is, has, should, can, etc.) | ❌      |
+| [enforce-constant-case](docs/rules/ENFORCE_CONSTANT_CASE.md)             | Enforce SCREAMING_SNAKE_CASE for static constant primitive values     | ❌      |
+| [no-misleading-constant-case](docs/rules/NO_MISLEADING_CONSTANT_CASE.md) | Disallow SCREAMING_SNAKE_CASE for non-constant or non-static values   | ❌      |
 
 ### File Naming Rules
 
@@ -206,6 +208,7 @@ export default [
 | [no-nested-interface-declaration](docs/rules/NO_NESTED_INTERFACE_DECLARATION.md)       | Disallow inline object types in interface/type properties        | ❌      |
 | [prefer-named-param-types](docs/rules/PREFER_NAMED_PARAM_TYPES.md)                     | Enforce named types for function parameters with object types    | ❌      |
 | [prefer-inline-literal-union](docs/rules/PREFER_INLINE_LITERAL_UNION.md)               | Enforce inlining literal union types for better IDE hover info   | ✅      |
+| [prefer-inline-type-export](docs/rules/PREFER_INLINE_TYPE_EXPORT.md)                   | Require type/interface exports inline at the declaration         | ✅      |
 | [prefer-interface-over-inline-types](docs/rules/PREFER_INTERFACE_OVER_INLINE_TYPES.md) | Enforce interface declarations over inline types for React props | ❌      |
 | [sort-type-alphabetically](docs/rules/SORT_TYPE_ALPHABETICALLY.md)                     | Enforce A-Z sorting of properties within type groups             | ✅      |
 | [sort-type-required-first](docs/rules/SORT_TYPE_REQUIRED_FIRST.md)                     | Enforce required properties before optional in types/interfaces  | ✅      |
@@ -214,7 +217,7 @@ export default [
 
 | Rule                                                                                     | Description                                                           | Fixable |
 | ---------------------------------------------------------------------------------------- | --------------------------------------------------------------------- | ------- |
-| [jsx-newline-between-elements](docs/rules/JSX_NEWLINE_BETWEEN_ELEMENTS.md)               | Require empty lines between sibling multi-line JSX elements           | ✅      |
+| [jsx-newline-between-elements](docs/rules/JSX_NEWLINE_BETWEEN_ELEMENTS.md)               | Require empty lines between sibling multi-line JSX children           | ✅      |
 | [jsx-no-inline-object-prop](docs/rules/JSX_NO_INLINE_OBJECT_PROP.md)                     | Disallow inline object literals in JSX props                          | ❌      |
 | [jsx-no-newline-single-line-elements](docs/rules/JSX_NO_NEWLINE_SINGLE_LINE_ELEMENTS.md) | Disallow empty lines between single-line sibling JSX elements         | ✅      |
 | [jsx-no-non-component-function](docs/rules/JSX_NO_NON_COMPONENT_FUNCTION.md)             | Disallow non-component functions at top level in .tsx/.jsx files      | ❌      |
@@ -240,14 +243,14 @@ export default [
 
 | Preset               | Severity | Base Rules | JSX Rules | Next.js Rules | Total Rules |
 | -------------------- | -------- | ---------- | --------- | ------------- | ----------- |
-| `base`               | warn     | 36         | 0         | 0             | 36          |
-| `base/recommended`   | error    | 36         | 0         | 0             | 36          |
-| `react`              | warn     | 36         | 15        | 0             | 51          |
-| `react/recommended`  | error    | 36         | 15        | 0             | 51          |
-| `nextjs`             | warn     | 36         | 15        | 1             | 52          |
-| `nextjs/recommended` | error    | 36         | 15        | 1             | 52          |
+| `base`               | warn     | 37         | 0         | 0             | 37          |
+| `base/recommended`   | error    | 37         | 0         | 0             | 37          |
+| `react`              | warn     | 37         | 15        | 0             | 52          |
+| `react/recommended`  | error    | 37         | 15        | 0             | 52          |
+| `nextjs`             | warn     | 37         | 15        | 1             | 53          |
+| `nextjs/recommended` | error    | 37         | 15        | 1             | 53          |
 
-### Base Configuration Rules (36 rules)
+### Base Configuration Rules (37 rules)
 
 Included in `base`, `base/recommended`, and all other presets:
 
@@ -280,6 +283,7 @@ Included in `base`, `base/recommended`, and all other presets:
 - `nextfriday/prefer-guard-clause`
 - `nextfriday/prefer-import-type`
 - `nextfriday/prefer-inline-literal-union`
+- `nextfriday/prefer-inline-type-export`
 - `nextfriday/prefer-named-param-types`
 - `nextfriday/prefer-react-import-types`
 - `nextfriday/require-explicit-return-type`
@@ -332,7 +336,7 @@ Additionally included in `nextjs`, `nextjs/recommended` only:
 
 ## Agent Skill
 
-This plugin ships with an [Agent Skill](https://github.com/anthropics/skills) that teaches AI coding assistants (Claude Code, Cursor, etc.) all 52 rules so they generate compliant code from the start.
+This plugin ships with an [Agent Skill](https://github.com/anthropics/skills) that teaches AI coding assistants (Claude Code, Cursor, etc.) all 53 rules so they generate compliant code from the start.
 
 ```bash
 npx skills add next-friday/eslint-plugin-nextfriday --skill eslint-plugin-nextfriday

--- a/docs/rules/ENFORCE_CONSTANT_CASE.md
+++ b/docs/rules/ENFORCE_CONSTANT_CASE.md
@@ -4,7 +4,7 @@ Enforce SCREAMING_SNAKE_CASE for constant primitive values.
 
 ## Rule Details
 
-This rule ensures that `const` declarations with primitive values (strings, numbers, booleans, template literals) use SCREAMING_SNAKE_CASE naming convention. Objects, arrays, and functions are not checked. Only `const` declarations are checked; `let` and `var` are ignored.
+This rule ensures that `const` declarations with static primitive values (strings, numbers, booleans, static template literals) use SCREAMING_SNAKE_CASE naming convention. Template literals with expressions (e.g., `` `${variable}` ``) are considered dynamic and are not checked. Objects, arrays, and functions are not checked. Only `const` declarations are checked; `let` and `var` are ignored.
 
 ## Examples
 
@@ -13,7 +13,6 @@ This rule ensures that `const` declarations with primitive values (strings, numb
 ```ts
 const defaultCover = "/images/default.jpg";
 const pageLimit = 10;
-const isEnabled = true;
 const apiBaseUrl = "https://api.example.com";
 const template = `hello world`;
 ```
@@ -23,9 +22,17 @@ const template = `hello world`;
 ```ts
 const DEFAULT_COVER = "/images/default.jpg";
 const PAGE_LIMIT = 10;
-const IS_ENABLED = true;
 const API_BASE_URL = "https://api.example.com";
 const TEMPLATE = `hello world`;
+
+// Booleans with standard prefixes (is, has, should, can, etc.) are exempt
+const isEnabled = true;
+const hasAccess = false;
+const shouldRender = true;
+
+// Template literals with expressions are dynamic, camelCase is fine
+const pendingHref = `/branch/${branch.branchNumber}`;
+const greeting = `Hello, ${user.name}!`;
 
 // Objects, arrays, and functions can use camelCase
 const config = { key: "value" };

--- a/docs/rules/JSX_NEWLINE_BETWEEN_ELEMENTS.md
+++ b/docs/rules/JSX_NEWLINE_BETWEEN_ELEMENTS.md
@@ -1,10 +1,10 @@
 # jsx-newline-between-elements
 
-Require empty lines between sibling JSX elements when at least one spans multiple lines.
+Require empty lines between sibling JSX elements and expression containers when at least one spans multiple lines.
 
 ## Rule Details
 
-This rule enforces empty lines between sibling JSX elements when either element spans multiple lines. This improves visual separation and readability of complex component structures. Single-line elements do not require empty lines between them.
+This rule enforces empty lines between sibling JSX elements, fragments, and expression containers (e.g., `{condition && (...)}`) when either sibling spans multiple lines. This improves visual separation and readability of complex component structures. Single-line siblings do not require empty lines between them.
 
 ## Examples
 
@@ -65,6 +65,28 @@ function UserProfile() {
       <Avatar src={user.avatar} alt={user.name} size="large" />
 
       <UserInfo name={user.name} email={user.email} />
+    </div>
+  );
+}
+```
+
+Expression containers also need empty lines:
+
+```tsx
+function StudentInfo({ studentId, name }) {
+  return (
+    <div>
+      {studentId && (
+        <div className="flex items-center gap-x-1">
+          <Text size="lg">{studentId}</Text>
+        </div>
+      )}
+
+      {name && (
+        <div className="flex items-center gap-x-1">
+          <Text size="lg">{name}</Text>
+        </div>
+      )}
     </div>
   );
 }

--- a/docs/rules/NO_LAZY_IDENTIFIERS.md
+++ b/docs/rules/NO_LAZY_IDENTIFIERS.md
@@ -60,9 +60,11 @@ The rule detects two types of lazy patterns:
 
 ### Repeated Characters (3+)
 
-Variables with 3 or more consecutive identical characters:
+Variables with 3 or more consecutive identical characters (case-sensitive):
 
 - `xxx`, `aaa`, `zzz`, `qqqq`, `aaaa`
+
+Compound names where repeated characters span word boundaries are not flagged (e.g., `ProfileProgressSkeleton` is allowed because `ss` and `S` are different cases).
 
 ### Keyboard Sequences (4+)
 

--- a/docs/rules/NO_MISLEADING_CONSTANT_CASE.md
+++ b/docs/rules/NO_MISLEADING_CONSTANT_CASE.md
@@ -1,0 +1,60 @@
+# no-misleading-constant-case
+
+Disallow SCREAMING_SNAKE_CASE for non-constant or non-static values.
+
+## Rule Details
+
+SCREAMING_SNAKE_CASE conventionally signals a compile-time constant with a static, immutable value. Using it for mutable bindings (`let`/`var`) or dynamic values (function calls, objects, arrays, computed expressions) is misleading because the name implies immutability that the value does not have.
+
+### Why?
+
+When reading `const API_URL = getUrl()`, the SCREAMING_SNAKE_CASE name suggests a hardcoded value, but it is actually computed at runtime. This mismatch makes code harder to reason about. Reserving SCREAMING_SNAKE_CASE for true static primitives keeps the convention meaningful.
+
+## Examples
+
+### Incorrect
+
+```ts
+// Mutable bindings should not use SCREAMING_SNAKE_CASE
+let API_URL = "https://api.example.com";
+var MAX_COUNT = 10;
+
+// Dynamic or computed values should use camelCase
+const API_URL = getUrl();
+const USER_ID = await fetchId();
+const PATHNAME = `/news/${slug}`;
+const CONFIG = { key: "value" };
+const ITEMS = [1, 2, 3];
+const RESULT = a + b;
+const ACTIVE_USERS = users.filter((u) => u.active);
+```
+
+### Correct
+
+```ts
+// Static primitive constants use SCREAMING_SNAKE_CASE
+const API_URL = "https://api.example.com";
+const MAX_COUNT = 10;
+const IS_PRODUCTION = true;
+const TEMPLATE = `hello world`;
+
+// Dynamic or computed values use camelCase
+const apiUrl = getUrl();
+const userId = await fetchId();
+const pathname = `/news/${slug}`;
+const config = { key: "value" };
+const items = [1, 2, 3];
+const result = a + b;
+
+// Mutable bindings use camelCase
+let count = 10;
+var name = "foo";
+```
+
+## When Not To Use It
+
+If your project does not follow the convention that SCREAMING_SNAKE_CASE is reserved for static primitive constants.
+
+## Related Rules
+
+- [enforce-constant-case](ENFORCE_CONSTANT_CASE.md) - The complementary rule that enforces SCREAMING_SNAKE_CASE for static primitive constants

--- a/docs/rules/PREFER_INLINE_TYPE_EXPORT.md
+++ b/docs/rules/PREFER_INLINE_TYPE_EXPORT.md
@@ -1,0 +1,64 @@
+# prefer-inline-type-export
+
+Require type and interface declarations to be exported inline rather than via a separate export statement.
+
+> This rule is auto-fixable using `--fix`.
+
+## Rule Details
+
+This rule enforces that `interface` and `type` declarations are exported directly at the declaration site using the `export` keyword, rather than being exported separately via `export type { ... }` or `export { ... }` at the bottom of the file.
+
+### Why?
+
+Inline exports make it immediately clear at the declaration site that a type is part of the module's public API. Separate export statements create a disconnect between the declaration and its visibility, making it harder to understand the module's surface area at a glance.
+
+## Examples
+
+### Incorrect
+
+```ts
+interface ButtonProps {
+  label: string;
+  disabled: boolean;
+}
+
+type Theme = "light" | "dark";
+
+export type { ButtonProps, Theme };
+```
+
+```ts
+interface Config {
+  port: number;
+}
+
+export { Config };
+```
+
+### Correct
+
+```ts
+export interface ButtonProps {
+  label: string;
+  disabled: boolean;
+}
+
+export type Theme = "light" | "dark";
+```
+
+```ts
+export interface Config {
+  port: number;
+}
+```
+
+## Exceptions
+
+This rule only applies to `interface` and `type` declarations defined in the same file. It does not flag:
+
+- Re-exports from other modules (`export type { Foo } from './types'`)
+- Separate exports of non-type declarations (variables, functions, classes)
+
+## When Not To Use It
+
+If your project prefers grouping all exports at the bottom of the file for consistency.

--- a/src/__tests__/rules.test.ts
+++ b/src/__tests__/rules.test.ts
@@ -96,8 +96,8 @@ describe("ESLint Plugin Rules", () => {
     expect(typeof rules["no-env-fallback"].create).toBe("function");
   });
 
-  it("should have exactly 52 rules", () => {
-    expect(Object.keys(rules)).toHaveLength(52);
+  it("should have exactly 54 rules", () => {
+    expect(Object.keys(rules)).toHaveLength(54);
   });
 
   it("should have correct rule names", () => {
@@ -152,6 +152,8 @@ describe("ESLint Plugin Rules", () => {
     expect(ruleNames).toContain("sort-type-alphabetically");
     expect(ruleNames).toContain("sort-type-required-first");
     expect(ruleNames).toContain("prefer-inline-literal-union");
+    expect(ruleNames).toContain("prefer-inline-type-export");
+    expect(ruleNames).toContain("no-misleading-constant-case");
     expect(ruleNames).toContain("no-nested-interface-declaration");
     expect(ruleNames).toContain("enforce-type-declaration-order");
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,7 @@ import noInlineDefaultExport from "./rules/no-inline-default-export";
 import noInlineNestedObject from "./rules/no-inline-nested-object";
 import noLazyIdentifiers from "./rules/no-lazy-identifiers";
 import noLogicInParams from "./rules/no-logic-in-params";
+import noMisleadingConstantCase from "./rules/no-misleading-constant-case";
 import noNestedInterfaceDeclaration from "./rules/no-nested-interface-declaration";
 import noNestedTernary from "./rules/no-nested-ternary";
 import noRelativeImports from "./rules/no-relative-imports";
@@ -45,6 +46,7 @@ import preferFunctionDeclaration from "./rules/prefer-function-declaration";
 import preferGuardClause from "./rules/prefer-guard-clause";
 import preferImportType from "./rules/prefer-import-type";
 import preferInlineLiteralUnion from "./rules/prefer-inline-literal-union";
+import preferInlineTypeExport from "./rules/prefer-inline-type-export";
 import preferInterfaceOverInlineTypes from "./rules/prefer-interface-over-inline-types";
 import preferJSXTemplateLiterals from "./rules/prefer-jsx-template-literals";
 import preferNamedParamTypes from "./rules/prefer-named-param-types";
@@ -101,6 +103,7 @@ const rules = {
   "no-inline-nested-object": noInlineNestedObject,
   "no-lazy-identifiers": noLazyIdentifiers,
   "no-logic-in-params": noLogicInParams,
+  "no-misleading-constant-case": noMisleadingConstantCase,
   "no-nested-interface-declaration": noNestedInterfaceDeclaration,
   "no-nested-ternary": noNestedTernary,
   "no-relative-imports": noRelativeImports,
@@ -111,6 +114,7 @@ const rules = {
   "prefer-guard-clause": preferGuardClause,
   "prefer-import-type": preferImportType,
   "prefer-inline-literal-union": preferInlineLiteralUnion,
+  "prefer-inline-type-export": preferInlineTypeExport,
   "prefer-interface-over-inline-types": preferInterfaceOverInlineTypes,
   "prefer-jsx-template-literals": preferJSXTemplateLiterals,
   "prefer-named-param-types": preferNamedParamTypes,
@@ -148,6 +152,7 @@ const baseRules = {
   "nextfriday/no-inline-nested-object": "warn",
   "nextfriday/no-lazy-identifiers": "warn",
   "nextfriday/no-logic-in-params": "warn",
+  "nextfriday/no-misleading-constant-case": "warn",
   "nextfriday/no-nested-interface-declaration": "warn",
   "nextfriday/no-nested-ternary": "warn",
   "nextfriday/no-relative-imports": "warn",
@@ -158,6 +163,7 @@ const baseRules = {
   "nextfriday/prefer-guard-clause": "warn",
   "nextfriday/prefer-import-type": "warn",
   "nextfriday/prefer-inline-literal-union": "warn",
+  "nextfriday/prefer-inline-type-export": "warn",
   "nextfriday/prefer-named-param-types": "warn",
   "nextfriday/prefer-react-import-types": "warn",
   "nextfriday/require-explicit-return-type": "warn",
@@ -187,6 +193,7 @@ const baseRecommendedRules = {
   "nextfriday/no-inline-nested-object": "error",
   "nextfriday/no-lazy-identifiers": "error",
   "nextfriday/no-logic-in-params": "error",
+  "nextfriday/no-misleading-constant-case": "error",
   "nextfriday/no-nested-interface-declaration": "error",
   "nextfriday/no-nested-ternary": "error",
   "nextfriday/no-relative-imports": "error",
@@ -197,6 +204,7 @@ const baseRecommendedRules = {
   "nextfriday/prefer-guard-clause": "error",
   "nextfriday/prefer-import-type": "error",
   "nextfriday/prefer-inline-literal-union": "error",
+  "nextfriday/prefer-inline-type-export": "error",
   "nextfriday/prefer-named-param-types": "error",
   "nextfriday/prefer-react-import-types": "error",
   "nextfriday/require-explicit-return-type": "error",

--- a/src/rules/__tests__/enforce-constant-case.test.ts
+++ b/src/rules/__tests__/enforce-constant-case.test.ts
@@ -76,6 +76,34 @@ describe("enforce-constant-case", () => {
         code: `const TEMPLATE = \`hello world\`;`,
         name: "should allow SCREAMING_SNAKE_CASE for template literals",
       },
+      {
+        code: `const pendingHref = \`/branch/\${branch.branchNumber}\`;`,
+        name: "should allow camelCase for template literals with expressions",
+      },
+      {
+        code: `const greeting = \`Hello, \${user.name}!\`;`,
+        name: "should allow camelCase for dynamic template literals",
+      },
+      {
+        code: `const isEnabled = true;`,
+        name: "should allow boolean with is prefix",
+      },
+      {
+        code: `const hasAccess = false;`,
+        name: "should allow boolean with has prefix",
+      },
+      {
+        code: `const shouldRender = true;`,
+        name: "should allow boolean with should prefix",
+      },
+      {
+        code: `const canSubmit = false;`,
+        name: "should allow boolean with can prefix",
+      },
+      {
+        code: `export const API_URL = "https://api.example.com";`,
+        name: "should allow exported SCREAMING_SNAKE_CASE constant",
+      },
     ],
     invalid: [
       {
@@ -100,19 +128,6 @@ describe("enforce-constant-case", () => {
             data: {
               name: "pageLimit",
               suggestion: "PAGE_LIMIT",
-            },
-          },
-        ],
-      },
-      {
-        code: `const isEnabled = true;`,
-        name: "should disallow camelCase for boolean constant",
-        errors: [
-          {
-            messageId: "useScreamingSnakeCase",
-            data: {
-              name: "isEnabled",
-              suggestion: "IS_ENABLED",
             },
           },
         ],

--- a/src/rules/__tests__/jsx-newline-between-elements.test.ts
+++ b/src/rules/__tests__/jsx-newline-between-elements.test.ts
@@ -139,6 +139,42 @@ describe("jsx-newline-between-elements", () => {
         filename: "Component.tsx",
         name: "multi-line p followed by single-line h3 with empty line",
       },
+      {
+        code: `
+          <div>
+            {studentId && (
+              <div>
+                <Text>{studentId}</Text>
+              </div>
+            )}
+
+            {name && (
+              <div>
+                <Text>{name}</Text>
+              </div>
+            )}
+          </div>
+        `,
+        filename: "Component.tsx",
+        name: "multi-line expression containers with empty line between",
+      },
+      {
+        code: `
+          <div>
+            {studentId && (
+              <div>
+                <Text>{studentId}</Text>
+              </div>
+            )}
+
+            <div>
+              <Text>Static</Text>
+            </div>
+          </div>
+        `,
+        filename: "Component.tsx",
+        name: "multi-line expression container followed by element with empty line",
+      },
     ],
     invalid: [
       {
@@ -350,6 +386,78 @@ describe("jsx-newline-between-elements", () => {
           </div>
         `,
         name: "single-line self-closing before multi-line sibling needs empty line",
+      },
+      {
+        code: `
+          <div>
+            {studentId && (
+              <div>
+                <Text>{studentId}</Text>
+              </div>
+            )}
+            {name && (
+              <div>
+                <Text>{name}</Text>
+              </div>
+            )}
+          </div>
+        `,
+        filename: "Component.tsx",
+        errors: [
+          {
+            messageId: "requireNewline",
+          },
+        ],
+        output: `
+          <div>
+            {studentId && (
+              <div>
+                <Text>{studentId}</Text>
+              </div>
+            )}
+
+            {name && (
+              <div>
+                <Text>{name}</Text>
+              </div>
+            )}
+          </div>
+        `,
+        name: "missing empty line between multi-line expression containers",
+      },
+      {
+        code: `
+          <div>
+            {studentId && (
+              <div>
+                <Text>{studentId}</Text>
+              </div>
+            )}
+            <div>
+              <Text>Static</Text>
+            </div>
+          </div>
+        `,
+        filename: "Component.tsx",
+        errors: [
+          {
+            messageId: "requireNewline",
+          },
+        ],
+        output: `
+          <div>
+            {studentId && (
+              <div>
+                <Text>{studentId}</Text>
+              </div>
+            )}
+
+            <div>
+              <Text>Static</Text>
+            </div>
+          </div>
+        `,
+        name: "missing empty line between expression container and element",
       },
     ],
   });

--- a/src/rules/__tests__/no-lazy-identifiers.test.ts
+++ b/src/rules/__tests__/no-lazy-identifiers.test.ts
@@ -77,6 +77,10 @@ describe("no-lazy-identifiers", () => {
         name: "should allow two repeated chars (not lazy)",
       },
       {
+        code: "const ProfileProgressSkeleton = () => {};",
+        name: "should allow compound names where repeated chars span word boundaries",
+      },
+      {
         code: "const qwe = 1;",
         name: "should allow short keyboard patterns under threshold",
       },

--- a/src/rules/__tests__/no-misleading-constant-case.test.ts
+++ b/src/rules/__tests__/no-misleading-constant-case.test.ts
@@ -1,0 +1,193 @@
+import { afterAll, describe, it } from "@jest/globals";
+import { RuleTester } from "@typescript-eslint/rule-tester";
+
+import noMisleadingConstantCase from "../no-misleading-constant-case";
+
+RuleTester.afterAll = afterAll;
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const ruleTester = new RuleTester();
+
+describe("no-misleading-constant-case", () => {
+  it("should have meta property", () => {
+    expect(noMisleadingConstantCase.meta).toBeDefined();
+  });
+
+  it("should have create method", () => {
+    expect(typeof noMisleadingConstantCase.create).toBe("function");
+  });
+
+  ruleTester.run("no-misleading-constant-case", noMisleadingConstantCase, {
+    valid: [
+      {
+        code: `const API_URL = "https://api.example.com";`,
+        name: "should allow SCREAMING_SNAKE_CASE for string literal",
+      },
+      {
+        code: `const MAX = 100;`,
+        name: "should allow SCREAMING_SNAKE_CASE for number literal",
+      },
+      {
+        code: `const IS_PRODUCTION = true;`,
+        name: "should allow SCREAMING_SNAKE_CASE for boolean literal",
+      },
+      {
+        code: `const TEMPLATE = \`hello world\`;`,
+        name: "should allow SCREAMING_SNAKE_CASE for static template literal",
+      },
+      {
+        code: `const NEGATIVE = -1;`,
+        name: "should allow SCREAMING_SNAKE_CASE for negative number",
+      },
+      {
+        code: `const config = getConfig();`,
+        name: "should allow camelCase for function call",
+      },
+      {
+        code: `const items = [1, 2, 3];`,
+        name: "should allow camelCase for array",
+      },
+      {
+        code: `const settings = { key: "value" };`,
+        name: "should allow camelCase for object",
+      },
+      {
+        code: `const pathname = \`/news/\${slug}\`;`,
+        name: "should allow camelCase for dynamic template literal",
+      },
+      {
+        code: `let count = 10;`,
+        name: "should allow camelCase for let declaration",
+      },
+      {
+        code: `var name = "foo";`,
+        name: "should allow camelCase for var declaration",
+      },
+      {
+        code: `const result = a + b;`,
+        name: "should allow camelCase for computed value",
+      },
+      {
+        code: `const userId = await fetchId();`,
+        name: "should allow camelCase for await expression",
+      },
+      {
+        code: `export const API_URL = "https://api.example.com";`,
+        name: "should allow exported SCREAMING_SNAKE_CASE for static primitive",
+      },
+    ],
+    invalid: [
+      {
+        code: `let API_URL = "https://api.example.com";`,
+        name: "should reject SCREAMING_SNAKE_CASE with let",
+        errors: [
+          {
+            messageId: "mutableScreamingCase",
+            data: { name: "API_URL", kind: "let" },
+          },
+        ],
+      },
+      {
+        code: `var MAX_COUNT = 10;`,
+        name: "should reject SCREAMING_SNAKE_CASE with var",
+        errors: [
+          {
+            messageId: "mutableScreamingCase",
+            data: { name: "MAX_COUNT", kind: "var" },
+          },
+        ],
+      },
+      {
+        code: `let TEMPLATE = \`hello\`;`,
+        name: "should reject SCREAMING_SNAKE_CASE template literal with let",
+        errors: [
+          {
+            messageId: "mutableScreamingCase",
+            data: { name: "TEMPLATE", kind: "let" },
+          },
+        ],
+      },
+      {
+        code: `const API_URL = getUrl();`,
+        name: "should reject SCREAMING_SNAKE_CASE for function call",
+        errors: [
+          {
+            messageId: "dynamicScreamingCase",
+            data: { name: "API_URL" },
+          },
+        ],
+      },
+      {
+        code: `const USER_ID = await fetchId();`,
+        name: "should reject SCREAMING_SNAKE_CASE for await expression",
+        errors: [
+          {
+            messageId: "dynamicScreamingCase",
+            data: { name: "USER_ID" },
+          },
+        ],
+      },
+      {
+        code: `const PATHNAME = \`/news/\${slug}\`;`,
+        name: "should reject SCREAMING_SNAKE_CASE for dynamic template literal",
+        errors: [
+          {
+            messageId: "dynamicScreamingCase",
+            data: { name: "PATHNAME" },
+          },
+        ],
+      },
+      {
+        code: `const CONFIG = { key: "value" };`,
+        name: "should reject SCREAMING_SNAKE_CASE for object literal",
+        errors: [
+          {
+            messageId: "dynamicScreamingCase",
+            data: { name: "CONFIG" },
+          },
+        ],
+      },
+      {
+        code: `const ITEMS = [1, 2, 3];`,
+        name: "should reject SCREAMING_SNAKE_CASE for array literal",
+        errors: [
+          {
+            messageId: "dynamicScreamingCase",
+            data: { name: "ITEMS" },
+          },
+        ],
+      },
+      {
+        code: `const RESULT = a + b;`,
+        name: "should reject SCREAMING_SNAKE_CASE for binary expression",
+        errors: [
+          {
+            messageId: "dynamicScreamingCase",
+            data: { name: "RESULT" },
+          },
+        ],
+      },
+      {
+        code: `const ACTIVE_USERS = users.filter(u => u.active);`,
+        name: "should reject SCREAMING_SNAKE_CASE for method call",
+        errors: [
+          {
+            messageId: "dynamicScreamingCase",
+            data: { name: "ACTIVE_USERS" },
+          },
+        ],
+      },
+      {
+        code: `const CLIENT = new ApiClient();`,
+        name: "should reject SCREAMING_SNAKE_CASE for new expression",
+        errors: [
+          {
+            messageId: "dynamicScreamingCase",
+            data: { name: "CLIENT" },
+          },
+        ],
+      },
+    ],
+  });
+});

--- a/src/rules/__tests__/prefer-inline-type-export.test.ts
+++ b/src/rules/__tests__/prefer-inline-type-export.test.ts
@@ -1,0 +1,95 @@
+import { afterAll, describe, it } from "@jest/globals";
+import { RuleTester } from "@typescript-eslint/rule-tester";
+
+import preferInlineTypeExport from "../prefer-inline-type-export";
+
+RuleTester.afterAll = afterAll;
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const ruleTester = new RuleTester();
+
+describe("prefer-inline-type-export", () => {
+  it("should have meta property", () => {
+    expect(preferInlineTypeExport.meta).toBeDefined();
+  });
+
+  it("should have create method", () => {
+    expect(typeof preferInlineTypeExport.create).toBe("function");
+  });
+
+  ruleTester.run("prefer-inline-type-export", preferInlineTypeExport, {
+    valid: [
+      {
+        code: "export interface UserProps { name: string; }",
+        name: "should allow inline exported interface",
+      },
+      {
+        code: "export type UserId = string;",
+        name: "should allow inline exported type alias",
+      },
+      {
+        code: "interface InternalProps { name: string; }",
+        name: "should allow non-exported interface",
+      },
+      {
+        code: "type InternalId = string;",
+        name: "should allow non-exported type alias",
+      },
+      {
+        code: "const value = 1;\nexport { value };",
+        name: "should allow separate export for non-type declarations",
+      },
+      {
+        code: "function getValue() { return 1; }\nexport { getValue };",
+        name: "should allow separate export for functions",
+      },
+      {
+        code: "export type { UserProps } from './types';",
+        name: "should allow re-export from another module",
+      },
+      {
+        code: "export { something } from './module';",
+        name: "should allow re-export of values from another module",
+      },
+    ],
+    invalid: [
+      {
+        code: "interface UserProps { name: string; }\nexport type { UserProps };",
+        name: "should reject separate export type for interface",
+        errors: [{ messageId: "preferInlineExport", data: { name: "UserProps" } }],
+        output: "export interface UserProps { name: string; }\n",
+      },
+      {
+        code: "type UserId = string;\nexport type { UserId };",
+        name: "should reject separate export type for type alias",
+        errors: [{ messageId: "preferInlineExport", data: { name: "UserId" } }],
+        output: "export type UserId = string;\n",
+      },
+      {
+        code: "interface UserProps { name: string; }\nexport { UserProps };",
+        name: "should reject separate export for interface without type keyword",
+        errors: [{ messageId: "preferInlineExport", data: { name: "UserProps" } }],
+        output: "export interface UserProps { name: string; }\n",
+      },
+      {
+        code: "interface AProps { a: string; }\ninterface BProps { b: string; }\nexport type { AProps, BProps };",
+        name: "should reject multiple types in separate export",
+        errors: [
+          { messageId: "preferInlineExport", data: { name: "AProps" } },
+          { messageId: "preferInlineExport", data: { name: "BProps" } },
+        ],
+        output: [
+          "export interface AProps { a: string; }\ninterface BProps { b: string; }\nexport type {  BProps };",
+          "export interface AProps { a: string; }\nexport interface BProps { b: string; }\n",
+        ],
+      },
+      {
+        code: "type Status = 'active' | 'inactive';\nconst value = 1;\nexport type { Status };",
+        name: "should reject separate export type for type alias with other declarations between",
+        errors: [{ messageId: "preferInlineExport", data: { name: "Status" } }],
+        output: "export type Status = 'active' | 'inactive';\nconst value = 1;\n",
+      },
+    ],
+  });
+});

--- a/src/rules/enforce-constant-case.ts
+++ b/src/rules/enforce-constant-case.ts
@@ -7,11 +7,33 @@ const createRule = ESLintUtils.RuleCreator(
 
 const SCREAMING_SNAKE_CASE_REGEX = /^[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)*$/;
 
+const BOOLEAN_PREFIXES = ["is", "has", "should", "can", "did", "will", "was", "are", "does", "had"];
+
 const toScreamingSnakeCase = (str: string): string =>
   str
     .replace(/([a-z])([A-Z])/g, "$1_$2")
     .replace(/([A-Z])([A-Z][a-z])/g, "$1_$2")
     .toUpperCase();
+
+const isStaticTemplateLiteral = (node: { type: AST_NODE_TYPES; expressions?: unknown[] }): boolean =>
+  node.type === AST_NODE_TYPES.TemplateLiteral && (node.expressions?.length ?? 0) === 0;
+
+const startsWithBooleanPrefix = (name: string): boolean =>
+  BOOLEAN_PREFIXES.some((prefix) => {
+    if (!name.startsWith(prefix)) {
+      return false;
+    }
+
+    if (name.length === prefix.length) {
+      return true;
+    }
+
+    const nextChar = name.charAt(prefix.length);
+    return nextChar === nextChar.toUpperCase() && nextChar !== nextChar.toLowerCase();
+  });
+
+const isBooleanLiteral = (init: { type: AST_NODE_TYPES; value?: unknown }): boolean =>
+  init.type === AST_NODE_TYPES.Literal && typeof init.value === "boolean";
 
 const enforceConstantCase = createRule({
   name: "enforce-constant-case",
@@ -27,10 +49,10 @@ const enforceConstantCase = createRule({
   },
   defaultOptions: [],
   create(context) {
-    const isPrimitiveValue = (init: AST_NODE_TYPES): boolean =>
-      init === AST_NODE_TYPES.Literal ||
-      init === AST_NODE_TYPES.UnaryExpression ||
-      init === AST_NODE_TYPES.TemplateLiteral;
+    const isStaticPrimitiveValue = (init: { type: AST_NODE_TYPES; expressions?: unknown[] }): boolean =>
+      init.type === AST_NODE_TYPES.Literal ||
+      init.type === AST_NODE_TYPES.UnaryExpression ||
+      isStaticTemplateLiteral(init);
 
     return {
       VariableDeclaration(node) {
@@ -43,20 +65,22 @@ const enforceConstantCase = createRule({
             return;
           }
 
-          const initType = declarator.init.type;
-
-          if (!isPrimitiveValue(initType)) {
+          if (!isStaticPrimitiveValue(declarator.init)) {
             return;
           }
 
-          if (initType === AST_NODE_TYPES.UnaryExpression) {
+          if (declarator.init.type === AST_NODE_TYPES.UnaryExpression) {
             const unary = declarator.init;
-            if (unary.type !== AST_NODE_TYPES.UnaryExpression || unary.argument.type !== AST_NODE_TYPES.Literal) {
+            if (unary.argument.type !== AST_NODE_TYPES.Literal) {
               return;
             }
           }
 
           const { name } = declarator.id;
+
+          if (isBooleanLiteral(declarator.init) && startsWithBooleanPrefix(name)) {
+            return;
+          }
 
           if (!SCREAMING_SNAKE_CASE_REGEX.test(name)) {
             context.report({

--- a/src/rules/jsx-newline-between-elements.ts
+++ b/src/rules/jsx-newline-between-elements.ts
@@ -25,8 +25,12 @@ const jsxNewlineBetweenElements = createRule({
   create(context) {
     const { sourceCode } = context;
 
-    function isJSXElementOrFragment(node: TSESTree.Node): boolean {
-      return node.type === AST_NODE_TYPES.JSXElement || node.type === AST_NODE_TYPES.JSXFragment;
+    function isSignificantJSXChild(node: TSESTree.Node): boolean {
+      return (
+        node.type === AST_NODE_TYPES.JSXElement ||
+        node.type === AST_NODE_TYPES.JSXFragment ||
+        node.type === AST_NODE_TYPES.JSXExpressionContainer
+      );
     }
 
     function isMultiLine(node: TSESTree.Node): boolean {
@@ -34,8 +38,9 @@ const jsxNewlineBetweenElements = createRule({
     }
 
     function checkSiblings(children: TSESTree.JSXChild[]) {
-      const jsxElements = children.filter((child): child is TSESTree.JSXElement | TSESTree.JSXFragment =>
-        isJSXElementOrFragment(child),
+      const jsxElements = children.filter(
+        (child): child is TSESTree.JSXElement | TSESTree.JSXFragment | TSESTree.JSXExpressionContainer =>
+          isSignificantJSXChild(child),
       );
 
       for (let i = 0; i < jsxElements.length - 1; i += 1) {

--- a/src/rules/no-lazy-identifiers.ts
+++ b/src/rules/no-lazy-identifiers.ts
@@ -12,15 +12,13 @@ const KEYBOARD_ROWS = ["qwertyuiop", "asdfghjkl", "zxcvbnm", "1234567890"];
 const MIN_LENGTH = 3;
 const MIN_SEQUENCE_LENGTH = 4;
 
-const hasRepeatedChars = (name: string): boolean => {
-  const lowerName = name.toLowerCase();
-  return lowerName.split("").some((char, index) => {
-    if (index > lowerName.length - 3) {
+const hasRepeatedChars = (name: string): boolean =>
+  name.split("").some((char, index) => {
+    if (index > name.length - 3) {
       return false;
     }
-    return char === lowerName[index + 1] && char === lowerName[index + 2];
+    return char === name[index + 1] && char === name[index + 2];
   });
-};
 
 const hasKeyboardSequence = (name: string): boolean => {
   const lowerName = name.toLowerCase();

--- a/src/rules/no-misleading-constant-case.ts
+++ b/src/rules/no-misleading-constant-case.ts
@@ -1,0 +1,85 @@
+import { AST_NODE_TYPES, ESLintUtils } from "@typescript-eslint/utils";
+
+import type { TSESTree } from "@typescript-eslint/utils";
+
+const createRule = ESLintUtils.RuleCreator(
+  (name) =>
+    `https://github.com/next-friday/eslint-plugin-nextfriday/blob/main/docs/rules/${name.replaceAll("-", "_").toUpperCase()}.md`,
+);
+
+const SCREAMING_SNAKE_CASE_REGEX = /^[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)*$/;
+
+const isStaticPrimitiveValue = (init: TSESTree.Expression): boolean => {
+  if (init.type === AST_NODE_TYPES.Literal) {
+    return true;
+  }
+
+  if (init.type === AST_NODE_TYPES.UnaryExpression && init.argument.type === AST_NODE_TYPES.Literal) {
+    return true;
+  }
+
+  if (init.type === AST_NODE_TYPES.TemplateLiteral && init.expressions.length === 0) {
+    return true;
+  }
+
+  return false;
+};
+
+const noMisleadingConstantCase = createRule({
+  name: "no-misleading-constant-case",
+  meta: {
+    type: "suggestion",
+    docs: {
+      description: "Disallow SCREAMING_SNAKE_CASE for non-constant or non-static values",
+    },
+    messages: {
+      mutableScreamingCase:
+        "Variable '{{ name }}' uses SCREAMING_SNAKE_CASE but is declared with '{{ kind }}'. Use camelCase for mutable bindings.",
+      dynamicScreamingCase:
+        "Constant '{{ name }}' uses SCREAMING_SNAKE_CASE but its value is not a static primitive. Use camelCase for dynamic or computed values.",
+    },
+    schema: [],
+  },
+  defaultOptions: [],
+  create(context) {
+    return {
+      VariableDeclaration(node) {
+        node.declarations.forEach((declarator) => {
+          if (declarator.id.type !== AST_NODE_TYPES.Identifier) {
+            return;
+          }
+
+          const { name } = declarator.id;
+
+          if (!SCREAMING_SNAKE_CASE_REGEX.test(name)) {
+            return;
+          }
+
+          if (node.kind === "let" || node.kind === "var") {
+            context.report({
+              node: declarator.id,
+              messageId: "mutableScreamingCase",
+              data: { name, kind: node.kind },
+            });
+
+            return;
+          }
+
+          if (!declarator.init) {
+            return;
+          }
+
+          if (!isStaticPrimitiveValue(declarator.init)) {
+            context.report({
+              node: declarator.id,
+              messageId: "dynamicScreamingCase",
+              data: { name },
+            });
+          }
+        });
+      },
+    };
+  },
+});
+
+export default noMisleadingConstantCase;

--- a/src/rules/prefer-inline-type-export.ts
+++ b/src/rules/prefer-inline-type-export.ts
@@ -1,0 +1,121 @@
+import { AST_NODE_TYPES, ESLintUtils } from "@typescript-eslint/utils";
+
+import type { TSESTree } from "@typescript-eslint/utils";
+
+const createRule = ESLintUtils.RuleCreator(
+  (name) =>
+    `https://github.com/next-friday/eslint-plugin-nextfriday/blob/main/docs/rules/${name.replaceAll("-", "_").toUpperCase()}.md`,
+);
+
+const isTypeDeclaration = (node: TSESTree.Node): boolean =>
+  node.type === AST_NODE_TYPES.TSInterfaceDeclaration || node.type === AST_NODE_TYPES.TSTypeAliasDeclaration;
+
+const preferInlineTypeExport = createRule({
+  name: "prefer-inline-type-export",
+  meta: {
+    type: "suggestion",
+    docs: {
+      description:
+        "Require type and interface declarations to be exported inline rather than via a separate export statement",
+    },
+    fixable: "code",
+    messages: {
+      preferInlineExport: "Export '{{name}}' inline at its declaration instead of using a separate export statement.",
+    },
+    schema: [],
+  },
+  defaultOptions: [],
+  create(context) {
+    const typeDeclarations = new Map<string, TSESTree.Node>();
+
+    function collectDeclaration(node: TSESTree.TSInterfaceDeclaration | TSESTree.TSTypeAliasDeclaration): void {
+      if (node.parent.type !== AST_NODE_TYPES.ExportNamedDeclaration) {
+        typeDeclarations.set(node.id.name, node);
+      }
+    }
+
+    function reportSpecifier(
+      specifier: TSESTree.ExportSpecifier,
+      statement: TSESTree.ExportNamedDeclaration,
+      declarationNode: TSESTree.Node,
+    ): void {
+      if (specifier.local.type !== AST_NODE_TYPES.Identifier) {
+        return;
+      }
+
+      const { name } = specifier.local;
+
+      context.report({
+        node: specifier,
+        messageId: "preferInlineExport",
+        data: { name },
+        fix(fixer) {
+          const { sourceCode } = context;
+          const declarationToken = sourceCode.getFirstToken(declarationNode);
+
+          if (!declarationToken) {
+            return null;
+          }
+
+          if (statement.specifiers.length === 1) {
+            const nextToken = sourceCode.getTokenAfter(statement);
+            const end = nextToken ? nextToken.range[0] : statement.range[1];
+
+            return [fixer.insertTextBefore(declarationToken, "export "), fixer.removeRange([statement.range[0], end])];
+          }
+
+          const tokenBefore = sourceCode.getTokenBefore(specifier);
+          const tokenAfter = sourceCode.getTokenAfter(specifier);
+
+          if (!tokenBefore || !tokenAfter) {
+            return null;
+          }
+
+          const isLastSpecifier = statement.specifiers.at(-1) === specifier;
+
+          const removalRange: TSESTree.Range =
+            isLastSpecifier && tokenBefore.value === ","
+              ? [tokenBefore.range[0], specifier.range[1]]
+              : [specifier.range[0], tokenAfter.range[1]];
+
+          return [fixer.insertTextBefore(declarationToken, "export "), fixer.removeRange(removalRange)];
+        },
+      });
+    }
+
+    return {
+      Program(node) {
+        node.body.forEach((statement) => {
+          if (
+            statement.type === AST_NODE_TYPES.TSInterfaceDeclaration ||
+            statement.type === AST_NODE_TYPES.TSTypeAliasDeclaration
+          ) {
+            collectDeclaration(statement);
+          }
+        });
+
+        node.body.forEach((statement) => {
+          if (statement.type !== AST_NODE_TYPES.ExportNamedDeclaration || statement.declaration !== null) {
+            return;
+          }
+
+          statement.specifiers.forEach((specifier) => {
+            if (specifier.local.type !== AST_NODE_TYPES.Identifier) {
+              return;
+            }
+
+            const declarationNode = typeDeclarations.get(specifier.local.name);
+
+            if (!declarationNode || !isTypeDeclaration(declarationNode)) {
+              return;
+            }
+
+            reportSpecifier(specifier, statement, declarationNode);
+          });
+        });
+      },
+    };
+  },
+});
+
+export default preferInlineTypeExport;


### PR DESCRIPTION
## Summary

- Add `no-misleading-constant-case` rule that disallows SCREAMING_SNAKE_CASE for mutable bindings (`let`/`var`) and non-static values (function calls, objects, arrays, dynamic templates, computed expressions)
- Add `prefer-inline-type-export` rule that requires type/interface declarations to be exported inline rather than via separate export statements
- Update `enforce-constant-case` to exempt booleans with standard prefixes (`is`, `has`, `should`, `can`, etc.) to resolve conflict with `boolean-naming-prefix`
- Update existing rules: `jsx-newline-between-elements`, `no-lazy-identifiers`

## Test plan

- [x] All 1241 tests pass
- [x] TypeScript typecheck passes
- [x] Build succeeds
- [ ] Verify `no-misleading-constant-case` flags `const CONFIG = getConfig()` but allows `const CONFIG = "value"`
- [ ] Verify `enforce-constant-case` no longer flags `const isEnabled = true`
- [ ] Verify `prefer-inline-type-export` flags separate export statements for types