### PR TITLE
fix(nextjs): exempt routing dirs from name rules

### DIFF
--- a/.changeset/docs-context7-quality.md
+++ b/.changeset/docs-context7-quality.md
@@ -1,0 +1,9 @@
+---
+"eslint-plugin-nextfriday": patch
+---
+
+Documentation quality improvements targeting Context7 scoring gaps:
+
+- `README.md` — "Per-Directory Configuration" section now explains how flat config resolves rules (config-array order, `files`/`ignores` precedence, why flat replaces `.eslintrc` overrides), adds a preset-tier-per-directory table, and lists common edge cases (glob ordering, top-level vs scoped `ignores`, spreading array-shaped presets, `--print-config` for debugging).
+- `README.md` — "Migration Strategy" section is restructured around six concrete phases: surveying violations with `eslint --format json | jq`, isolating the auto-fix pass into its own PR, adopting the warn-level preset, ratcheting clean directories to `/recommended`, managing exceptions (severity override → directory override → disable comment, in that order of preference), and tracking violation count over time. The "Prioritize rules by impact" table is unchanged.
+- `docs/rules/ENFORCE_CONSTANT_CASE.md` — Configuration section split into install / enable-just-this-rule / enable-with-related-rules / enable-via-preset / scope-to-directory subsections, plus a "Severity-only — no rule options" callout clarifying that the legacy `["error", { ... }]` array form is not accepted because no rule in this plugin has options.

--- a/.changeset/nextjs-routing-disable-filename-rules.md
+++ b/.changeset/nextjs-routing-disable-filename-rules.md
@@ -1,0 +1,7 @@
+---
+"eslint-plugin-nextfriday": minor
+---
+
+`nextjs` and `nextjs/recommended` presets now also disable `nextfriday/file-kebab-case` (in addition to `nextfriday/jsx-pascal-case`) for files under `app/**`, `src/app/**`, `pages/**`, and `src/pages/**`. The override globs are expanded from `*.{jsx,tsx}` to `*.{js,jsx,ts,tsx}` so `route.ts`, `middleware.ts`, and other framework-named `.ts`/`.js` files in those directories are no longer flagged by either filename rule. Filename conventions in routing directories are owned by the framework, not by this plugin.
+
+The `react` and `react/recommended` presets are unchanged — projects using them still enforce `file-kebab-case` on every `.ts`/`.js` and `jsx-pascal-case` on every `.tsx`/`.jsx`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,8 +33,8 @@ The plugin dogfoods its own rules via `eslint.config.mjs`. Build config lives in
 `src/index.ts` - Main plugin export containing:
 
 - `meta` - Plugin name and version from package.json
-- `rules` - All 56 rule implementations keyed by hyphenated name
-- `configs` - Six configuration presets via `createConfig()` (each rule set has a `warn` and `error`/`recommended` variant)
+- `rules` - All 57 rule implementations keyed by hyphenated name
+- `configs` - Six configuration presets (each rule set has a `warn` and `error`/`recommended` variant). `base`/`react` presets are built via `createConfig()` and return a single config object; `nextjs` presets are built via `createNextjsConfig()` and return an **array** containing the base config plus a routing override that disables both `file-kebab-case` and `jsx-pascal-case` for files under `app/**`, `src/app/**`, `pages/**`, `src/pages/**` (matched against `*.{js,jsx,ts,tsx}`) — Next.js owns these filenames (`page.tsx`, `layout.tsx`, `route.ts`, `middleware.ts`, etc.). Consumers must spread these arrays into their flat config.
 
 The plugin is exported both as default and as named exports `{ meta, configs, rules }`.
 
