### PR TITLE
feat(rules): add index-only and type-import lints

### DIFF
--- a/.changeset/index-export-only-rule.md
+++ b/.changeset/index-export-only-rule.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-nextfriday": minor
+---
+
+Add `index-export-only` rule. Restricts `index.{js,jsx,ts,tsx}` files to imports, re-exports, and type/interface declarations only — flagging local function/class/variable declarations, inline `export const`/`export function`/`export class`, top-level expressions, and control flow. Type aliases, interfaces, and `export type` are allowed since they have no runtime cost. Included in `base`, `react`, and `nextjs` presets.

--- a/.changeset/no-inline-type-import-rule.md
+++ b/.changeset/no-inline-type-import-rule.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-nextfriday": minor
+---
+
+Add `no-inline-type-import` rule. Disallows inline `type` markers on import specifiers (`import { type Foo }` and `import { value, type Foo }`); auto-fix hoists single inline-type imports to `import type { ... }` and splits mixed value/type imports into two separate statements while preserving aliases, default specifiers, and quote style. Also strips redundant inline markers from existing `import type { ... }` statements. Included in `base`, `react`, and `nextjs` presets.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-This is `eslint-plugin-nextfriday`, an ESLint plugin providing custom rules and configurations for Next Friday development workflows. Supports ESLint 9+ flat config with presets for base (JS/TS), React, and Next.js projects. Built with tsup for dual CJS/ESM output.
+This is `eslint-plugin-nextfriday`, an ESLint plugin providing custom rules and configurations for Next Friday development workflows. Requires ESLint 10+ flat config (peer dependency `^10.0.0`) with presets for base (JS/TS), React, and Next.js projects. Built with tsup for dual CJS/ESM output.
 
 ## Development Commands
 
@@ -22,6 +22,7 @@ pnpm prettier:check      # Verify formatting
 pnpm sort-package-json   # Sort package.json keys
 pnpm clear               # Remove lib/, node_modules/.cache, .eslintcache
 pnpm changeset           # Create a changeset for version bumping
