### PR TITLE
ci(workflows): auto-approve trusted bot prs

### DIFF
--- a/.github/workflows/auto-approve-trusted-bots.yml
+++ b/.github/workflows/auto-approve-trusted-bots.yml
@@ -1,0 +1,60 @@
+name: Auto-approve Trusted Bot PRs
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  auto-approve:
+    name: Auto-approve and Enable Auto-merge
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: >-
+      ${{
+        github.actor == 'dependabot[bot]'
+        || startsWith(github.event.pull_request.title, 'ci(changesets):')
+        || startsWith(github.head_ref, 'changeset-release/')
+      }}
+
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        if: github.actor == 'dependabot[bot]'
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Determine eligibility
+        id: eligible
+        env:
+          ACTOR: ${{ github.actor }}
+          UPDATE_TYPE: ${{ steps.metadata.outputs.update-type }}
+        run: |
+          if [ "$ACTOR" = "dependabot[bot]" ]; then
+            if [ "$UPDATE_TYPE" = "version-update:semver-patch" ] || [ "$UPDATE_TYPE" = "version-update:semver-minor" ]; then
+              echo "eligible=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "eligible=false" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo "eligible=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Approve PR
+        if: steps.eligible.outputs.eligible == 'true'
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.CHANGESETS_TOKEN }}
+        run: gh pr review --approve "$PR_URL"
+
+      - name: Enable auto-merge
+        if: steps.eligible.outputs.eligible == 'true'
+        uses: peter-evans/enable-pull-request-automerge@v3
+        with:
+          token: ${{ secrets.CHANGESETS_TOKEN }}
+          pull-request-number: ${{ github.event.pull_request.number }}
+          merge-method: squash


### PR DESCRIPTION
## Summary

Adds `.github/workflows/auto-approve-trusted-bots.yml` to auto-approve and enable auto-merge for PRs from trusted bots, so they don't get stuck on the `required_approving_review_count: 1` branch protection rule.

**Triggers** when:
- PR actor is `dependabot[bot]`, **or**
- PR title starts with `ci(changesets):`, **or**
- Head branch starts with `changeset-release/`

**Behavior:**
- **Dependabot** — uses `dependabot/fetch-metadata@v2`, auto-approves only `semver-patch` and `semver-minor` (major bumps still require manual review).
- **Changeset PRs** — always auto-approves.
- Approval and `enable-pull-request-automerge@v3` both use `CHANGESETS_TOKEN` (already configured for `release.yml`).
- Merge method: squash.

## Why

After enabling branch protection earlier today (`required_approving_review_count: 1`, `enforce_admins: true`), bot PRs cannot self-approve and get blocked. Six dependabot PRs are currently stuck (#106–#111), and the next changeset version-PR would also block.

## Test plan

- [ ] Verify repo setting `allow_auto_merge` is enabled (`gh api repos/next-friday/eslint-plugin-nextfriday --jq .allow_auto_merge`).
- [ ] After merge: comment `@dependabot rebase` on PRs #106–#111 to trigger the workflow on synchronize.
- [ ] Watch one of those PRs auto-approve and queue for auto-merge once CI passes.