@@ -53,8 +53,8 @@ Six configs total. Three rule set tiers, each with a `warn` variant and a `Recom
 | Preset                          | Rules                       | Severity     |
 | ------------------------------- | --------------------------- | ------------ |
 | `base` / `base/recommended`     | 40 base                     | warn / error |
-| `react` / `react/recommended`   | 40 base + 15 JSX            | warn / error |
-| `nextjs` / `nextjs/recommended` | 40 base + 15 JSX + 1 nextjs | warn / error |
+| `react` / `react/recommended`   | 40 base + 16 JSX            | warn / error |
+| `nextjs` / `nextjs/recommended` | 40 base + 16 JSX + 1 nextjs | warn / error |
 
 ### Utilities
 

--- a/README.md
+++ b/README.md
@@ -178,44 +178,115 @@ export default [
 
 ### Per-Directory Configuration
 
-ESLint flat config is an array of config objects. Each object's `files` and `ignores` glob patterns scope its rules to a subset of the project. Use this to apply different rule severities to different directories.
+#### How ESLint flat config resolves rules
+
+Flat config (the only format this plugin supports) is an **array of config objects** evaluated in order. For every file ESLint lints, it walks the array and merges every object whose `files` glob matches and whose `ignores` glob does not. Later objects override earlier ones rule-by-rule, so the **last matching object wins** for any given rule. Objects with no `files` field apply globally; objects with only `ignores` at the top level remove files from the entire run.
+
+This is why per-directory configuration works: you stack a global default first, then layer narrower `files`-scoped objects on top. ESLint 9+ also flattens nested arrays automatically, so spreading a preset that ships as an array (like `nextfriday.configs.nextjs`) works the same as spreading a single object.
+
+The legacy `.eslintrc` format used `overrides` and an inheritance tree to express the same thing. Flat config replaces that tree with a flat, deterministic array — easier to reason about, no implicit merging across `extends`, and no `parserOptions` plumbing per directory. The plugin does not ship `.eslintrc` shims, so projects on ESLint 8 or below cannot consume it without upgrading.
+
+#### Layering strict and loose presets
+
+Apply different rule severities to different directories by stacking config objects:
 
 ```js
 import nextfriday from "eslint-plugin-nextfriday";
 
 export default [
   {
-    files: ["src/components/**/*.{ts,tsx}"],
+    ignores: ["src/legacy/**", "dist/**", "build/**", "**/*.generated.ts"],
+  },
+
+  nextfriday.configs.react,
+
+  {
+    files: ["src/components/**/*.{ts,tsx}", "src/hooks/**/*.{ts,tsx}"],
     ...nextfriday.configs["react/recommended"],
   },
 
   {
-    files: ["src/utils/**/*.ts"],
-    ...nextfriday.configs.base,
+    files: ["src/utils/**/*.ts", "src/lib/**/*.ts"],
+    rules: {
+      "nextfriday/require-explicit-return-type": "error",
+      "nextfriday/no-relative-imports": "error",
+    },
   },
 
   {
-    files: ["src/legacy/**/*.{ts,tsx}"],
-    ignores: ["src/legacy/**/*"],
-  },
-
-  {
-    files: ["**/*.test.{ts,tsx}"],
+    files: ["**/*.{test,spec}.{ts,tsx}"],
     rules: {
       "nextfriday/require-explicit-return-type": "off",
       "nextfriday/no-single-char-variables": "off",
+      "nextfriday/no-direct-date": "off",
     },
   },
 ];
 ```
 
-The first config block applies the strict `react/recommended` preset (errors) to component files. The second applies the looser `base` preset (warnings) to utilities. The third excludes legacy code from linting entirely. The fourth keeps lint enabled for tests but turns off rules that conflict with common test patterns.
+Reading top to bottom:
+
+1. **Top-level `ignores`** removes legacy and build artifacts from the entire run. A config object containing _only_ `ignores` is treated as a global ignore — narrower `ignores` inside a `files`-scoped object only affect that object.
+2. **`nextfriday.configs.react`** applies as the warn-level baseline to every file ESLint sees (no `files` glob).
+3. **Component and hook directories** get promoted to `react/recommended` (errors). Because this object comes after the baseline, its severities win.
+4. **Utility directories** keep the warn-level baseline but selectively promote two correctness rules to `error`. Use this pattern when you don't want the full `/recommended` preset but do want specific rules treated as blocking.
+5. **Test files** keep most rules but turn off rules that conflict with common test patterns (single-letter loop counters, frozen `Date.now()` mocks, void-returning `it()` callbacks).
+
+#### Choosing a preset tier per directory
+
+| Code area                         | Suggested preset                            | Why                                                                        |
+| --------------------------------- | ------------------------------------------- | -------------------------------------------------------------------------- |
+| Library / SDK code                | `base/recommended` or `react/recommended`   | Public surface should be tightest. `error` blocks regressions at PR time.  |
+| New product code                  | `react/recommended` or `nextjs/recommended` | New code starts clean; lock the conventions in immediately.                |
+| Mature product code mid-migration | `react` or `nextjs` (warn)                  | Ship while migrating. Switch to `/recommended` after a clean run.          |
+| Tests, scripts, fixtures          | preset + targeted overrides                 | Keep the core lint signal; turn off rules that mismatch test/CLI patterns. |
+| Legacy / vendored / generated     | top-level `ignores`                         | No lint signal at all. Don't waste reviewer attention or CI time.          |
+
+#### Edge cases and troubleshooting
+
+- **Glob precedence is order-dependent, not specificity-based.** A more specific glob later in the array wins; a more specific glob _earlier_ in the array does not. If `files: ["src/**"]` appears after `files: ["src/components/**"]`, the broader rule set wins for components. Put broader configs first.
+- **`files` and `ignores` are anchored to the project root** (the directory containing `eslint.config.{js,mjs,ts}`), not the file's directory. Use `**/` prefixes for matches anywhere in the tree (e.g., `**/*.test.ts`).
+- **Top-level `ignores` ≠ `ignores` inside a config object.** A standalone object `{ ignores: [...] }` removes files from the entire run; an `ignores` field next to `files` and `rules` only narrows that one config object's match.
+- **Spreading a preset replaces, not merges, the `plugins` field.** If you spread `...nextfriday.configs.react` and then a different config later, the later object's `plugins` wins. Re-declare `plugins: { nextfriday }` if you add rules in a later object.
+- **`nextfriday.configs.nextjs` is an array, not a single object.** Spreading it inline with `...nextfriday.configs.nextjs` only spreads array indices, not the inner objects. Use it as an array entry (`nextfriday.configs.nextjs,`) instead, so ESLint 9+ flattens it.
+- **Two presets in one project.** Use scoped `files` rather than two unscoped presets — unscoped presets stack and the later one's rule severities win for every file, which is rarely what you want.
+- **Verifying the resolved config for a file:** `pnpm eslint --print-config path/to/file.tsx` prints the merged config ESLint would actually use. Reach for this when a rule fires (or doesn't) and you can't tell why.
 
 ### Migration Strategy
 
-For an existing codebase with many violations, enable rules gradually instead of all at once. Three patterns, in order of how disruptive each is to your team:
+For an existing codebase with many violations, treat the migration as a phased rollout — survey, fix, lock in, repeat.
 
-**1. Start with the warn-level preset.** All rules surface as warnings, so the build still passes. Fix issues at your own pace, then switch to `/recommended`.
+#### 1. Survey violations before changing anything
+
+Install the plugin as a dev dependency, drop a warn-level preset into `eslint.config.mjs`, and run a read-only lint. Don't `--fix` yet — you want to see the raw shape of the codebase first.
+
+```bash
+pnpm add -D eslint-plugin-nextfriday eslint
+pnpm eslint . --no-fix
+```
+
+Group violations by rule so you can plan the work. Most CI dashboards do this for you, but a one-liner works locally:
+
+```bash
+pnpm eslint . --no-fix --format json | jq -r '.[].messages[].ruleId' | sort | uniq -c | sort -rn
+```
+
+The output tells you which rules account for most of the noise. A rule with 3 violations is a 10-minute fix; a rule with 800 is a multi-week project. Plan accordingly.
+
+#### 2. Run the auto-fixers in an isolated PR
+
+Roughly a third of this plugin's rules are auto-fixable (the `Fixable ✅` column in the [Rules](#rules) table). Run them in a dedicated commit so the diff is purely mechanical and reviewers don't have to read every line:
+
+```bash
+pnpm eslint . --fix
+git add -u && git commit -m "style(lint): autofix nextfriday rules"
+```
+
+Open this as its own PR. Mixing auto-fix output with hand-written changes in the same diff makes review almost impossible.
+
+#### 3. Adopt the warn-level preset
+
+After the auto-fix pass, drop in the warn-level preset so the remaining violations surface during local dev and CI without breaking the build:
 
 ```js
 import nextfriday from "eslint-plugin-nextfriday";
@@ -223,7 +294,11 @@ import nextfriday from "eslint-plugin-nextfriday";
 export default [nextfriday.configs.react];
 ```
 
-**2. Lock-in a clean directory at a time.** Use `files` to apply `/recommended` (errors) only where the code is already clean, and the warn-level preset everywhere else.
+Warnings don't fail `eslint --max-warnings=0`, so add that flag in CI only when you're ready to block on warnings. Until then, warnings are visible signal without pressure.
+
+#### 4. Lock in clean directories one at a time
+
+As individual directories or features reach zero violations, promote them to `/recommended` (errors) so regressions block at PR time. Everything else stays on the warn-level preset.
 
 ```js
 import nextfriday from "eslint-plugin-nextfriday";
@@ -238,11 +313,15 @@ export default [
 ];
 ```
 
-**3. Disable individual rules until the codebase is ready.** Re-declare specific rules with a lower severity (or `"off"`) after spreading the preset. Useful when one rule produces too much noise to fix at once.
+Repeat per directory. This is how you ratchet without flag-day rewrites.
+
+#### 5. Manage exceptions explicitly
+
+Three ways to carve out an exception, in order of preference. Pick the narrowest one that solves the problem.
+
+**Per-rule severity override** — turn off a single noisy rule globally until you can fix it at the codebase level:
 
 ```js
-import nextfriday from "eslint-plugin-nextfriday";
-
 export default [
   nextfriday.configs["react/recommended"],
 
@@ -255,13 +334,55 @@ export default [
 ];
 ```
 
-Pair these with `ignores` to skip vendored or generated files entirely:
+**Per-directory exception** — keep the rule strict everywhere except one stubborn corner:
 
 ```js
-{
-  ignores: ["dist/**", "build/**", "**/*.generated.ts"],
-}
+export default [
+  nextfriday.configs["react/recommended"],
+
+  {
+    files: ["src/legacy/**/*.{ts,tsx}"],
+    rules: {
+      "nextfriday/no-relative-imports": "off",
+      "nextfriday/enforce-camel-case": "off",
+    },
+  },
+];
 ```
+
+**Per-file or per-line disable comments** — last resort, for genuinely irreducible cases:
+
+```ts
+// eslint-disable-next-line nextfriday/no-direct-date
+const epochAnchor = new Date(0);
+
+/* eslint-disable nextfriday/no-emoji */
+export const FLAG_EMOJIS = ["🇹🇭", "🇯🇵", "🇺🇸"];
+/* eslint-enable nextfriday/no-emoji */
+```
+
+Always disable a _named_ rule, never blanket-disable ESLint. A blanket `// eslint-disable` mutes every rule including correctness ones, so legitimate bugs slip through later.
+
+**Skip vendored or generated files entirely** with a top-level ignore — these aren't exceptions to manage, they're code you don't lint at all:
+
+```js
+export default [
+  {
+    ignores: ["dist/**", "build/**", "coverage/**", "**/*.generated.ts"],
+  },
+
+  nextfriday.configs["react/recommended"],
+];
+```
+
+#### 6. Track progress so the migration actually lands
+
+Migrations stall when nobody can see how close you are. Two cheap signals:
+
+- **Violation count over time.** Pipe `pnpm eslint . --no-fix --format compact | wc -l` into your CI metrics or a daily Slack post. Trend it weekly. If the number stops dropping, the migration has stalled.
+- **Verify a single file's resolved config.** When a contributor asks "why did this rule fire on my file?", run `pnpm eslint --print-config path/to/file.tsx`. The output shows exactly which severity ESLint resolved for every rule on that file — usually answers the question in seconds.
+
+Once a directory hits zero, lock it in (step 4). Once the warn-level count hits zero across the whole repo, switch the global preset to `/recommended` and add `--max-warnings=0` to CI. The migration is done.
 
 #### Prioritize rules by impact
 