+pnpm audit               # Audit prod dependencies at high severity
 ```
 
 The plugin dogfoods its own rules via `eslint.config.mjs`. Build config lives in `tsup.config.ts`, Jest config in `jest.config.ts`. Distributed exports (per `package.json`): `lib/index.js` (ESM), `lib/index.cjs` (CJS), `lib/index.d.ts` (types).
@@ -33,7 +34,7 @@ The plugin dogfoods its own rules via `eslint.config.mjs`. Build config lives in
 `src/index.ts` - Main plugin export containing:
 
 - `meta` - Plugin name and version from package.json
-- `rules` - All 57 rule implementations keyed by hyphenated name
+- `rules` - All 59 rule implementations keyed by hyphenated name
 - `configs` - Six configuration presets (each rule set has a `warn` and `error`/`recommended` variant). `base`/`react` presets are built via `createConfig()` and return a single config object; `nextjs` presets are built via `createNextjsConfig()` and return an **array** containing the base config plus a routing override that disables both `file-kebab-case` and `jsx-pascal-case` for files under `app/**`, `src/app/**`, `pages/**`, `src/pages/**` (matched against `*.{js,jsx,ts,tsx}`) — Next.js owns these filenames (`page.tsx`, `layout.tsx`, `route.ts`, `middleware.ts`, etc.). Consumers must spread these arrays into their flat config.
 
 The plugin is exported both as default and as named exports `{ meta, configs, rules }`.
@@ -52,9 +53,9 @@ Six configs total. Three rule set tiers, each with a `warn` variant and a `Recom
 
 | Preset                          | Rules                       | Severity     |
 | ------------------------------- | --------------------------- | ------------ |
-| `base` / `base/recommended`     | 40 base                     | warn / error |
-| `react` / `react/recommended`   | 40 base + 16 JSX            | warn / error |
-| `nextjs` / `nextjs/recommended` | 40 base + 16 JSX + 1 nextjs | warn / error |
+| `base` / `base/recommended`     | 42 base                     | warn / error |
+| `react` / `react/recommended`   | 42 base + 16 JSX            | warn / error |
+| `nextjs` / `nextjs/recommended` | 42 base + 16 JSX + 1 nextjs | warn / error |
 
 ### Utilities
 
@@ -164,4 +165,4 @@ Git hooks (husky): `pre-commit` runs lint-staged, `pre-push` runs `test:coverage
 
 - Node: >=22.0.0
 - pnpm: >=9.0.0 (enforced)
-- ESLint: ^9.0.0 (peer dependency)
+- ESLint: ^10.0.0 (peer dependency)

--- a/README.md
+++ b/README.md
@@ -434,6 +434,7 @@ In practice: turn the high tier on as `"error"` first, leave the medium tier as 
 | [enforce-sorted-destructuring](docs/rules/ENFORCE_SORTED_DESTRUCTURING.md)   | Enforce alphabetical sorting of destructured properties                | ✅      |
 | [no-env-fallback](docs/rules/NO_ENV_FALLBACK.md)                             | Disallow fallback values for environment variables                     | ❌      |
 | [no-inline-default-export](docs/rules/NO_INLINE_DEFAULT_EXPORT.md)           | Disallow inline default exports - declare first, then export           | ❌      |
+| [index-export-only](docs/rules/INDEX_EXPORT_ONLY.md)                         | Restrict index files to imports, re-exports, and type declarations     | ❌      |
 | [no-direct-date](docs/rules/NO_DIRECT_DATE.md)                               | Disallow direct usage of Date constructor and methods                  | ❌      |
 | [newline-after-multiline-block](docs/rules/NEWLINE_AFTER_MULTILINE_BLOCK.md) | Require a blank line after multi-line statements                       | ✅      |
 | [newline-before-return](docs/rules/NEWLINE_BEFORE_RETURN.md)                 | Require a blank line before return statements                          | ✅      |
@@ -449,6 +450,7 @@ In practice: turn the high tier on as `"error"` first, leave the medium tier as 
 | Rule                                                                 | Description                                               | Fixable |
 | -------------------------------------------------------------------- | --------------------------------------------------------- | ------- |
 | [no-relative-imports](docs/rules/NO_RELATIVE_IMPORTS.md)             | Disallow relative imports with ../ - use absolute imports | ❌      |
+| [no-inline-type-import](docs/rules/NO_INLINE_TYPE_IMPORT.md)         | Disallow inline 'type' markers - hoist or split imports   | ✅      |
 | [prefer-import-type](docs/rules/PREFER_IMPORT_TYPE.md)               | Enforce using 'import type' for type-only imports         | ✅      |
 | [prefer-react-import-types](docs/rules/PREFER_REACT_IMPORT_TYPES.md) | Enforce direct imports from 'react' instead of React.X    | ✅      |
 | [sort-exports](docs/rules/SORT_EXPORTS.md)                           | Enforce a consistent ordering of export groups            | ✅      |
@@ -498,16 +500,16 @@ In practice: turn the high tier on as `"error"` first, leave the medium tier as 
 
 | Preset               | Severity | Base Rules | JSX Rules | Next.js Rules | Total Rules |
 | -------------------- | -------- | ---------- | --------- | ------------- | ----------- |
-| `base`               | warn     | 40         | 0         | 0             | 40          |
-| `base/recommended`   | error    | 40         | 0         | 0             | 40          |
-| `react`              | warn     | 40         | 16        | 0             | 56          |
-| `react/recommended`  | error    | 40         | 16        | 0             | 56          |
-| `nextjs`             | warn     | 40         | 16        | 1             | 57          |
-| `nextjs/recommended` | error    | 40         | 16        | 1             | 57          |
+| `base`               | warn     | 42         | 0         | 0             | 42          |
+| `base/recommended`   | error    | 42         | 0         | 0             | 42          |
+| `react`              | warn     | 42         | 16        | 0             | 58          |
+| `react/recommended`  | error    | 42         | 16        | 0             | 58          |
+| `nextjs`             | warn     | 42         | 16        | 1             | 59          |
+| `nextjs/recommended` | error    | 42         | 16        | 1             | 59          |
 
 The `nextjs` and `nextjs/recommended` presets ship as an array of two flat-config objects: the rule set above, plus a routing override that disables `nextfriday/file-kebab-case` and `nextfriday/jsx-pascal-case` for files matching `app/**/*.{js,jsx,ts,tsx}`, `src/app/**/*.{js,jsx,ts,tsx}`, `pages/**/*.{js,jsx,ts,tsx}`, and `src/pages/**/*.{js,jsx,ts,tsx}`. Next.js owns the filenames in those directories (`page.tsx`, `layout.tsx`, `route.ts`, `middleware.ts`, etc.), so the plugin steps out of the way. ESLint 9+ flattens nested config arrays automatically, so spreading the preset works as expected.
 
-### Base Configuration Rules (40 rules)
+### Base Configuration Rules (42 rules)
 
 Included in `base`, `base/recommended`, and all other presets:
 
@@ -521,6 +523,7 @@ Included in `base`, `base/recommended`, and all other presets:
 - `nextfriday/enforce-sorted-destructuring`
 - `nextfriday/enforce-type-declaration-order`
 - `nextfriday/file-kebab-case`
+- `nextfriday/index-export-only`
 - `nextfriday/newline-after-multiline-block`
 - `nextfriday/newline-before-return`
 - `nextfriday/no-complex-inline-return`
@@ -530,6 +533,7 @@ Included in `base`, `base/recommended`, and all other presets:
 - `nextfriday/no-inline-default-export`
 - `nextfriday/no-inline-nested-object`
 - `nextfriday/no-inline-return-properties`
+- `nextfriday/no-inline-type-import`
 - `nextfriday/no-lazy-identifiers`
 - `nextfriday/no-logic-in-params`
 - `nextfriday/no-misleading-constant-case`

--- a/docs/rules/INDEX_EXPORT_ONLY.md
+++ b/docs/rules/INDEX_EXPORT_ONLY.md
@@ -1,0 +1,88 @@
+# index-export-only
+
+Restrict `index` files to imports, re-exports, and type declarations only.
+
+## Rule Details
+
+This rule enforces that `index.{js,jsx,ts,tsx}` files act purely as barrel files. Any runtime declaration — functions, classes, variables, top-level expressions, or inline `export const`/`export function`/`export class` — must live in its own module and be re-exported from the index.
+
+The rule applies only when the basename of the file is `index`. Files like `index.test.ts`, `index.spec.ts`, or `index.d.ts` are not affected.
+
+### Why?
+
+Index files are entry points. Mixing implementation into them obscures where behavior lives, breaks file-based code navigation, and makes the import surface harder to refactor. A barrel file should describe the public API of a directory — nothing more.
+
+## Examples
+
+### Incorrect
+
+```ts
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+function cn(...inputs: ClassValue[]): string {
+  return twMerge(clsx(inputs));
+}
+
+export { cn };
+```
+
+```ts
+export const VERSION = "1.0.0";
+
+export function helper() {
+  return 1;
+}
+
+export class Service {}
+```
+
+```ts
+console.log("loaded");
+```
+
+### Correct
+
+```ts
+export { cn } from "./cn";
+export * from "./types";
+export type { Props } from "./props";
+export { default as Button } from "./button";
+```
+
+```ts
+import button from "./button";
+
+export default button;
+```
+
+```ts
+export type Foo = string;
+export interface Bar {
+  id: string;
+}
+```
+
+## What This Rule Allows
+
+- `import` statements (including side-effect imports like `import "./styles.css"`)
+- Specifier-only `export` and `export ... from` re-exports
+- `export *` and `export * as ns` re-exports
+- `export default identifier` where the identifier comes from an import
+- Top-level `type` aliases and `interface` declarations (they have no runtime cost)
+- `export type` and `export interface` declarations
+
+## What This Rule Disallows
+
+- `function`, `class`, and `const`/`let`/`var` declarations at the top level
+- Inline `export function`, `export class`, `export const`, `export let`, `export var`
+- `export default` of a function/class/literal/object expression
+- Top-level expression statements and control flow (`console.log(...)`, `if`, `for`, etc.)
+
+## When Not To Use It
+
+If your project intentionally mixes implementation and re-exports in index files — for example, a single-file utility library where `index.ts` is the only source file — disable this rule.
+
+## Related Rules
+
+- [no-inline-default-export](./NO_INLINE_DEFAULT_EXPORT.md) - Disallow inline default and named exports across all files

--- a/docs/rules/NO_INLINE_TYPE_IMPORT.md
+++ b/docs/rules/NO_INLINE_TYPE_IMPORT.md
@@ -1,0 +1,86 @@
+# no-inline-type-import
+
+Disallow inline `type` markers on import specifiers. Use `import type` or split into a separate type-only import statement.
+
+> This rule is auto-fixable using `--fix`.
+
+## Rule Details
+
+This rule forbids the inline-`type` form `import { type Foo }` and the mixed form `import { value, type Foo }`. Type-only imports must be expressed at the statement level with `import type { ... }`. When value and type imports come from the same module, the rule splits them into two separate statements.
+
+### Why?
+
+Statement-level `import type` makes the runtime cost of every import unambiguous at a glance, simplifies tooling that distinguishes erased imports from real ones (bundlers, type-only emit, transpilers), and removes the need for readers to scan each specifier for an inline keyword.
+
+## Examples
+
+### Incorrect
+
+```ts
+import { type foo } from "bar";
+
+import { baz, type moo } from "mee";
+
+import Default, { value, type Foo } from "src";
+```
+
+### Correct
+
+```ts
+import type { foo } from "bar";
+
+import { baz } from "mee";
+import type { moo } from "mee";
+
+import Default, { value } from "src";
+import type { Foo } from "src";
+```
+
+## Auto-fixing
+
+The rule's `--fix` produces these transformations:
+
+```ts
+// Single inline type → hoisted
+import { type foo } from "bar";
+// becomes
+import type { foo } from "bar";
+
+// All inline types → hoisted
+import { type foo, type bar } from "src";
+// becomes
+import type { foo, bar } from "src";
+
+// Mixed value + inline type → split
+import { baz, type moo } from "mee";
+// becomes
+import { baz } from "mee";
+import type { moo } from "mee";
+
+// Default + inline type → split
+import Default, { type Foo } from "src";
+// becomes
+import Default from "src";
+import type { Foo } from "src";
+
+// Aliases are preserved
+import { foo as bar, type baz as qux } from "src";
+// becomes
+import { foo as bar } from "src";
+import type { baz as qux } from "src";
+
+// Redundant inline markers inside `import type` are stripped
+import type { foo, type bar } from "src";
+// becomes
+import type { foo, bar } from "src";
+```
+
+After auto-fix, other import-ordering rules (such as `sort-imports`) may re-order the resulting statements according to their own grouping rules.
+
+## When Not To Use It
+
+If your codebase intentionally uses the inline `type` form to keep value and type imports adjacent in a single statement, disable this rule.
+
+## Related Rules
+
+- [prefer-import-type](./PREFER_IMPORT_TYPE.md) - Hoists imports that are used only as types to `import type`. Complements this rule for usage-based detection.

--- a/src/__tests__/rules.test.ts
+++ b/src/__tests__/rules.test.ts
@@ -88,8 +88,8 @@ describe("ESLint Plugin Rules", () => {
     expect(typeof rules["no-env-fallback"].create).toBe("function");
   });
 
-  it("should have exactly 57 rules", () => {
-    expect(Object.keys(rules)).toHaveLength(57);
+  it("should have exactly 59 rules", () => {
+    expect(Object.keys(rules)).toHaveLength(59);
   });
 
   it("should have correct rule names", () => {
@@ -151,6 +151,8 @@ describe("ESLint Plugin Rules", () => {
     expect(ruleNames).toContain("no-misleading-constant-case");
     expect(ruleNames).toContain("no-nested-interface-declaration");
     expect(ruleNames).toContain("enforce-type-declaration-order");
+    expect(ruleNames).toContain("index-export-only");
+    expect(ruleNames).toContain("no-inline-type-import");
   });
 
   it("should have prefer-interface-over-inline-types rule", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import enforceServiceNaming from "./rules/enforce-service-naming";
 import enforceSortedDestructuring from "./rules/enforce-sorted-destructuring";
 import enforceTypeDeclarationOrder from "./rules/enforce-type-declaration-order";
 import fileKebabCase from "./rules/file-kebab-case";
+import indexExportOnly from "./rules/index-export-only";
 import jsxNewlineBetweenElements from "./rules/jsx-newline-between-elements";
 import jsxNoInlineObjectProp from "./rules/jsx-no-inline-object-prop";
 import jsxNoNewlineSingleLineElements from "./rules/jsx-no-newline-single-line-elements";
@@ -33,6 +34,7 @@ import noEnvFallback from "./rules/no-env-fallback";
 import noInlineDefaultExport from "./rules/no-inline-default-export";
 import noInlineNestedObject from "./rules/no-inline-nested-object";
 import noInlineReturnProperties from "./rules/no-inline-return-properties";
+import noInlineTypeImport from "./rules/no-inline-type-import";
 import noLazyIdentifiers from "./rules/no-lazy-identifiers";
 import noLogicInParams from "./rules/no-logic-in-params";
 import noMisleadingConstantCase from "./rules/no-misleading-constant-case";
@@ -78,6 +80,7 @@ const rules = {
   "enforce-sorted-destructuring": enforceSortedDestructuring,
   "enforce-type-declaration-order": enforceTypeDeclarationOrder,
   "file-kebab-case": fileKebabCase,
+  "index-export-only": indexExportOnly,
   "jsx-newline-between-elements": jsxNewlineBetweenElements,
   "jsx-no-inline-object-prop": jsxNoInlineObjectProp,
   "jsx-no-newline-single-line-elements": jsxNoNewlineSingleLineElements,
@@ -99,6 +102,7 @@ const rules = {
   "no-inline-default-export": noInlineDefaultExport,
   "no-inline-nested-object": noInlineNestedObject,
   "no-inline-return-properties": noInlineReturnProperties,
+  "no-inline-type-import": noInlineTypeImport,
   "no-lazy-identifiers": noLazyIdentifiers,
   "no-logic-in-params": noLogicInParams,
   "no-misleading-constant-case": noMisleadingConstantCase,
@@ -141,6 +145,7 @@ const baseRules = {
   "nextfriday/enforce-sorted-destructuring": "warn",
   "nextfriday/enforce-type-declaration-order": "warn",
   "nextfriday/file-kebab-case": "warn",
+  "nextfriday/index-export-only": "warn",
   "nextfriday/newline-after-multiline-block": "warn",
   "nextfriday/newline-before-return": "warn",
   "nextfriday/no-complex-inline-return": "warn",
@@ -150,6 +155,7 @@ const baseRules = {
   "nextfriday/no-inline-default-export": "warn",
   "nextfriday/no-inline-nested-object": "warn",
   "nextfriday/no-inline-return-properties": "warn",
+  "nextfriday/no-inline-type-import": "warn",
   "nextfriday/no-lazy-identifiers": "warn",
   "nextfriday/no-logic-in-params": "warn",
   "nextfriday/no-misleading-constant-case": "warn",
@@ -184,6 +190,7 @@ const baseRecommendedRules = {
   "nextfriday/enforce-sorted-destructuring": "error",
   "nextfriday/enforce-type-declaration-order": "error",
   "nextfriday/file-kebab-case": "error",
+  "nextfriday/index-export-only": "error",
   "nextfriday/newline-after-multiline-block": "error",
   "nextfriday/newline-before-return": "error",
   "nextfriday/no-complex-inline-return": "error",
@@ -193,6 +200,7 @@ const baseRecommendedRules = {
   "nextfriday/no-inline-default-export": "error",
   "nextfriday/no-inline-nested-object": "error",
   "nextfriday/no-inline-return-properties": "error",
+  "nextfriday/no-inline-type-import": "error",
   "nextfriday/no-lazy-identifiers": "error",
   "nextfriday/no-logic-in-params": "error",
   "nextfriday/no-misleading-constant-case": "error",

--- a/src/rules/__tests__/index-export-only.test.ts
+++ b/src/rules/__tests__/index-export-only.test.ts
@@ -1,0 +1,262 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import { afterAll, describe, it } from "@jest/globals";
+
+import indexExportOnly from "../index-export-only";
+
+RuleTester.afterAll = afterAll;
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const ruleTester = new RuleTester();
+
+describe("index-export-only", () => {
+  ruleTester.run("index-export-only", indexExportOnly, {
+    valid: [
+      {
+        code: `export { cn } from "./cn";`,
+        filename: "index.ts",
+        name: "should allow named re-export from another module",
+      },
+      {
+        code: `export * from "./types";`,
+        filename: "index.ts",
+        name: "should allow star re-export",
+      },
+      {
+        code: `export * as utils from "./utils";`,
+        filename: "index.ts",
+        name: "should allow namespace re-export",
+      },
+      {
+        code: `export type { Props } from "./props";`,
+        filename: "index.ts",
+        name: "should allow type re-export",
+      },
+      {
+        code: `export { default } from "./button";`,
+        filename: "index.ts",
+        name: "should allow default re-export",
+      },
+      {
+        code: `export { foo as default } from "./foo";`,
+        filename: "index.ts",
+        name: "should allow renamed default re-export",
+      },
+      {
+        code: `
+import { cn } from "./cn";
+
+export { cn };
+`,
+        filename: "index.ts",
+        name: "should allow import followed by specifier-only export",
+      },
+      {
+        code: `
+import button from "./button";
+
+export default button;
+`,
+        filename: "index.ts",
+        name: "should allow default export of imported identifier",
+      },
+      {
+        code: `
+type Foo = string;
+
+export type { Foo };
+`,
+        filename: "index.ts",
+        name: "should allow top-level type alias declaration",
+      },
+      {
+        code: `
+interface Bar {
+  id: string;
+}
+
+export type { Bar };
+`,
+        filename: "index.ts",
+        name: "should allow top-level interface declaration",
+      },
+      {
+        code: `export type Foo = string;`,
+        filename: "index.ts",
+        name: "should allow exported type alias declaration",
+      },
+      {
+        code: `export interface Bar { id: string; }`,
+        filename: "index.ts",
+        name: "should allow exported interface declaration",
+      },
+      {
+        code: ``,
+        filename: "index.ts",
+        name: "should allow empty file",
+      },
+      {
+        code: `import "./side-effect";`,
+        filename: "index.ts",
+        name: "should allow side-effect imports",
+      },
+      {
+        code: `
+function cn() {
+  return "x";
+}
+
+export { cn };
+`,
+        filename: "src/utils/cn.ts",
+        name: "should not lint non-index files",
+      },
+      {
+        code: `
+function cn() {
+  return "x";
+}
+
+export { cn };
+`,
+        filename: "index.test.ts",
+        name: "should not lint files like index.test.ts",
+      },
+    ],
+    invalid: [
+      {
+        code: `
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+function cn(...inputs: ClassValue[]): string {
+  return twMerge(clsx(inputs));
+}
+
+export { cn };
+`,
+        filename: "index.ts",
+        name: "should reject local function declaration",
+        errors: [{ messageId: "indexExportOnly" }],
+      },
+      {
+        code: `
+const value = 42;
+
+export { value };
+`,
+        filename: "index.ts",
+        name: "should reject local variable declaration",
+        errors: [{ messageId: "indexExportOnly" }],
+      },
+      {
+        code: `
+class Service {}
+
+export { Service };
+`,
+        filename: "index.ts",
+        name: "should reject local class declaration",
+        errors: [{ messageId: "indexExportOnly" }],
+      },
+      {
+        code: `export const foo = 1;`,
+        filename: "index.ts",
+        name: "should reject inline named const export",
+        errors: [{ messageId: "indexExportOnly" }],
+      },
+      {
+        code: `export function bar() { return 1; }`,
+        filename: "index.ts",
+        name: "should reject inline named function export",
+        errors: [{ messageId: "indexExportOnly" }],
+      },
+      {
+        code: `export class Baz {}`,
+        filename: "index.ts",
+        name: "should reject inline named class export",
+        errors: [{ messageId: "indexExportOnly" }],
+      },
+      {
+        code: `export default function() { return 1; }`,
+        filename: "index.ts",
+        name: "should reject inline anonymous default function",
+        errors: [{ messageId: "indexExportOnly" }],
+      },
+      {
+        code: `export default class {}`,
+        filename: "index.ts",
+        name: "should reject inline anonymous default class",
+        errors: [{ messageId: "indexExportOnly" }],
+      },
+      {
+        code: `export default 42;`,
+        filename: "index.ts",
+        name: "should reject inline default literal",
+        errors: [{ messageId: "indexExportOnly" }],
+      },
+      {
+        code: `console.log("side effect");`,
+        filename: "index.ts",
+        name: "should reject top-level expression statements",
+        errors: [{ messageId: "indexExportOnly" }],
+      },
+      {
+        code: `
+if (process.env.NODE_ENV === "production") {
+  console.log("prod");
+}
+`,
+        filename: "index.ts",
+        name: "should reject top-level control flow",
+        errors: [{ messageId: "indexExportOnly" }],
+      },
+      {
+        code: `
+function helper() {}
+
+class Service {}
+
+const value = 1;
+`,
+        filename: "index.ts",
+        name: "should report each disallowed statement",
+        errors: [{ messageId: "indexExportOnly" }, { messageId: "indexExportOnly" }, { messageId: "indexExportOnly" }],
+      },
+      {
+        code: `
+function cn() {
+  return "x";
+}
+
+export { cn };
+`,
+        filename: "index.tsx",
+        name: "should lint index.tsx files",
+        errors: [{ messageId: "indexExportOnly" }],
+      },
+      {
+        code: `
+function cn() {
+  return "x";
+}
+
+export { cn };
+`,
+        filename: "index.js",
+        name: "should lint index.js files",
+        errors: [{ messageId: "indexExportOnly" }],
+      },
+    ],
+  });
+
+  describe("rule structure", () => {
+    it("should have meta property", () => {
+      expect(indexExportOnly.meta).toBeDefined();
+    });
+
+    it("should have create method", () => {
+      expect(typeof indexExportOnly.create).toBe("function");
+    });
+  });
+});

--- a/src/rules/__tests__/no-inline-type-import.test.ts
+++ b/src/rules/__tests__/no-inline-type-import.test.ts
@@ -1,0 +1,137 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import { afterAll, describe, it } from "@jest/globals";
+
+import noInlineTypeImport from "../no-inline-type-import";
+
+RuleTester.afterAll = afterAll;
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const ruleTester = new RuleTester();
+
+describe("no-inline-type-import", () => {
+  ruleTester.run("no-inline-type-import", noInlineTypeImport, {
+    valid: [
+      {
+        code: `import { foo } from "bar";`,
+        name: "should allow regular value import",
+      },
+      {
+        code: `import type { foo } from "bar";`,
+        name: "should allow declaration-level type import",
+      },
+      {
+        code: `import type { foo, bar } from "src";`,
+        name: "should allow multiple specifiers in type import",
+      },
+      {
+        code: `import * as ns from "bar";`,
+        name: "should allow namespace import",
+      },
+      {
+        code: `import Default from "bar";`,
+        name: "should allow default import",
+      },
+      {
+        code: `import Default, { foo, bar } from "src";`,
+        name: "should allow default with named value imports",
+      },
+      {
+        code: `import "./side-effect";`,
+        name: "should allow side-effect imports",
+      },
+      {
+        code: `import type * as ns from "bar";`,
+        name: "should allow namespace type import",
+      },
+      {
+        code: `import type Default from "bar";`,
+        name: "should allow default type import",
+      },
+    ],
+    invalid: [
+      {
+        code: `import { type foo } from "bar";`,
+        name: "should hoist single inline type to import type",
+        output: `import type { foo } from "bar";`,
+        errors: [{ messageId: "noInlineTypeImport" }],
+      },
+      {
+        code: `import { type foo, type bar } from "src";`,
+        name: "should hoist multiple inline types to import type",
+        output: `import type { foo, bar } from "src";`,
+        errors: [{ messageId: "noInlineTypeImport" }],
+      },
+      {
+        code: `import { baz, type moo } from "mee";`,
+        name: "should split mixed value and inline type into two statements",
+        output: `import { baz } from "mee";\nimport type { moo } from "mee";`,
+        errors: [{ messageId: "noInlineTypeImport" }],
+      },
+      {
+        code: `import { value, type Foo, type Bar } from "src";`,
+        name: "should split mixed with multiple type specifiers",
+        output: `import { value } from "src";\nimport type { Foo, Bar } from "src";`,
+        errors: [{ messageId: "noInlineTypeImport" }],
+      },
+      {
+        code: `import { type Foo, value } from "src";`,
+        name: "should split when inline type comes first",
+        output: `import { value } from "src";\nimport type { Foo } from "src";`,
+        errors: [{ messageId: "noInlineTypeImport" }],
+      },
+      {
+        code: `import Default, { type Foo } from "src";`,
+        name: "should split default and inline type",
+        output: `import Default from "src";\nimport type { Foo } from "src";`,
+        errors: [{ messageId: "noInlineTypeImport" }],
+      },
+      {
+        code: `import Default, { value, type Foo } from "src";`,
+        name: "should split default with mixed named",
+        output: `import Default, { value } from "src";\nimport type { Foo } from "src";`,
+        errors: [{ messageId: "noInlineTypeImport" }],
+      },
+      {
+        code: `import { foo as bar, type baz as qux } from "src";`,
+        name: "should preserve aliases when splitting",
+        output: `import { foo as bar } from "src";\nimport type { baz as qux } from "src";`,
+        errors: [{ messageId: "noInlineTypeImport" }],
+      },
+      {
+        code: `import { type foo as bar } from "src";`,
+        name: "should preserve alias on hoist",
+        output: `import type { foo as bar } from "src";`,
+        errors: [{ messageId: "noInlineTypeImport" }],
+      },
+      {
+        code: `import { type foo } from 'bar';`,
+        name: "should preserve single quotes",
+        output: `import type { foo } from 'bar';`,
+        errors: [{ messageId: "noInlineTypeImport" }],
+      },
+      {
+        code: `import type { type foo } from "bar";`,
+        name: "should strip redundant inline type from import type",
+        output: `import type { foo } from "bar";`,
+        errors: [{ messageId: "noInlineTypeImport" }],
+      },
+      {
+        code: `import type { foo, type bar } from "src";`,
+        name: "should strip multiple redundant inline types from import type",
+        output: `import type { foo, bar } from "src";`,
+        errors: [{ messageId: "noInlineTypeImport" }],
+      },
+    ],
+  });
+
+  describe("rule structure", () => {
+    it("should have meta property", () => {
+      expect(noInlineTypeImport.meta).toBeDefined();
+    });
+
+    it("should have create method", () => {
+      expect(typeof noInlineTypeImport.create).toBe("function");
+    });
+  });
+});

--- a/src/rules/index-export-only.ts
+++ b/src/rules/index-export-only.ts
@@ -1,0 +1,79 @@
+import { AST_NODE_TYPES, ESLintUtils } from "@typescript-eslint/utils";
+
+import { getBaseName } from "../utils";
+
+import type { TSESTree } from "@typescript-eslint/utils";
+
+const createRule = ESLintUtils.RuleCreator(
+  (name) =>
+    `https://github.com/next-friday/eslint-plugin-nextfriday/blob/main/docs/rules/${name.replaceAll("-", "_").toUpperCase()}.md`,
+);
+
+const isIndexFile = (filename: string): boolean => getBaseName(filename) === "index";
+
+const isAllowedExportNamed = (node: TSESTree.ExportNamedDeclaration): boolean => {
+  if (!node.declaration) {
+    return true;
+  }
+
+  return (
+    node.declaration.type === AST_NODE_TYPES.TSTypeAliasDeclaration ||
+    node.declaration.type === AST_NODE_TYPES.TSInterfaceDeclaration
+  );
+};
+
+const isAllowedExportDefault = (node: TSESTree.ExportDefaultDeclaration): boolean =>
+  node.declaration.type === AST_NODE_TYPES.Identifier;
+
+const isAllowedTopLevel = (node: TSESTree.ProgramStatement): boolean => {
+  switch (node.type) {
+    case AST_NODE_TYPES.ImportDeclaration:
+    case AST_NODE_TYPES.ExportAllDeclaration:
+    case AST_NODE_TYPES.TSTypeAliasDeclaration:
+    case AST_NODE_TYPES.TSInterfaceDeclaration:
+    case AST_NODE_TYPES.TSImportEqualsDeclaration:
+      return true;
+    case AST_NODE_TYPES.ExportNamedDeclaration:
+      return isAllowedExportNamed(node);
+    case AST_NODE_TYPES.ExportDefaultDeclaration:
+      return isAllowedExportDefault(node);
+    default:
+      return false;
+  }
+};
+
+const indexExportOnly = createRule({
+  name: "index-export-only",
+  meta: {
+    type: "suggestion",
+    docs: {
+      description: "Restrict index files to imports, re-exports, and type declarations only.",
+    },
+    messages: {
+      indexExportOnly:
+        "Index files must contain only imports, re-exports, and type declarations. Move runtime code to a separate module and re-export it from here.",
+    },
+    schema: [],
+  },
+  defaultOptions: [],
+  create(context) {
+    if (!isIndexFile(context.filename)) {
+      return {};
+    }
+
+    return {
+      Program(node: TSESTree.Program) {
+        for (const statement of node.body) {
+          if (!isAllowedTopLevel(statement)) {
+            context.report({
+              node: statement,
+              messageId: "indexExportOnly",
+            });
+          }
+        }
+      },
+    };
+  },
+});
+
+export default indexExportOnly;

