### PR TITLE
fix(constant-case): narrow to magic literals

### DIFF
--- a/.changeset/enforce-constant-case-narrow-scope.md
+++ b/.changeset/enforce-constant-case-narrow-scope.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-nextfriday": patch
+---
+
+`enforce-constant-case` now only flags global `const` declarations bound to a magic number or magic text literal. Object literals, array literals, RegExp, template literals (static or dynamic), `as const` assertions, booleans, and any non-literal initializer are no longer checked. This unblocks Next.js App Router files where reserved exports like `metadata`, `viewport`, `dynamic`, `revalidate`, `runtime`, `fetchCache`, `dynamicParams`, `preferredRegion`, and `maxDuration` are framework-owned and must keep their exact names. The rule scope now matches the documented intent of the plugin's naming convention skill ("top-level constant primitive values") instead of every static-shaped initializer.

--- a/docs/rules/ENFORCE_CONSTANT_CASE.md
+++ b/docs/rules/ENFORCE_CONSTANT_CASE.md
@@ -1,14 +1,23 @@
 # enforce-constant-case
 
-Enforce SCREAMING_SNAKE_CASE for global constant static values.
+Enforce SCREAMING_SNAKE_CASE for global magic-number and magic-text constants.
 
 ## Rule Details
 
-This rule ensures that global-scope `const` declarations with static values use SCREAMING_SNAKE_CASE naming convention. Static values include: string/number/boolean literals, RegExp, static template literals, `as const` assertions, and objects/arrays containing only literal values.
+This rule ensures that global-scope `const` declarations bound to a **magic number** or **magic text** literal use SCREAMING_SNAKE_CASE. The rule scope is intentionally narrow:
+
+- A magic text constant is a string literal: `const API_URL = "https://api.example.com"`
+- A magic number constant is a number literal (including a unary `-`/`+` over a numeric literal): `const PAGE_LIMIT = 10`, `const OFFSET = -1`
+
+Anything else is **not** checked: booleans, RegExp, template literals (static or dynamic), arrays, objects, `as const` assertions, function calls, identifiers, member expressions, JSX. Use whatever name fits the value (`metadata`, `viewport`, `statusMap`, `phoneRegex`, `isEnabled`, etc.) — the rule will not flag it.
 
 Only global scope (top-level of a file) is checked. Local scope constants inside functions are not checked by this rule.
 
 **Config files are exempt.** Files matching `*.config.{ts,mjs,cjs,js}`, `*.rc.*`, `*.setup.*`, `*.spec.*`, `*.test.*`, `.eslintrc*`, `.babelrc*`, and `.prettierrc*` skip this rule entirely. This avoids conflicts with framework conventions that require specific identifier names — e.g. Next.js expects `nextConfig` (not `NEXT_CONFIG`) in `next.config.ts`, Vite expects `config`, Tailwind expects `config`, etc.
+
+### Why magic numbers and magic text only?
+
+Reserved framework export names commonly bind to objects (Next.js App Router exports `metadata`, `viewport`, `generateStaticParams`, `dynamic`, `revalidate`, `runtime`, `fetchCache`, `dynamicParams`, `preferredRegion`, `maxDuration`; React Server Components and others have similar patterns). Forcing SCREAMING_SNAKE_CASE on any static-shaped initializer would rename those exports and break framework integration. Restricting the rule to bare number and string literals keeps the convention where it adds value (avoiding magic constants scattered through code) without colliding with framework-owned names.
 
 ## Examples
 
@@ -18,10 +27,8 @@ Only global scope (top-level of a file) is checked. Local scope constants inside
 const defaultCover = "/images/default.jpg";
 const pageLimit = 10;
 const apiBaseUrl = "https://api.example.com";
-const template = `hello world`;
-const phoneRegex = /^[0-9]{10}$/;
+const negativeOne = -1;
 const default_theme = "dark";
