### PR TITLE
chore(infra): tighten claude permissions and ci

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -14,5 +14,23 @@
         ]
       }
     ]
+  },
+  "permissions": {
+    "allow": [
+      "Bash(git -C * diff*)",
+      "Bash(git -C * fetch*)",
+      "Bash(git -C * log*)",
+      "Bash(git -C * ls-files*)",
+      "Bash(git -C * stash*)",
+      "Bash(git -C * status*)",
+      "Bash(git diff *)",
+      "Bash(git fetch *)",
+      "Bash(git log *)",
+      "Bash(git ls-files *)",
+      "Bash(git stash *)",
+      "Bash(git status*)"
+    ],
+    "deny": ["Bash(git clean *)", "Bash(git push --force*)", "Bash(git reset --hard*)"],
+    "ask": ["Bash(git commit *)", "Bash(git push *)", "Bash(git rebase *)"]
   }
 }

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,52 +1,31 @@
 ## Summary
 
-Brief description of the changes in this PR.
+<!-- What does this PR change and why? -->
 
 ## Type of Change
 
 - [ ] Bug fix
-- [ ] New feature
+- [ ] New rule or rule enhancement
 - [ ] Breaking change
-- [ ] Documentation update
-- [ ] Refactor
-- [ ] Performance improvement
-- [ ] Test improvement
+- [ ] Documentation
+- [ ] Tooling / CI
 
-## Changes Made
+## Test Plan
 
--
--
--
-
-## Testing
-
-- [ ] Unit tests pass
-- [ ] Manual testing completed
-- [ ] Added/updated tests for new functionality
+<!-- How was this verified? Reference test files or include reproducible steps. -->
 
 ## Related Issues
 
-Closes #[issue_number]
+<!-- Closes #N -->
 
-## Pre-merge Checklist
-
-<!-- For maintainers - contributors can ignore this section -->
+---
 
 <details>
+<summary>Maintainer checklist</summary>
 