--- a/src/rules/no-inline-type-import.ts
+++ b/src/rules/no-inline-type-import.ts
@@ -1,0 +1,91 @@
+import { AST_NODE_TYPES, ESLintUtils } from "@typescript-eslint/utils";
+
+import type { TSESTree } from "@typescript-eslint/utils";
+
+const createRule = ESLintUtils.RuleCreator(
+  (name) =>
+    `https://github.com/next-friday/eslint-plugin-nextfriday/blob/main/docs/rules/${name.replaceAll("-", "_").toUpperCase()}.md`,
+);
+
+const isInlineTypeSpecifier = (specifier: TSESTree.ImportClause): specifier is TSESTree.ImportSpecifier =>
+  specifier.type === AST_NODE_TYPES.ImportSpecifier && specifier.importKind === "type";
+
+const noInlineTypeImport = createRule({
+  name: "no-inline-type-import",
+  meta: {
+    type: "suggestion",
+    docs: {
+      description:
+        "Disallow inline 'type' markers on import specifiers. Use 'import type' or split into a separate type-only import statement.",
+    },
+    fixable: "code",
+    messages: {
+      noInlineTypeImport:
+        "Avoid inline 'type' markers on import specifiers. Hoist to 'import type' or split into a separate type-only import statement.",
+    },
+    schema: [],
+  },
+  defaultOptions: [],
+  create(context) {
+    return {
+      ImportDeclaration(node: TSESTree.ImportDeclaration) {
+        const inlineTypeSpecifiers = node.specifiers.filter(isInlineTypeSpecifier);
+
+        if (inlineTypeSpecifiers.length === 0) {
+          return;
+        }
+
+        context.report({
+          node,
+          messageId: "noInlineTypeImport",
+          fix(fixer) {
+            if (node.importKind === "type") {
+              return inlineTypeSpecifiers.map((specifier) =>
+                fixer.removeRange([specifier.range[0], specifier.imported.range[0]]),
+              );
+            }
+
+            const sourceText = context.sourceCode.getText(node.source);
+            const fileText = context.sourceCode.text;
+
+            const typeSpecifierTexts = inlineTypeSpecifiers.map((specifier) =>
+              fileText.slice(specifier.imported.range[0], specifier.range[1]),
+            );
+            const typeImport = `import type { ${typeSpecifierTexts.join(", ")} } from ${sourceText};`;
+
+            const valueSpecifiers = node.specifiers.filter(
+              (specifier) => !(specifier.type === AST_NODE_TYPES.ImportSpecifier && specifier.importKind === "type"),
+            );
+
+            if (valueSpecifiers.length === 0) {
+              return fixer.replaceText(node, typeImport);
+            }
+
+            const parts: string[] = [];
+            const namedValueSpecifiers: TSESTree.ImportSpecifier[] = [];
+
+            for (const specifier of valueSpecifiers) {
+              if (specifier.type === AST_NODE_TYPES.ImportDefaultSpecifier) {
+                parts.push(specifier.local.name);
+              } else if (specifier.type === AST_NODE_TYPES.ImportNamespaceSpecifier) {
+                parts.push(`* as ${specifier.local.name}`);
+              } else if (specifier.type === AST_NODE_TYPES.ImportSpecifier) {
+                namedValueSpecifiers.push(specifier);
+              }
+            }
+
+            if (namedValueSpecifiers.length > 0) {
+              const namedTexts = namedValueSpecifiers.map((specifier) => context.sourceCode.getText(specifier));
+              parts.push(`{ ${namedTexts.join(", ")} }`);
+            }
+
+            const valueImport = `import ${parts.join(", ")} from ${sourceText};`;
+            return fixer.replaceText(node, `${valueImport}\n${typeImport}`);
+          },
+        });
+      },
+    };
+  },
+});
+
+export default noInlineTypeImport;