@@ -379,10 +500,12 @@ In practice: turn the high tier on as `"error"` first, leave the medium tier as 
 | -------------------- | -------- | ---------- | --------- | ------------- | ----------- |
 | `base`               | warn     | 40         | 0         | 0             | 40          |
 | `base/recommended`   | error    | 40         | 0         | 0             | 40          |
-| `react`              | warn     | 40         | 15        | 0             | 55          |
-| `react/recommended`  | error    | 40         | 15        | 0             | 55          |
-| `nextjs`             | warn     | 40         | 15        | 1             | 56          |
-| `nextjs/recommended` | error    | 40         | 15        | 1             | 56          |
+| `react`              | warn     | 40         | 16        | 0             | 56          |
+| `react/recommended`  | error    | 40         | 16        | 0             | 56          |
+| `nextjs`             | warn     | 40         | 16        | 1             | 57          |
+| `nextjs/recommended` | error    | 40         | 16        | 1             | 57          |
+
+The `nextjs` and `nextjs/recommended` presets ship as an array of two flat-config objects: the rule set above, plus a routing override that disables `nextfriday/file-kebab-case` and `nextfriday/jsx-pascal-case` for files matching `app/**/*.{js,jsx,ts,tsx}`, `src/app/**/*.{js,jsx,ts,tsx}`, `pages/**/*.{js,jsx,ts,tsx}`, and `src/pages/**/*.{js,jsx,ts,tsx}`. Next.js owns the filenames in those directories (`page.tsx`, `layout.tsx`, `route.ts`, `middleware.ts`, etc.), so the plugin steps out of the way. ESLint 9+ flattens nested config arrays automatically, so spreading the preset works as expected.
 
 ### Base Configuration Rules (40 rules)
 