-export const categories = [{ id: "1" }] as const;
 ```
 
 ### Correct
@@ -30,35 +37,39 @@ export const categories = [{ id: "1" }] as const;
 const DEFAULT_COVER = "/images/default.jpg";
 const PAGE_LIMIT = 10;
 const API_BASE_URL = "https://api.example.com";
-const TEMPLATE = `hello world`;
-const PHONE_REGEX = /^[0-9]{10}$/;
+const NEGATIVE_ONE = -1;
 const DEFAULT_THEME = "dark";
-export const CATEGORIES = [{ id: "1" }] as const;
 
-const SKELETON_ITEMS = [1, 2, 3, 4, 5];
-const MAP_STYLE = { height: "320px", width: "100%" };
-const STATUS_MAP = { ACTIVE: "active" } as const;
-
-// Booleans with standard prefixes (is, has, should, etc.) are exempt
 const isProduction = true;
 const hasAccess = false;
+const featureEnabled = true;
 
-// Template literals with expressions are dynamic, camelCase is fine
+const phoneRegex = /^[0-9]{10}$/;
+const template = `hello world`;
+const skeletonItems = [1, 2, 3, 4, 5];
+const mapStyle = { height: "320px", width: "100%" };
+const statusMap = { ACTIVE: "active" } as const;
+const categories = [{ id: "1" }] as const;
+
+export const metadata: Metadata = { title: "404 - Page Not Found" };
+export const viewport: Viewport = { themeColor: "#fff" };
+export const generateStaticParams = async () => [];
+
 const pendingHref = `/branch/${branch.branchNumber}`;
 
-// Functions and components are not checked
 const handleClick = () => {};
 const MyComponent = () => {};
 
-// Local scope is not checked
 function foo() {
   const maxRetry = 3;
 }
 ```
 
+> Note: Next.js App Router has a few string-valued reserved exports — `dynamic = "force-dynamic"`, `runtime = "edge"`, `fetchCache = "default-cache"`, etc. — and one number-valued one (`revalidate = 60`, `maxDuration = 30`). These remain in scope for this rule because their initializers are bare literals. Disable `nextfriday/enforce-constant-case` for `app/**` and `pages/**` in your own flat config if you use those exports.
+
 ## Configuration
 
-This rule has no options — only severity is configurable (`"error"`, `"warn"`, `"off"`). It pairs with [`no-misleading-constant-case`](./NO_MISLEADING_CONSTANT_CASE.md) so that static globals use `SCREAMING_SNAKE_CASE` while local scopes and dynamic values keep `camelCase`.
+This rule has no options — only severity is configurable (`"error"`, `"warn"`, `"off"`). It pairs with [`no-misleading-constant-case`](./NO_MISLEADING_CONSTANT_CASE.md) so that magic-literal globals use `SCREAMING_SNAKE_CASE` while local scopes and dynamic values keep `camelCase`.
 
 ### Install
 

