### PR TITLE
feat(rules): add no-inline-return-properties rule

### DIFF
--- a/.changeset/add-inline-return-properties-rule.md
+++ b/.changeset/add-inline-return-properties-rule.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-nextfriday": minor
+---
+
+Add `no-inline-return-properties` rule that enforces shorthand-only properties in return objects

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ pnpm changeset           # Create a changeset for version bumping
 `src/index.ts` - Main plugin export containing:
 
 - `meta` - Plugin name and version from package.json
-- `rules` - All 54 rule implementations keyed by hyphenated name
+- `rules` - All 55 rule implementations keyed by hyphenated name
 - `configs` - Eight configuration presets (six nextfriday presets via `createConfig()`, plus lazy `sonarjs` and `unicorn` getters that wrap external plugins)
 
 The plugin is exported both as default and as named exports `{ meta, configs, rules }`.
@@ -43,9 +43,9 @@ Eight configs total. Six nextfriday presets built from three rule set tiers, eac
 
 | Preset                          | Rules                             | Severity     |
 | ------------------------------- | --------------------------------- | ------------ |
-| `base` / `base/recommended`     | 38 base                           | warn / error |
-| `react` / `react/recommended`   | 38 base + 15 JSX                  | warn / error |
-| `nextjs` / `nextjs/recommended` | 38 base + 15 JSX + 1 nextjs       | warn / error |
+| `base` / `base/recommended`     | 39 base                           | warn / error |
+| `react` / `react/recommended`   | 39 base + 15 JSX                  | warn / error |
+| `nextjs` / `nextjs/recommended` | 39 base + 15 JSX + 1 nextjs       | warn / error |
 | `sonarjs`                       | eslint-plugin-sonarjs recommended | -            |
 | `unicorn`                       | eslint-plugin-unicorn recommended | -            |
 