--- a/docs/rules/ENFORCE_CONSTANT_CASE.md
+++ b/docs/rules/ENFORCE_CONSTANT_CASE.md
@@ -58,7 +58,36 @@ function foo() {
 
 ## Configuration
 
-This rule pairs with [`no-misleading-constant-case`](./NO_MISLEADING_CONSTANT_CASE.md) so that static globals use `SCREAMING_SNAKE_CASE` while local scopes and dynamic values keep `camelCase`. ESLint 9+ flat config:
+This rule has no options — only severity is configurable (`"error"`, `"warn"`, `"off"`). It pairs with [`no-misleading-constant-case`](./NO_MISLEADING_CONSTANT_CASE.md) so that static globals use `SCREAMING_SNAKE_CASE` while local scopes and dynamic values keep `camelCase`.
+
+### Install
+
+```bash
+pnpm add -D eslint-plugin-nextfriday eslint
+# npm install --save-dev eslint-plugin-nextfriday eslint
+# yarn add --dev eslint-plugin-nextfriday eslint
+```
+
+### Enable just this rule
+
+Use this when you want the rule but not the rest of the preset (e.g., adopting one rule at a time during a migration). The `plugins` field registers the plugin under the `nextfriday` namespace; the `rules` field turns on the rule by name:
+
+```js
+import nextfriday from "eslint-plugin-nextfriday";
+
+export default [
+  {
+    plugins: { nextfriday },
+    rules: {
+      "nextfriday/enforce-constant-case": "error",
+    },
+  },
+];
+```
+
+### Enable with related rules
+
+Constants, locals, and dynamic values each need a different naming convention. Enable the trio together so violations from any direction surface:
 
 ```js
 import nextfriday from "eslint-plugin-nextfriday";
@@ -75,7 +104,9 @@ export default [
 ];
 ```
 
-Or via a preset (every preset already enables all three at the configured severity):
+### Enable via a preset
+
+Every preset includes this rule at the preset's severity (`warn` or `error`). This is the simplest setup and the recommended one for most projects:
 
 ```js
 import nextfriday from "eslint-plugin-nextfriday";
@@ -83,7 +114,38 @@ import nextfriday from "eslint-plugin-nextfriday";
 export default [nextfriday.configs["base/recommended"]];
 ```
 
-This plugin only supports ESLint 9+ flat config — legacy `.eslintrc` is not supported.
+### Scope to a directory
+
+If you're migrating an existing codebase, scope the rule to a clean directory first and leave the rest of the project on `"warn"` until you've fixed the violations there. ESLint 9+ flat config layers configs in array order; the later object's severity wins for any file matching its `files` glob:
+
+```js
+import nextfriday from "eslint-plugin-nextfriday";
+
+export default [
+  nextfriday.configs.base,
+
+  {
+    files: ["src/config/**/*.ts", "src/lib/**/*.ts"],
+    rules: {
+      "nextfriday/enforce-constant-case": "error",
+    },
+  },
+];
+```
+
+### Severity-only — no rule options
+
+Each rule in this plugin uses `schema: []` and `defaultOptions: []` (no options). The flat-config value is **only** the severity string — `"error"`, `"warn"`, or `"off"`. The legacy `["error", { ... }]` array form is not accepted because there are no options to pass.
+
+```js
+// Correct
+"nextfriday/enforce-constant-case": "error"
+
+// Won't apply — there are no options to override
+"nextfriday/enforce-constant-case": ["error", { allowCamelCase: true }]
+```
+
+This plugin only supports ESLint 9+ flat config — legacy `.eslintrc` is not supported. Projects on ESLint 8 or below cannot consume it without upgrading.
 
 ## When Not To Use It
 

--- a/docs/rules/FILE_KEBAB_CASE.md
+++ b/docs/rules/FILE_KEBAB_CASE.md
@@ -40,9 +40,15 @@ This rule enforces that all TypeScript (.ts) and JavaScript (.js) files use keba
 - **Numbers are allowed inside segments.** `file-with-numbers-123.ts` ✓
 - **Single-word filenames are valid.** `single.ts` ✓ (no hyphens needed)
 
+## Scoping the Rule
+
+This rule has **no built-in framework detection**. It checks every `.ts`/`.js` file it sees against kebab-case. In Next.js projects, routing directories (`app/`, `pages/`) contain framework-named files (`route.ts`, `middleware.ts`) that already happen to be kebab-case — but if you colocate helpers there with non-kebab names (`useThing.ts`, `MyHelper.ts`), the rule will flag them.
+
+The `nextjs` and `nextjs/recommended` presets ship with an override that **automatically disables this rule** for files under `app/**`, `src/app/**`, `pages/**`, and `src/pages/**` (matched against `*.{js,jsx,ts,tsx}`). Filename conventions in those directories are owned by the framework, not by this plugin. The `base` and `react` presets do **not** include this override — they enforce `file-kebab-case` on every `.ts`/`.js` regardless of directory.
+
 ## Disabling the Rule
 
-To opt out for a specific directory or file pattern, add an override in your flat config:
+To opt out for additional directories or file patterns, add an override in your flat config:
 
 ```js
 import nextfriday from "eslint-plugin-nextfriday";

--- a/docs/rules/JSX_PASCAL_CASE.md
+++ b/docs/rules/JSX_PASCAL_CASE.md
@@ -30,7 +30,11 @@ This rule enforces that JSX and TSX files use PascalCase naming convention for t
 
 ## Scoping the Rule
 
-This rule has **no built-in framework detection** and no allowlist of "known" filenames. It checks every `.jsx`/`.tsx` it sees. If your project mixes component files with framework routing files that use lowercase names (e.g. Next.js App Router `page.tsx`, `layout.tsx`, `error.tsx`, or Pages Router `_app.tsx`), scope the rule explicitly via ESLint's `files` glob in flat config:
+This rule has **no built-in framework detection** and no allowlist of "known" filenames. It checks every `.jsx`/`.tsx` it sees against PascalCase.
+
+The `nextjs` and `nextjs/recommended` presets ship with an override that **automatically disables this rule** for files under `app/**`, `src/app/**`, `pages/**`, and `src/pages/**` — Next.js owns those filenames (`page.tsx`, `layout.tsx`, `error.tsx`, etc.). If you use a `nextjs` preset, you do not need to add a routing override yourself.
+
+The `base` and `react` presets do **not** include this override. If you use `react` on a Next.js project (or any project that mixes PascalCase component files with lowercase framework routing files), scope the rule explicitly via ESLint's `files` glob:
 
 ```js
 import nextfriday from "eslint-plugin-nextfriday";
@@ -56,7 +60,7 @@ export default [
 
 The first override turns the rule on only inside component directories where PascalCase is the convention. The second override explicitly disables the rule for Next.js routing directories where the framework owns the filename.
 
-The plugin deliberately does not try to detect Next.js, Remix, or other framework conventions automatically — folder structures vary across projects (monorepos, custom `app` locations, hybrid Pages + App Router setups), and a built-in allowlist would inevitably go stale. ESLint's `files` glob is the deterministic way to express the scope you actually want.
+The plugin deliberately does not try to detect Next.js, Remix, or other framework conventions outside of the `nextjs` preset — folder structures vary across projects (monorepos, custom `app` locations, hybrid Pages + App Router setups), and a built-in allowlist would inevitably go stale. ESLint's `files` glob is the deterministic way to express the scope you actually want.
 
 ## When Not To Use It
 

--- a/skills/eslint-plugin-nextfriday/SKILL.md
+++ b/skills/eslint-plugin-nextfriday/SKILL.md
@@ -24,7 +24,7 @@ const userName = getUser(); // not "u" or "temp"
 
 Prefixes: `is`, `has`, `should`, `can`, `did`, `will`, `was`, `are`, `does`, `had`
 
-Files: `.ts` → `kebab-case.ts`, `.tsx` → `PascalCase.tsx`, `.md` → `UPPER_SNAKE_CASE.md`
+Files: `.ts` → `kebab-case.ts`, `.tsx` → `PascalCase.tsx`, `.md` → `UPPER_SNAKE_CASE.md`. Files under `app/**`, `src/app/**`, `pages/**`, `src/pages/**` follow Next.js conventions and are exempt from both filename rules under the `nextjs` preset.
 
 See [naming-conventions.md](./naming-conventions.md) for hook/service naming and props suffix rules.
 

--- a/skills/eslint-plugin-nextfriday/naming-conventions.md
+++ b/skills/eslint-plugin-nextfriday/naming-conventions.md
@@ -55,6 +55,8 @@ const user = getUser();
 | `.tsx`, `.jsx` | PascalCase       | `UserProfile.tsx`    |
 | `.md`          | UPPER_SNAKE_CASE | `GETTING_STARTED.md` |
 
+**Next.js routing exception:** when using the `nextjs` or `nextjs/recommended` preset, files under `app/**`, `src/app/**`, `pages/**`, and `src/pages/**` are exempt from both `file-kebab-case` and `jsx-pascal-case`. Use the framework's own filenames there (`page.tsx`, `layout.tsx`, `error.tsx`, `not-found.tsx`, `route.ts`, `middleware.ts`, etc.) without renaming.
+
 ## Hook and Service Files
 
 - Functions in `*.hook.ts` files must start with `use` prefix

--- a/src/__tests__/configs.test.ts
+++ b/src/__tests__/configs.test.ts
@@ -89,18 +89,21 @@ describe("ESLint Plugin Configs", () => {
       expect(nextjsRules).toHaveProperty("nextfriday/prefer-react-import-types", "warn");
     });
 
-    it("should disable jsx-pascal-case in Next.js routing directories", () => {
+    it("should disable filename rules in Next.js routing directories", () => {
       const override = configs.nextjs[1] as { files: string[]; rules: Record<string, string> };
       expect(override).toHaveProperty("files");
       expect(override.files).toEqual(
         expect.arrayContaining([
-          "app/**/*.{jsx,tsx}",
-          "src/app/**/*.{jsx,tsx}",
-          "pages/**/*.{jsx,tsx}",
-          "src/pages/**/*.{jsx,tsx}",
+          "app/**/*.{js,jsx,ts,tsx}",
+          "src/app/**/*.{js,jsx,ts,tsx}",
+          "pages/**/*.{js,jsx,ts,tsx}",
+          "src/pages/**/*.{js,jsx,ts,tsx}",
         ]),
       );