### PR DESCRIPTION
## Summary

- New `index-export-only` rule: restricts `index.{js,jsx,ts,tsx}` files to imports, re-exports, and type/interface declarations only. Blocks local function/class/variable declarations, inline `export const`/`export function`/`export class`, top-level expressions, and control flow. Type aliases and interfaces are allowed (no runtime cost).
- New `no-inline-type-import` rule (auto-fixable): bans inline `type` markers on import specifiers. Auto-fix hoists `import { type Foo }` to `import type { Foo }`, splits mixed `import { value, type Foo }` into two statements (preserving aliases, default specifiers, and quote style), and strips redundant inline markers from existing `import type { ... }` statements.
- Both included in `base`, `react`, and `nextjs` presets (warn / error variants).
- Total rule count: 57 → 59 (base 40 → 42).

## Test plan

- [x] 75 unit tests across both new rules (28 valid + 32 invalid + structural checks for both)
- [x] Auto-fix outputs verified exactly via RuleTester `output` for every `no-inline-type-import` invalid case
- [x] Integration test (`src/__tests__/rules.test.ts`) updated to count 59 and asserts both rule names
- [x] Full suite: 1358 tests across 63 suites pass
- [x] `tsc --noEmit` clean
- [x] `eslint:check` clean
- [x] `prettier:check` clean
- [x] `tsup` build succeeds (CJS + ESM + .d.ts)
- [x] Two changeset files added (minor bump each)