-<summary>For maintainers</summary>
-
-- [ ] Code follows the project's style guidelines
-- [ ] Self-review of code completed
-- [ ] All tests pass locally
-- [ ] ESLint checks pass
-- [ ] TypeScript compilation successful
-- [ ] Changeset added (for src/ or docs/ changes)
-- [ ] Documentation updated (if applicable)
-- [ ] Breaking changes documented
-- [ ] Examples updated (if API changed)
-- [ ] Commit messages follow conventional commits
-- [ ] No debug code or console.log statements left
-- [ ] Performance impact considered
+- [ ] Tests added or updated
+- [ ] Docs added or updated (`docs/rules/` and `README.md`)
+- [ ] Changeset added (`pnpm changeset`) for `src/` or `docs/` changes
+- [ ] PR title follows `type(scope): subject` (no uppercase start, ≤50 chars)
 
 </details>

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,29 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest published minor version of `eslint-plugin-nextfriday` receives security updates. Older versions may not receive fixes.
+
+## Reporting a Vulnerability
+
+Please **do not** open public issues, pull requests, or discussions for security vulnerabilities.
+
+Report them privately via [GitHub Security Advisories](https://github.com/next-friday/eslint-plugin-nextfriday/security/advisories/new).
+
+We aim to:
+
+- Acknowledge receipt within 72 hours.
+- Provide a fix or mitigation timeline within 7 days.
+- Credit the reporter in the published advisory unless anonymity is requested.
+
+## Scope
+
+In scope:
+
+- Code execution, prototype pollution, ReDoS, or other vulnerabilities in published rule logic or configuration.
+- Supply-chain issues affecting the published npm package.
+
+Out of scope:
+
+- Issues in dependencies that have a known upstream advisory and a maintained fix.
+- Lint rule false positives or false negatives that are not security-impacting.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,30 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    groups:
+      production-deps:
+        dependency-type: "production"
+      dev-deps:
+        dependency-type: "development"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "ci"
+      include: "scope"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,37 @@
+rules:
+  - changed-files:
+      - any-glob-to-any-file: "src/rules/**"
+
+tests:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/__tests__/**"
+          - "**/*.test.ts"
+
+dependencies:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "package.json"
+          - "pnpm-lock.yaml"
+
+ci:
+  - changed-files:
+      - any-glob-to-any-file: ".github/**"
+
+changesets:
+  - changed-files:
+      - any-glob-to-any-file: ".changeset/**"
+
+config:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "*.config.{ts,mjs,js}"
+          - "tsconfig.json"
+          - "eslint.config.*"
+          - ".prettierrc*"
+          - ".husky/**"
+          - ".lintstagedrc*"
+
+documentation:
+  - changed-files:
+      - any-glob-to-any-file: "**/*.md"

--- a/.github/workflows/changeset-version-validation.yml
+++ b/.github/workflows/changeset-version-validation.yml
@@ -5,19 +5,24 @@ on:
     branches: [main]
 
 concurrency:
-  group: changeset-validation-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
-  validate-changes:
-    name: Validate Changes
+  validate-changeset:
+    name: Validate Changeset
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: ${{ github.event.pull_request.draft == false }}
     env:
       IS_TRUSTED_BOT: >-
         ${{
           contains(fromJson('["github-actions[bot]","changeset-bot","changeset-bot[bot]","dependabot[bot]"]'), github.actor)
-          || contains(fromJson('["github-actions[bot]","changeset-bot","changeset-bot[bot]"]'), github.event.pull_request.user.login)
+          || contains(fromJson('["github-actions[bot]","changeset-bot","changeset-bot[bot]","dependabot[bot]"]'), github.event.pull_request.user.login)
+          || github.event.pull_request.user.type == 'Bot'
           || startsWith(github.event.pull_request.title, 'ci(changesets):')
           || startsWith(github.head_ref, 'changeset-release/')
         }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,11 +8,19 @@ on:
   schedule:
     - cron: "0 2 * * 1"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    timeout-minutes: 30
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/commit-message-validation.yml
+++ b/.github/workflows/commit-message-validation.yml
@@ -5,16 +5,27 @@ on:
     branches: [main]
 
 concurrency:
-  group: commit-validation-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
+
+permissions:
+  contents: read
 
 jobs:
   validate-commits:
     name: Validate Commit Messages
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: ${{ github.event.pull_request.draft == false }}
     env:
-      IS_TRUSTED_BOT: ${{ github.actor == 'github-actions[bot]' || github.actor == 'changeset-bot' || github.event.pull_request.user.type == 'Bot' }}
+      IS_TRUSTED_BOT: >-
+        ${{
+          contains(fromJson('["github-actions[bot]","changeset-bot","changeset-bot[bot]","dependabot[bot]"]'), github.actor)
+          || contains(fromJson('["github-actions[bot]","changeset-bot","changeset-bot[bot]","dependabot[bot]"]'), github.event.pull_request.user.login)
+          || github.event.pull_request.user.type == 'Bot'
+          || startsWith(github.event.pull_request.title, 'ci(changesets):')
+          || startsWith(github.head_ref, 'changeset-release/')
+        }}
 
     steps:
       - name: Fast-pass for trusted bots

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,28 @@
+name: PR Labeler
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  apply-labels:
+    name: Apply Labels
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: ${{ github.event.pull_request.draft == false }}
+
+    steps:
+      - name: Apply Labels
+        uses: actions/labeler@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/labeler.yml
+          sync-labels: true

--- a/.github/workflows/pull-request-title-validation.yml
+++ b/.github/workflows/pull-request-title-validation.yml
@@ -4,24 +4,38 @@ on:
   pull_request:
     types: [opened, edited, reopened, synchronize]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
-  main:
+  validate-pr-title:
     name: Validate Pull Request Title
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     if: ${{ github.event.pull_request.draft == false }}
-    permissions:
-      contents: read
-      pull-requests: write
     env:
-      IS_TRUSTED_BOT: ${{ github.actor == 'github-actions[bot]' || github.actor == 'changeset-bot' || github.event.pull_request.user.type == 'Bot' }}
+      IS_TRUSTED_BOT: >-
+        ${{
+          contains(fromJson('["github-actions[bot]","changeset-bot","changeset-bot[bot]","dependabot[bot]"]'), github.actor)
+          || contains(fromJson('["github-actions[bot]","changeset-bot","changeset-bot[bot]","dependabot[bot]"]'), github.event.pull_request.user.login)
+          || github.event.pull_request.user.type == 'Bot'
+          || startsWith(github.event.pull_request.title, 'ci(changesets):')
+          || startsWith(github.head_ref, 'changeset-release/')
+        }}
 
     steps:
       - name: Fast-pass for trusted bots
         if: ${{ env.IS_TRUSTED_BOT == 'true' }}
         run: echo "Trusted bot PR → skip PR title validation but report success."
 
-      - uses: amannn/action-semantic-pull-request@v5
+      - name: Validate PR Title
         if: ${{ env.IS_TRUSTED_BOT != 'true' }}
+        uses: amannn/action-semantic-pull-request@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -5,7 +5,7 @@ on:
     branches: [main]
 
 concurrency:
-  group: quality-${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -13,14 +13,21 @@ permissions:
 
 jobs:
   quality-checks:
-    if: ${{ github.event.pull_request.draft == false }}
     name: Quality Checks
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    if: ${{ github.event.pull_request.draft == false }}
     env:
       CI: true
       NODE_OPTIONS: --max-old-space-size=4096
-      IS_TRUSTED_BOT: ${{ github.actor == 'github-actions[bot]' || github.actor == 'changeset-bot' }}
+      IS_TRUSTED_BOT: >-
+        ${{
+          contains(fromJson('["github-actions[bot]","changeset-bot","changeset-bot[bot]","dependabot[bot]"]'), github.actor)
+          || contains(fromJson('["github-actions[bot]","changeset-bot","changeset-bot[bot]","dependabot[bot]"]'), github.event.pull_request.user.login)
+          || github.event.pull_request.user.type == 'Bot'
+          || startsWith(github.event.pull_request.title, 'ci(changesets):')
+          || startsWith(github.head_ref, 'changeset-release/')
+        }}
 
     steps:
       - name: Fast-pass for trusted bots

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,9 @@ on:
   push:
     branches: [main]
 
-concurrency: ${{ github.workflow }}-${{ github.ref }}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 
 permissions:
   contents: write
@@ -15,6 +17,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v5


### PR DESCRIPTION
## Summary

- Tighten Claude Code permissions in `.claude/settings.json` — move destructive git/gh ops to `ask`/`deny`, allow only read-only git subcommands.
- Unify GitHub workflow patterns across all PR validation workflows: shared `IS_TRUSTED_BOT` detection, top-level `permissions: contents: read`, consistent `concurrency` keys, `timeout-minutes`, and job IDs.
- Add `SECURITY.md` (vulnerability reporting policy).
- Add `.github/workflows/labeler.yml` to make the existing `labeler.yml` config functional, and update the config for this repo's actual paths.
- Trim PR template.

## Test plan

- [x] All workflow YAMLs validated.
- [x] Pre-push: \`test:coverage\` + \`typecheck\` + \`build\` pass.
- [ ] CI runs green on this PR.