-      expect(override.rules).toEqual({ "nextfriday/jsx-pascal-case": "off" });
+      expect(override.rules).toEqual({
+        "nextfriday/file-kebab-case": "off",
+        "nextfriday/jsx-pascal-case": "off",
+      });
     });
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -270,15 +270,16 @@ const createConfig = (configRules: Record<string, string>) => ({
 });
 
 const NEXTJS_ROUTING_GLOBS = [
-  "app/**/*.{jsx,tsx}",
-  "src/app/**/*.{jsx,tsx}",
-  "pages/**/*.{jsx,tsx}",
-  "src/pages/**/*.{jsx,tsx}",
+  "app/**/*.{js,jsx,ts,tsx}",
+  "src/app/**/*.{js,jsx,ts,tsx}",
+  "pages/**/*.{js,jsx,ts,tsx}",
+  "src/pages/**/*.{js,jsx,ts,tsx}",
 ];
 
 const nextjsRoutingOverride = {
   files: NEXTJS_ROUTING_GLOBS,
   rules: {
+    "nextfriday/file-kebab-case": "off",
     "nextfriday/jsx-pascal-case": "off",
   },
 };


### PR DESCRIPTION
## Summary

Two changes bundled into one PR (one changeset each):

1. **`fix(nextjs)`** — `nextjs` and `nextjs/recommended` presets now also disable `nextfriday/file-kebab-case` (in addition to `nextfriday/jsx-pascal-case`) for files under `app/**`, `src/app/**`, `pages/**`, and `src/pages/**`. The override globs are widened from `*.{jsx,tsx}` to `*.{js,jsx,ts,tsx}` so framework-named `.ts` files (`route.ts`, `middleware.ts`) are no longer flagged. The `react`/`react/recommended` presets are unchanged — projects on those still enforce `file-kebab-case` on every `.ts`/`.js`. **Minor bump.**