--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ export default [
 | [newline-after-multiline-block](docs/rules/NEWLINE_AFTER_MULTILINE_BLOCK.md) | Require a blank line after multi-line statements                       | ✅      |
 | [newline-before-return](docs/rules/NEWLINE_BEFORE_RETURN.md)                 | Require a blank line before return statements                          | ✅      |
 | [no-inline-nested-object](docs/rules/NO_INLINE_NESTED_OBJECT.md)             | Require nested objects and arrays to span multiple lines               | ✅      |
+| [no-inline-return-properties](docs/rules/NO_INLINE_RETURN_PROPERTIES.md)     | Require return object properties to use shorthand notation             | ❌      |
 | [prefer-async-await](docs/rules/PREFER_ASYNC_AWAIT.md)                       | Enforce async/await over .then() promise chains                        | ❌      |
 | [enforce-curly-newline](docs/rules/ENFORCE_CURLY_NEWLINE.md)                 | Enforce curly braces for multi-line if, forbid for single-line         | ✅      |
 | [no-nested-ternary](docs/rules/NO_NESTED_TERNARY.md)                         | Disallow nested ternary expressions                                    | ❌      |

--- a/docs/rules/NO_INLINE_RETURN_PROPERTIES.md
+++ b/docs/rules/NO_INLINE_RETURN_PROPERTIES.md
@@ -1,0 +1,83 @@
+# no-inline-return-properties
+
+Require return object properties to use shorthand notation by extracting non-shorthand values to const variables.
+
+## Rule Details
+
+This rule enforces that all properties in a returned object literal use shorthand notation. When a return statement contains an object with renamed or computed properties, the values should be extracted into const variables before the return statement.
+
+### Why?
+
+Return objects with a mix of shorthand and non-shorthand properties are harder to scan. Extracting values into named constants before returning keeps the return statement clean and makes the data flow easier to follow.
+
+## Examples
+
+### Incorrect
+
+```ts
+function useBranch() {
+  return {
+    admins,
+    branch,
+    coursesCurrentPage: coursePage,
+    coursesTotalPages: Math.ceil(sortedLearning.length / COURSES_PER_PAGE) || 1,
+    members,
+    membersHref: `/branch/${branchNumber}/members`,
+    news,
+    newsCurrentPage: newsData?.currentPage ?? 1,
+    newsTotalPages: newsData?.pages ?? 1,
+    stats,
+  };
+}
+```
+
+```ts
+function useJoin() {
+  return {
+    error,
+    isSubmitting,
+    onJoin: handleJoin,
+  };
+}
+```
+
+### Correct
+
+```ts
+function useBranch() {
+  const coursesCurrentPage = coursePage;
+  const coursesTotalPages = Math.ceil(sortedLearning.length / COURSES_PER_PAGE) || 1;
+  const membersHref = `/branch/${branchNumber}/members`;
+  const newsCurrentPage = newsData?.currentPage ?? 1;
+  const newsTotalPages = newsData?.pages ?? 1;
+
+  return {
+    admins,
+    branch,
+    coursesCurrentPage,
+    coursesTotalPages,
+    members,
+    membersHref,
+    news,
+    newsCurrentPage,
+    newsTotalPages,
+    stats,
+  };
+}
+```
+
+```ts
+function useJoin() {
+  const onJoin = handleJoin;
+
+  return {
+    error,
+    isSubmitting,
+    onJoin,
+  };
+}
+```
+
+## When Not To Use It
+
+If your project prefers inline property values in return statements for brevity.

--- a/src/__tests__/rules.test.ts
+++ b/src/__tests__/rules.test.ts
@@ -96,8 +96,8 @@ describe("ESLint Plugin Rules", () => {
     expect(typeof rules["no-env-fallback"].create).toBe("function");
   });
 
-  it("should have exactly 54 rules", () => {
-    expect(Object.keys(rules)).toHaveLength(54);
+  it("should have exactly 55 rules", () => {
+    expect(Object.keys(rules)).toHaveLength(55);
   });
 
   it("should have correct rule names", () => {
@@ -134,6 +134,7 @@ describe("ESLint Plugin Rules", () => {
     expect(ruleNames).toContain("no-nested-ternary");
     expect(ruleNames).toContain("no-env-fallback");
     expect(ruleNames).toContain("no-inline-default-export");
+    expect(ruleNames).toContain("no-inline-return-properties");
     expect(ruleNames).toContain("no-inline-nested-object");
     expect(ruleNames).toContain("no-lazy-identifiers");
     expect(ruleNames).toContain("no-relative-imports");

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,7 @@ import noEmoji from "./rules/no-emoji";
 import noEnvFallback from "./rules/no-env-fallback";
 import noInlineDefaultExport from "./rules/no-inline-default-export";
 import noInlineNestedObject from "./rules/no-inline-nested-object";
+import noInlineReturnProperties from "./rules/no-inline-return-properties";
 import noLazyIdentifiers from "./rules/no-lazy-identifiers";
 import noLogicInParams from "./rules/no-logic-in-params";
 import noMisleadingConstantCase from "./rules/no-misleading-constant-case";
@@ -101,6 +102,7 @@ const rules = {
   "no-env-fallback": noEnvFallback,
   "no-inline-default-export": noInlineDefaultExport,
   "no-inline-nested-object": noInlineNestedObject,
+  "no-inline-return-properties": noInlineReturnProperties,
   "no-lazy-identifiers": noLazyIdentifiers,
   "no-logic-in-params": noLogicInParams,
   "no-misleading-constant-case": noMisleadingConstantCase,
@@ -150,6 +152,7 @@ const baseRules = {
   "nextfriday/no-env-fallback": "warn",
   "nextfriday/no-inline-default-export": "warn",
   "nextfriday/no-inline-nested-object": "warn",
+  "nextfriday/no-inline-return-properties": "warn",
   "nextfriday/no-lazy-identifiers": "warn",
   "nextfriday/no-logic-in-params": "warn",
   "nextfriday/no-misleading-constant-case": "warn",
@@ -191,6 +194,7 @@ const baseRecommendedRules = {
   "nextfriday/no-env-fallback": "error",
   "nextfriday/no-inline-default-export": "error",
   "nextfriday/no-inline-nested-object": "error",
+  "nextfriday/no-inline-return-properties": "error",
   "nextfriday/no-lazy-identifiers": "error",
   "nextfriday/no-logic-in-params": "error",
   "nextfriday/no-misleading-constant-case": "error",

--- a/src/rules/__tests__/no-inline-return-properties.test.ts
+++ b/src/rules/__tests__/no-inline-return-properties.test.ts
@@ -1,0 +1,147 @@
+import { afterAll, describe, it } from "@jest/globals";
+import { RuleTester } from "@typescript-eslint/rule-tester";
+
+import noInlineReturnProperties from "../no-inline-return-properties";
+
+RuleTester.afterAll = afterAll;
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const ruleTester = new RuleTester();
+
+describe("no-inline-return-properties", () => {
+  it("should have meta property", () => {
+    expect(noInlineReturnProperties.meta).toBeDefined();
+  });
+
+  it("should have create method", () => {
+    expect(typeof noInlineReturnProperties.create).toBe("function");
+  });
+
+  ruleTester.run("no-inline-return-properties", noInlineReturnProperties, {
+    valid: [
+      {
+        code: `function foo() { return { a, b, c }; }`,
+        name: "should allow all shorthand properties",
+      },
+      {
+        code: `function foo() { return { error, isSubmitting, onJoin }; }`,
+        name: "should allow shorthand properties with descriptive names",
+      },
+      {
+        code: `function foo() { return { admins, branch, courses, members, news, stats }; }`,
+        name: "should allow many shorthand properties",
+      },
+      {
+        code: `function foo() { return { ...props, name }; }`,
+        name: "should allow spread elements with shorthand",
+      },
+      {
+        code: `function foo() { return 42; }`,
+        name: "should allow non-object return",
+      },
+      {
+        code: `function foo() { return; }`,
+        name: "should allow empty return",
+      },
+      {
+        code: `function foo() { return { ...data }; }`,
+        name: "should allow spread-only return",
+      },
+      {
+        code: `const obj = { key: value };`,
+        name: "should not check non-return objects",
+      },
+      {
+        code: `function foo() { const membersHref = \`/branch/\${branchNumber}/members\`; return { membersHref }; }`,
+        name: "should allow extracted value with shorthand",
+      },
+    ],
+    invalid: [
+      {
+        code: `function foo() { return { name: value }; }`,
+        name: "should reject renamed property",
+        errors: [
+          {
+            messageId: "noInlineProperty",
+            data: { name: "name" },
+          },
+        ],
+      },
+      {
+        code: `function foo() { return { onJoin: handleJoin }; }`,
+        name: "should reject renamed handler property",
+        errors: [
+          {
+            messageId: "noInlineProperty",
+            data: { name: "onJoin" },
+          },
+        ],
+      },
+      {
+        code: `function foo() { return { coursesCurrentPage: coursePage }; }`,
+        name: "should reject renamed variable property",
+        errors: [
+          {
+            messageId: "noInlineProperty",
+            data: { name: "coursesCurrentPage" },
+          },
+        ],
+      },
+      {
+        code: `function foo() { return { total: Math.ceil(items.length / PAGE_SIZE) }; }`,
+        name: "should reject computed value property",
+        errors: [
+          {
+            messageId: "noInlineProperty",
+            data: { name: "total" },
+          },
+        ],
+      },
+      {
+        code: `function foo() { return { membersHref: \`/branch/\${branchNumber}/members\` }; }`,
+        name: "should reject template literal value property",
+        errors: [
+          {
+            messageId: "noInlineProperty",
+            data: { name: "membersHref" },
+          },
+        ],
+      },
+      {
+        code: `function foo() { return { newsCurrentPage: newsData?.currentPage ?? 1, newsTotalPages: newsData?.pages ?? 1 }; }`,
+        name: "should reject multiple non-shorthand properties",
+        errors: [
+          {
+            messageId: "noInlineProperty",
+            data: { name: "newsCurrentPage" },
+          },
+          {
+            messageId: "noInlineProperty",
+            data: { name: "newsTotalPages" },
+          },
+        ],
+      },
+      {
+        code: `function foo() { return { admins, coursesCurrentPage: coursePage, members }; }`,
+        name: "should reject mixed shorthand and non-shorthand",
+        errors: [
+          {
+            messageId: "noInlineProperty",
+            data: { name: "coursesCurrentPage" },
+          },
+        ],
+      },
+      {
+        code: `function foo() { return { data: getData() }; }`,
+        name: "should reject function call value property",
+        errors: [
+          {
+            messageId: "noInlineProperty",
+            data: { name: "data" },
+          },
+        ],
+      },
+    ],
+  });
+});

--- a/src/rules/no-inline-return-properties.ts
+++ b/src/rules/no-inline-return-properties.ts
@@ -1,0 +1,72 @@
+import { AST_NODE_TYPES, ESLintUtils } from "@typescript-eslint/utils";
+
+import type { TSESTree } from "@typescript-eslint/utils";
+
+const createRule = ESLintUtils.RuleCreator(
+  (name) =>
+    `https://github.com/next-friday/eslint-plugin-nextfriday/blob/main/docs/rules/${name.replaceAll("-", "_").toUpperCase()}.md`,
+);
+
+const isShorthandProperty = (property: TSESTree.ObjectLiteralElement): boolean => {
+  if (property.type === AST_NODE_TYPES.SpreadElement) {
+    return true;
+  }
+
+  if (property.type !== AST_NODE_TYPES.Property) {
+    return false;
+  }
+
+  return property.shorthand;
+};
+
+const noInlineReturnProperties = createRule({
+  name: "no-inline-return-properties",
+  meta: {
+    type: "suggestion",
+    docs: {
+      description:
+        "Require return object properties to use shorthand notation by extracting non-shorthand values to const variables",
+    },
+    messages: {
+      noInlineProperty:
+        "Property '{{ name }}' should use shorthand notation. Extract the value to a const variable before the return statement.",
+    },
+    schema: [],
+  },
+  defaultOptions: [],
+  create(context) {
+    return {
+      ReturnStatement(node) {
+        if (!node.argument || node.argument.type !== AST_NODE_TYPES.ObjectExpression) {
+          return;
+        }
+
+        node.argument.properties.forEach((property) => {
+          if (isShorthandProperty(property)) {
+            return;
+          }
+
+          if (property.type !== AST_NODE_TYPES.Property) {
+            return;
+          }
+
+          let keyName: string | null = null;
+
+          if (property.key.type === AST_NODE_TYPES.Identifier) {
+            keyName = property.key.name;
+          } else if (property.key.type === AST_NODE_TYPES.Literal) {
+            keyName = String(property.key.value);
+          }
+
+          context.report({
+            node: property,
+            messageId: "noInlineProperty",
+            data: { name: keyName ?? "unknown" },
+          });
+        });
+      },
+    };
+  },
+});
+
+export default noInlineReturnProperties;


### PR DESCRIPTION
## Summary

- Add `no-inline-return-properties` rule that enforces shorthand-only properties in return object literals
- Non-shorthand properties (renamed, computed, template literals, function calls) must be extracted to const variables before the return statement

## Test plan

- [x] All 1260 tests pass
- [x] TypeScript typecheck passes
- [x] Build succeeds
- [ ] Verify `return { a, b, c }` passes (all shorthand)
- [ ] Verify `return { name: value }` is flagged (non-shorthand)
- [ ] Verify `return { ...props, a }` passes (spread + shorthand)