--- a/src/rules/__tests__/enforce-constant-case.test.ts
+++ b/src/rules/__tests__/enforce-constant-case.test.ts
@@ -29,10 +29,6 @@ describe("enforce-constant-case", () => {
         name: "should allow SCREAMING_SNAKE_CASE number constant",
       },
       {
-        code: `const IS_PRODUCTION = true;`,
-        name: "should allow SCREAMING_SNAKE_CASE boolean constant",
-      },
-      {
         code: `const API_URL = "https://api.example.com";`,
         name: "should allow SCREAMING_SNAKE_CASE url constant",
       },
@@ -41,40 +37,52 @@ describe("enforce-constant-case", () => {
         name: "should allow SCREAMING_SNAKE_CASE for negative numbers",
       },
       {
-        code: `const TEMPLATE = \`hello world\`;`,
-        name: "should allow SCREAMING_SNAKE_CASE for template literals",
-      },
-      {
-        code: `const PHONE_REGEX = /^[0-9]{10}$/;`,
-        name: "should allow SCREAMING_SNAKE_CASE for RegExp",
-      },
-      {
-        code: `const STATUS_MAP = { ACTIVE: "active", INACTIVE: "inactive" } as const;`,
-        name: "should allow SCREAMING_SNAKE_CASE for as const object",
-      },
-      {
-        code: `const CATEGORIES = [{ id: "1", label: "one" }] as const;`,
-        name: "should allow SCREAMING_SNAKE_CASE for as const array",
-      },
-      {
-        code: `const SKELETON_ITEMS = [1, 2, 3, 4, 5];`,
-        name: "should allow SCREAMING_SNAKE_CASE for static array",
-      },
-      {
-        code: `const MAP_STYLE = { height: "320px", width: "100%" };`,
-        name: "should allow SCREAMING_SNAKE_CASE for static object",
-      },
-      {
         code: `export const MAX_RETRY = 3;`,
         name: "should allow exported SCREAMING_SNAKE_CASE constant",
       },
       {
         code: `const isEnabled = true;`,
-        name: "should allow boolean with is prefix",
+        name: "should ignore boolean constants",
       },
       {
         code: `const hasAccess = false;`,
-        name: "should allow boolean with has prefix",
+        name: "should ignore boolean constants regardless of prefix",
+      },
+      {
+        code: `const featureEnabled = true;`,
+        name: "should ignore boolean constants without is/has prefix",
+      },
+      {
+        code: `const template = \`hello world\`;`,
+        name: "should ignore static template literals",
+      },
+      {
+        code: `const phoneRegex = /^[0-9]{10}$/;`,
+        name: "should ignore RegExp literals",
+      },
+      {
+        code: `const skeletonItems = [1, 2, 3, 4, 5];`,
+        name: "should ignore array literals",
+      },
+      {
+        code: `const mapStyle = { height: "320px", width: "100%" };`,
+        name: "should ignore object literals",
+      },
+      {
+        code: `const statusMap = { ACTIVE: "active" } as const;`,
+        name: "should ignore as const object",
+      },
+      {
+        code: `const categories = [{ id: "1" }] as const;`,
+        name: "should ignore as const array",
+      },
+      {
+        code: `export const metadata: Metadata = { title: "404" };`,
+        name: "should ignore framework reserved object exports like Next.js metadata",
+      },
+      {
+        code: `export const viewport: Viewport = { themeColor: "#fff" };`,
+        name: "should ignore framework reserved object exports like Next.js viewport",
       },
       {
         code: `const config = { key: getValue() };`,
@@ -166,16 +174,6 @@ describe("enforce-constant-case", () => {
         ],
       },
       {
-        code: `const template = \`hello\`;`,
-        name: "should disallow camelCase for global template literal constant",
-        errors: [
-          {
-            messageId: "useScreamingSnakeCase",
-            data: { name: "template", suggestion: "TEMPLATE" },
-          },
-        ],
-      },
-      {
         code: `const negativeOne = -1;`,
         name: "should disallow camelCase for global negative number constant",
         errors: [
@@ -187,7 +185,7 @@ describe("enforce-constant-case", () => {
       },
       {
         code: `export const maxRetryCount = 3;`,
-        name: "should disallow camelCase for exported global constant",
+        name: "should disallow camelCase for exported global magic number",
         errors: [
           {
             messageId: "useScreamingSnakeCase",
@@ -197,31 +195,11 @@ describe("enforce-constant-case", () => {
       },
       {
         code: `const default_theme = "dark";`,
-        name: "should disallow snake_case for global constant",
+        name: "should disallow snake_case for global magic text",
         errors: [
           {
             messageId: "noSnakeCase",
             data: { name: "default_theme", suggestion: "DEFAULT_THEME" },
-          },
-        ],
-      },
-      {
-        code: `const categories = [{ id: "1" }] as const;`,
-        name: "should disallow camelCase for global as const array",
-        errors: [
-          {
-            messageId: "useScreamingSnakeCase",
-            data: { name: "categories", suggestion: "CATEGORIES" },
-          },
-        ],
-      },
-      {
-        code: `const phoneRegex = /^[0-9]{10}$/;`,
-        name: "should disallow camelCase for global RegExp",
-        errors: [
-          {
-            messageId: "useScreamingSnakeCase",
-            data: { name: "phoneRegex", suggestion: "PHONE_REGEX" },
           },
         ],
       },

--- a/src/rules/enforce-constant-case.ts
+++ b/src/rules/enforce-constant-case.ts
@@ -11,7 +11,6 @@ const createRule = ESLintUtils.RuleCreator(
 
 const SCREAMING_SNAKE_CASE_REGEX = /^[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)*$/;
 const SNAKE_CASE_REGEX = /^[a-z]+_[a-z0-9_]*$/;
-const BOOLEAN_PREFIXES = ["is", "has", "should", "can", "did", "will", "was", "are", "does", "had"];
 
 const toScreamingSnakeCase = (str: string): string =>
   str
@@ -19,53 +18,17 @@ const toScreamingSnakeCase = (str: string): string =>
     .replace(/([A-Z])([A-Z][a-z])/g, "$1_$2")
     .toUpperCase();
 
-const startsWithBooleanPrefix = (name: string): boolean =>
-  BOOLEAN_PREFIXES.some((prefix) => {
-    if (!name.startsWith(prefix)) {
-      return false;
-    }
-
-    if (name.length === prefix.length) {
-      return true;
-    }
-
-    const nextChar = name.charAt(prefix.length);
-    return nextChar === nextChar.toUpperCase() && nextChar !== nextChar.toLowerCase();
-  });
-
-const isBooleanLiteral = (init: TSESTree.Expression): boolean =>
-  init.type === AST_NODE_TYPES.Literal && typeof init.value === "boolean";
-
-const isAsConstAssertion = (node: TSESTree.Expression): boolean =>
-  node.type === AST_NODE_TYPES.TSAsExpression &&
-  node.typeAnnotation.type === AST_NODE_TYPES.TSTypeReference &&
-  node.typeAnnotation.typeName.type === AST_NODE_TYPES.Identifier &&
-  node.typeAnnotation.typeName.name === "const";
-
-const isStaticValue = (init: TSESTree.Expression): boolean => {
-  if (isAsConstAssertion(init)) {
-    return true;
-  }
-
+const isMagicLiteral = (init: TSESTree.Expression): boolean => {
   if (init.type === AST_NODE_TYPES.Literal) {
-    return true;
+    return typeof init.value === "string" || typeof init.value === "number";
   }
 
-  if (init.type === AST_NODE_TYPES.UnaryExpression && init.argument.type === AST_NODE_TYPES.Literal) {
-    return true;
-  }
-
-  if (init.type === AST_NODE_TYPES.TemplateLiteral && init.expressions.length === 0) {
-    return true;
-  }
-
-  if (init.type === AST_NODE_TYPES.ArrayExpression) {
-    return init.elements.every((el) => el !== null && el.type !== AST_NODE_TYPES.SpreadElement && isStaticValue(el));
-  }
-
-  if (init.type === AST_NODE_TYPES.ObjectExpression) {
-    return init.properties.every(
-      (prop) => prop.type === AST_NODE_TYPES.Property && isStaticValue(prop.value as TSESTree.Expression),
+  if (init.type === AST_NODE_TYPES.UnaryExpression) {
+    const { argument, operator } = init;
+    return (
+      (operator === "-" || operator === "+") &&
+      argument.type === AST_NODE_TYPES.Literal &&
+      typeof argument.value === "number"
     );
   }
 
@@ -86,15 +49,12 @@ const isGlobalScope = (node: TSESTree.VariableDeclaration): boolean => {
   return false;
 };
 
-const isFunctionOrComponent = (init: TSESTree.Expression): boolean =>
-  init.type === AST_NODE_TYPES.ArrowFunctionExpression || init.type === AST_NODE_TYPES.FunctionExpression;
-
 const enforceConstantCase = createRule({
   name: "enforce-constant-case",
   meta: {
     type: "suggestion",
     docs: {
-      description: "Enforce SCREAMING_SNAKE_CASE for global constant static values",
+      description: "Enforce SCREAMING_SNAKE_CASE for global magic-number and magic-text constants",
     },
     messages: {
       useScreamingSnakeCase: "Constant '{{ name }}' should use SCREAMING_SNAKE_CASE. Rename to '{{ suggestion }}'.",
@@ -119,19 +79,11 @@ const enforceConstantCase = createRule({
             return;
           }
 
-          if (isFunctionOrComponent(declarator.init)) {
-            return;
-          }
-
-          if (!isStaticValue(declarator.init)) {
+          if (!isMagicLiteral(declarator.init)) {
             return;
           }
 
           const { name } = declarator.id;
-
-          if (isBooleanLiteral(declarator.init) && startsWithBooleanPrefix(name)) {
-            return;
-          }
 
           if (SNAKE_CASE_REGEX.test(name)) {
             context.report({


### PR DESCRIPTION
## Summary

- Narrow `enforce-constant-case` to fire only on global `const` bound to a string or number literal (or `-num`/`+num`). Object literals, arrays, RegExp, template literals (static or dynamic), `as const`, booleans, and any non-literal initializer are no longer checked.
- Unblocks Next.js App Router files where reserved exports like `metadata`, `viewport`, `generateStaticParams`, etc. are framework-owned and must keep their exact names.
- Aligns the rule with the documented intent in `skills/eslint-plugin-nextfriday/naming-conventions.md` ("Top-level constant primitive values must use SCREAMING_SNAKE_CASE").

## Test plan

- [x] `pnpm test` (1357 passed across 63 suites)
- [x] `pnpm typecheck`
- [x] `pnpm build`
- [x] `pnpm eslint:check`
- [x] Verified `export const metadata: Metadata = { title: "..." }` no longer triggers the rule
- [x] Verified plain magic literals (`const apiUrl = "..."`, `const pageLimit = 10`) still trigger