2. **`docs(context7)`** — quality uplift for the three lowest-scoring sections in Context7 evaluations:
   - `README.md` "Per-Directory Configuration" — adds an explanation of how flat config resolves rules (config-array order, `files`/`ignores` precedence, why flat replaces `.eslintrc` overrides), a preset-tier-per-directory table, and an edge-cases / troubleshooting section.
   - `README.md` "Migration Strategy" — restructured around six concrete phases (survey violations with `eslint --format json | jq`, isolate the auto-fix pass into its own PR, adopt the warn-level preset, ratchet clean directories to `/recommended`, manage exceptions via severity → directory → disable-comment, track violation count over time).
   - `docs/rules/ENFORCE_CONSTANT_CASE.md` — Configuration section split into install / enable-just-this-rule / enable-with-related-rules / enable-via-preset / scope-to-directory subsections, plus a "Severity-only — no rule options" callout clarifying the legacy `["error", { ... }]` array form is not accepted.

   **Patch bump.**

Supporting doc updates that go with the fix: `CLAUDE.md`, `docs/rules/FILE_KEBAB_CASE.md`, `docs/rules/JSX_PASCAL_CASE.md`, `skills/eslint-plugin-nextfriday/SKILL.md`, `skills/eslint-plugin-nextfriday/naming-conventions.md`.

## Type of Change

- [x] Bug fix
- [ ] New rule or rule enhancement
- [ ] Breaking change
- [x] Documentation
- [ ] Tooling / CI

## Test Plan

- [x] `pnpm test` — 1303/1303 pass (61 suites)
- [x] `pnpm typecheck` clean
- [x] `pnpm eslint:check` clean
- [x] `pnpm prettier:check` clean
- [x] `src/__tests__/configs.test.ts` updated to assert the new override shape (`files` widened to `*.{js,jsx,ts,tsx}`, `rules` now disables both `file-kebab-case` and `jsx-pascal-case`)
- [x] Pre-push hook ran (test:coverage + typecheck + build succeeded)

Manual verification on a Next.js consumer project:

```js
// eslint.config.mjs
import nextfriday from "eslint-plugin-nextfriday";
export default [nextfriday.configs["nextjs/recommended"]];
```

| File                              | Before this PR                        | After this PR                |
| --------------------------------- | ------------------------------------- | ---------------------------- |
| `app/page.tsx`                    | not flagged (jsx-pascal-case off)     | not flagged (unchanged)      |
| `app/api/route.ts`                | flagged: `file-kebab-case` if renamed | not flagged                  |
| `app/middleware.ts`               | flagged if user moves to `app/`       | not flagged                  |
| `src/providers/Provider.tsx`      | not flagged (PascalCase, valid)       | not flagged (unchanged)      |
| `src/utils/myHelper.ts`           | flagged: `file-kebab-case`            | flagged: `file-kebab-case`   |

## Related Issues

User report: filename rules incorrectly applying to framework-owned files in Next.js routing directories.