### PR TITLE
feat(jsx): add data, sub-interface, render rules

### DIFF
--- a/.changeset/shaky-walls-sink.md
+++ b/.changeset/shaky-walls-sink.md
@@ -1,0 +1,15 @@
+---
+"eslint-plugin-nextfriday": minor
+---
+
+add four JSX rules that target a single anti-pattern: component files acting as content / type / naming dumping grounds. The `.tsx` and `.jsx` file is meant to describe one component's render — data, sub-types, and helper render-fragments belong elsewhere or under a clearer name.
+
+- `jsx-no-data-array` flags top-level `const` declarations whose initializer is an array literal containing object literals — including `as const` and `satisfies` variants and exported declarations. Arrays of primitives are unaffected. The shape is a strong signal of fixture / seed / content data, which belongs in a sibling `*.data.ts` module.
+
+- `jsx-no-data-object` flags top-level `const` declarations whose initializer is an object literal that contains a nested object or a nested array of objects — including `as const` and `satisfies` variants and exported declarations. Flat maps of primitives (`{ home: "/", about: "/about" }`) are not flagged. Nested configuration / content belongs in a data module.
+
+- `jsx-no-sub-interface` flags any top-level `interface` or `type` declaration in a `.tsx` / `.jsx` file that is not the main props type for a component declared in the same file. The "main" type is determined by the parameter type of a top-level PascalCase function or arrow component, with common wrappers (`Readonly<T>`, `Required<T>`, `Partial<T>`, `PropsWithChildren<T>`, `NoInfer<T>`) unwrapped. Sub-interfaces (e.g. `StoreCardAddressProps` referenced as a field in `StoreCardProps`) and helper unions belong in their own module — typically a sibling `*.types.ts`. Files that declare no component at all are not checked, so type-only `.tsx` modules and re-export-only files are unaffected.
+
+- `enforce-render-naming` flags variables declared inside a top-level PascalCase component whose initializer holds or returns JSX, but whose name does not start with `render` followed by a camelCase boundary. Detected JSX-producing initializers include `JSXElement` / `JSXFragment` literals, conditional and logical expressions whose branch is JSX, arrays of JSX, arrow / function expressions whose body returns JSX, `.map` / `.flatMap` / `.filter` calls whose callback returns JSX, and `as` / `satisfies` wrappers around any of the above. Both value form (`const renderHeader = <div />`) and function form (`const renderHeader = () => <div />`) satisfy the rule — the convention checks intent via the prefix, not the shape.
+
+All four rules ship in the `react`, `react/recommended`, `nextjs`, and `nextjs/recommended` presets at `warn` and `error` severity respectively. Total rule count is now 63 (40 base + 23 JSX). None of the new rules are auto-fixable: each surfaces a structural decision (where to put the data, where to put the type, what to name the fragment) that the author should make explicitly.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ The plugin dogfoods its own rules via `eslint.config.mjs`. Build config lives in
 `src/index.ts` - Main plugin export containing:
 
 - `meta` - Plugin name and version from package.json
-- `rules` - All 59 rule implementations keyed by hyphenated name
+- `rules` - All 63 rule implementations keyed by hyphenated name
 - `configs` - Six configuration presets (each rule set has a `warn` and `error`/`recommended` variant). All presets are built via `createConfig()` and return a single config object. The `nextjs` and `nextjs/recommended` presets currently share the same rule set as `react` and `react/recommended`; they are kept as named aliases.
 
 The plugin is exported both as default and as named exports `{ meta, configs, rules }`.
@@ -55,8 +55,8 @@ Six configs total. Two rule set tiers, each with a `warn` variant and a `Recomme
 | Preset                          | Rules            | Severity     |
 | ------------------------------- | ---------------- | ------------ |
 | `base` / `base/recommended`     | 40 base          | warn / error |
-| `react` / `react/recommended`   | 40 base + 19 JSX | warn / error |
-| `nextjs` / `nextjs/recommended` | 40 base + 19 JSX | warn / error |
+| `react` / `react/recommended`   | 40 base + 23 JSX | warn / error |
+| `nextjs` / `nextjs/recommended` | 40 base + 23 JSX | warn / error |
 
 ### Utilities
 

--- a/README.md
+++ b/README.md
@@ -458,9 +458,12 @@ In practice: turn the high tier on as `"error"` first, leave the medium tier as 
 | Rule                                                                                     | Description                                                           | Fixable |
 | ---------------------------------------------------------------------------------------- | --------------------------------------------------------------------- | ------- |
 | [jsx-newline-between-elements](docs/rules/JSX_NEWLINE_BETWEEN_ELEMENTS.md)               | Require empty lines between sibling multi-line JSX children           | ✅      |
+| [jsx-no-data-array](docs/rules/JSX_NO_DATA_ARRAY.md)                                     | Disallow top-level array of object literals in `.tsx`/`.jsx`          | ❌      |
+| [jsx-no-data-object](docs/rules/JSX_NO_DATA_OBJECT.md)                                   | Disallow top-level nested object literals in `.tsx`/`.jsx`            | ❌      |
 | [jsx-no-inline-object-prop](docs/rules/JSX_NO_INLINE_OBJECT_PROP.md)                     | Disallow inline object literals in JSX props                          | ❌      |
 | [jsx-no-newline-single-line-elements](docs/rules/JSX_NO_NEWLINE_SINGLE_LINE_ELEMENTS.md) | Disallow empty lines between single-line sibling JSX elements         | ✅      |
 | [jsx-no-non-component-function](docs/rules/JSX_NO_NON_COMPONENT_FUNCTION.md)             | Disallow non-component functions at top level in .tsx/.jsx files      | ❌      |
+| [jsx-no-sub-interface](docs/rules/JSX_NO_SUB_INTERFACE.md)                               | Disallow sub-interfaces and helper types in component files           | ❌      |
 | [jsx-no-ternary-null](docs/rules/JSX_NO_TERNARY_NULL.md)                                 | Enforce logical AND over ternary with null/undefined in JSX           | ✅      |
 | [jsx-no-variable-in-callback](docs/rules/JSX_NO_VARIABLE_IN_CALLBACK.md)                 | Disallow variable declarations inside callback functions in JSX       | ❌      |
 | [jsx-require-suspense](docs/rules/JSX_REQUIRE_SUSPENSE.md)                               | Require lazy-loaded components to be wrapped in Suspense              | ❌      |
@@ -474,6 +477,7 @@ In practice: turn the high tier on as `"error"` first, leave the medium tier as 
 | [react-props-destructure](docs/rules/REACT_PROPS_DESTRUCTURE.md)                         | Enforce destructuring props inside React component body               | ❌      |
 | [enforce-props-suffix](docs/rules/ENFORCE_PROPS_SUFFIX.md)                               | Enforce 'Props' suffix for interfaces and types in \*.tsx files       | ❌      |
 | [enforce-readonly-component-props](docs/rules/ENFORCE_READONLY_COMPONENT_PROPS.md)       | Enforce Readonly wrapper for React component props                    | ✅      |
+| [enforce-render-naming](docs/rules/ENFORCE_RENDER_NAMING.md)                             | Enforce 'render' prefix for variables holding JSX inside components   | ❌      |
 
 ## Configurations
 
@@ -483,10 +487,10 @@ In practice: turn the high tier on as `"error"` first, leave the medium tier as 
 | -------------------- | -------- | ---------- | --------- | ----------- |
 | `base`               | warn     | 40         | 0         | 40          |
 | `base/recommended`   | error    | 40         | 0         | 40          |
-| `react`              | warn     | 40         | 19        | 59          |
-| `react/recommended`  | error    | 40         | 19        | 59          |
-| `nextjs`             | warn     | 40         | 19        | 59          |
-| `nextjs/recommended` | error    | 40         | 19        | 59          |
+| `react`              | warn     | 40         | 23        | 63          |
+| `react/recommended`  | error    | 40         | 23        | 63          |
+| `nextjs`             | warn     | 40         | 23        | 63          |
+| `nextjs/recommended` | error    | 40         | 23        | 63          |
 
 The `nextjs` and `nextjs/recommended` presets currently share the same rule set as `react` and `react/recommended`; they are kept as named aliases for ergonomics.
 
@@ -535,16 +539,20 @@ Included in `base`, `base/recommended`, and all other presets:
 - `nextfriday/sort-type-alphabetically`
 - `nextfriday/sort-type-required-first`
 
-### JSX Rules (19 rules)
+### JSX Rules (23 rules)
 
 Additionally included in `react`, `react/recommended`, `nextjs`, `nextjs/recommended`:
 
 - `nextfriday/enforce-props-suffix`
 - `nextfriday/enforce-readonly-component-props`
+- `nextfriday/enforce-render-naming`
 - `nextfriday/jsx-newline-between-elements`
+- `nextfriday/jsx-no-data-array`
+- `nextfriday/jsx-no-data-object`
 - `nextfriday/jsx-no-inline-object-prop`
 - `nextfriday/jsx-no-newline-single-line-elements`
 - `nextfriday/jsx-no-non-component-function`
+- `nextfriday/jsx-no-sub-interface`
 - `nextfriday/jsx-no-ternary-null`
 - `nextfriday/jsx-no-variable-in-callback`
 - `nextfriday/jsx-require-suspense`

--- a/docs/rules/ENFORCE_RENDER_NAMING.md
+++ b/docs/rules/ENFORCE_RENDER_NAMING.md
@@ -1,0 +1,96 @@
+# enforce-render-naming
+
+Enforce `render` prefix for variables that hold or return JSX inside React components.
+
+## Rule Details
+
+This rule flags variables declared inside a React component (a top-level PascalCase function or arrow function) whose initializer holds or returns JSX, but whose name does not start with `render`. The `render` prefix makes intent explicit: a reader scanning the component body can tell at a glance which locals are render fragments and which are plain data.
+
+The rule applies inside any function or block nested within the component — not only the component's top-level body.
+
+The prefix must be `render` followed by a camelCase boundary (uppercase letter, or end-of-name). Names like `renderer` (lowercase letter after the prefix) do not count.
+
+### Why?
+
+- **Self-documenting code**: `renderPhoneEntries` reads as "this is a render fragment for phone entries". `phoneEntries` reads as "this is data — a list of phones". The distinction matters when the same component holds both.
+- **Refactor signal**: When you want to extract render fragments into separate components, grepping for `render*` finds candidates immediately.
+- **Consistency**: Aligns with `enforce-hook-naming` (`use*` for hooks) and `enforce-service-naming` (`fetch*` for services) — name-by-purpose conventions throughout the plugin.
+
+## Examples
+
+### Incorrect
+
+```tsx
+const Component = (props) => {
+  const header = <div />;
+  const cardElements = props.items.map((item) => <Card {...item} />);
+  const phoneEntries = props.phones.map((phone) => {
+    return <span>{phone}</span>;
+  });
+  const fallback = props.condition ? <A /> : <B />;
+  const banner = props.isVisible && <Banner />;
+  return (
+    <>
+      {header}
+      {cardElements}
+      {phoneEntries}
+      {fallback}
+      {banner}
+    </>
+  );
+};
+```
+
+### Correct
+
+```tsx
+const Component = (props) => {
+  const renderHeader = <div />;
+  const renderCardElements = props.items.map((item) => <Card {...item} />);
+  const renderPhoneEntries = props.phones.map((phone) => {
+    return <span>{phone}</span>;
+  });
+  const renderFallback = props.condition ? <A /> : <B />;
+  const renderBanner = props.isVisible && <Banner />;
+  return (
+    <>
+      {renderHeader}
+      {renderCardElements}
+      {renderPhoneEntries}
+      {renderFallback}
+      {renderBanner}
+    </>
+  );
+};
+```
+
+Both value form and function form are accepted as long as the prefix is correct:
+
+```tsx
+const renderHeader = <div />; // value form — eval once at component render
+const renderHeader = () => <div />; // function form — eval each call
+```
+
+## What This Rule Checks
+
+The rule fires when a `const` or `let` declaration is created **inside** a top-level PascalCase function (a React component) and the initializer is one of:
+
+- A `JSXElement` or `JSXFragment` directly
+- A `ConditionalExpression` whose consequent or alternate produces JSX
+- A `LogicalExpression` whose right-hand side produces JSX
+- An `ArrayExpression` containing JSX elements
+- An `ArrowFunctionExpression` or `FunctionExpression` whose body returns JSX
+- A `CallExpression` to `.map`, `.flatMap`, or `.filter` whose callback returns JSX
+- A `TSAsExpression` or `TSSatisfiesExpression` wrapping any of the above
+
+The rule applies only to `.tsx` and `.jsx` files. Variables declared outside any PascalCase function (top-level module constants, helpers in plain functions) are not checked.
+
+## When Not To Use It
+
+If your team prefers other naming conventions for extracted JSX (e.g., `*Element`, `*Section`, `*Fragment`), or if you do not extract JSX into intermediate variables in the first place.
+
+## Related Rules
+
+- [enforce-hook-naming](ENFORCE_HOOK_NAMING.md)
+- [enforce-service-naming](ENFORCE_SERVICE_NAMING.md)
+- [boolean-naming-prefix](BOOLEAN_NAMING_PREFIX.md)

--- a/docs/rules/JSX_NO_DATA_ARRAY.md
+++ b/docs/rules/JSX_NO_DATA_ARRAY.md
@@ -1,0 +1,63 @@
+# jsx-no-data-array
+
+Disallow top-level arrays of object literals in `.tsx`/`.jsx` files (extract to a data file).
+
+## Rule Details
+
+This rule flags top-level `const` declarations in `.tsx` and `.jsx` files whose initializer is an array literal containing one or more object literals. This shape is a strong signal of fixture / seed / content data, which belongs in a sibling data module — not in a component file.
+
+The rule fires on both unexported declarations and `export const` declarations, and on `as const` / `satisfies` variants.
+
+### Why?
+
+- **Separation of concerns**: Component files should describe rendering. Content / fixture data belongs in `*.data.ts`, `*.fixtures.ts`, a CMS, or a content layer.
+- **Diff hygiene**: Editing one address line should not produce noise inside the component diff.
+- **AI assistant pressure**: LLMs default to inlining mock data when they cannot find a data layer; a lint rule is the cheapest way to redirect them.
+
+## Examples
+
+### Incorrect
+
+```tsx
+const stores = [{ name: "Koh Samui", isOpen: true }];
+const items: Item[] = [{ id: 1 }, { id: 2 }];
+const config = [{ key: "a" }] as const;
+const data = [{ id: 1 }] satisfies readonly { id: number }[];
+export const navItems = [{ label: "Home", href: "/" }];
+```
+
+### Correct
+
+```tsx
+const TIMEOUT_MS = 1000;
+const labels = ["Home", "About", "Contact"];
+const numbers = [1, 2, 3];
+const ROUTES = { home: "/", about: "/about" };
+```
+
+Move arrays of object literals to a sibling data file:
+
+```ts
+// stores.data.ts
+export const stores = [{ name: "Koh Samui", isOpen: true }];
+```
+
+```tsx
+// HeaderStore.tsx
+import { stores } from "./stores.data";
+```
+
+## What This Rule Checks
+
+The rule fires when a top-level `const` declaration's initializer (after unwrapping `as`/`satisfies`) is an `ArrayExpression` and at least one of its elements is an `ObjectExpression` (also after unwrapping). Arrays of primitives, identifiers, or member expressions are not flagged.
+
+The rule applies only to `.tsx` and `.jsx` files. Plain `.ts` and `.js` files are not checked — extract data files into those extensions.
+
+## When Not To Use It
+
+If your project deliberately co-locates small static data with components, or if you treat `.tsx` files as both component and data layer.
+
+## Related Rules
+
+- [jsx-no-data-object](JSX_NO_DATA_OBJECT.md)
+- [jsx-no-non-component-function](JSX_NO_NON_COMPONENT_FUNCTION.md)

--- a/docs/rules/JSX_NO_DATA_OBJECT.md
+++ b/docs/rules/JSX_NO_DATA_OBJECT.md
@@ -1,0 +1,71 @@
+# jsx-no-data-object
+
+Disallow top-level nested object literals in `.tsx`/`.jsx` files (extract to a data file).
+
+## Rule Details
+
+This rule flags top-level `const` declarations in `.tsx` and `.jsx` files whose initializer is an object literal that contains at least one nested object or nested array. The "nesting" is the smell — flat maps of primitives are fine, but objects-of-objects or objects-of-object-arrays look like configuration / content data and belong in a data module.
+
+The rule fires on both unexported declarations and `export const` declarations, and on `as const` / `satisfies` variants.
+
+### Why?
+
+- **Separation of concerns**: Component files should describe rendering. Nested configuration / content belongs in a sibling data module.
+- **Diff hygiene**: Tweaking a nested setting should not bloat the component diff.
+- **AI assistant pressure**: LLMs default to inlining mock config when they cannot find a data layer; a lint rule is the cheapest way to redirect them.
+
+## Examples
+
+### Incorrect
+
+```tsx
+const config = { home: { url: "/" } };
+const config = { items: [{ id: 1 }] };
+const matrix = {
+  values: [
+    [1, 2],
+    [3, 4],
+  ],
+};
+const config = { a: { b: 1 } } as const;
+export const config = { a: { b: 1 } };
+```
+
+### Correct
+
+```tsx
+const TIMEOUT_MS = 1000;
+const ROUTES = { home: "/", about: "/about", contact: "/contact" };
+const labels = ["Home", "About"];
+const config = { a: 1, b: "x", c: true };
+```
+
+Move nested objects to a sibling data file:
+
+```ts
+// settings.data.ts
+export const settings = { home: { url: "/" } };
+```
+
+```tsx
+// HomePage.tsx
+import { settings } from "./settings.data";
+```
+
+## What This Rule Checks
+
+The rule fires when a top-level `const` declaration's initializer (after unwrapping `as`/`satisfies`) is an `ObjectExpression` whose properties contain at least one of:
+
+- A property whose value is another `ObjectExpression`
+- A property whose value is an `ArrayExpression` containing an `ObjectExpression` or another `ArrayExpression`
+
+Flat maps of primitives are not flagged. The rule applies only to `.tsx` and `.jsx` files.
+
+## When Not To Use It
+
+If your project deliberately co-locates small nested config with components, or if you treat `.tsx` files as both component and data layer.
+
+## Related Rules
+
+- [jsx-no-data-array](JSX_NO_DATA_ARRAY.md)
+- [jsx-no-non-component-function](JSX_NO_NON_COMPONENT_FUNCTION.md)

--- a/docs/rules/JSX_NO_SUB_INTERFACE.md
+++ b/docs/rules/JSX_NO_SUB_INTERFACE.md
@@ -1,0 +1,86 @@
+# jsx-no-sub-interface
+
+Disallow sub-interfaces and helper types in component files; keep only the main component props.
+
+## Rule Details
+
+This rule flags any top-level `interface` or `type` declaration in a `.tsx` / `.jsx` file that is not the main props type for a component declared in the same file. Sub-interfaces (e.g., `StoreCardAddressProps` referenced as a field in `StoreCardProps`) and helper unions (e.g., `type StoreCardKind = "a" | "b"`) should live in their own modules — typically a sibling `*.types.ts` file or alongside their own component.
+
+The "main" props type is determined by the parameter type of a top-level PascalCase function or arrow component. Common wrappers like `Readonly<T>`, `Required<T>`, `Partial<T>`, `PropsWithChildren<T>`, and `NoInfer<T>` are unwrapped to find the underlying type name.
+
+If the file declares no component at all, the rule does not fire — pure `.tsx` / `.jsx` files used as type or re-export modules are skipped.
+
+### Why?
+
+- **Single responsibility per file**: A component file should describe one component. Sub-types pollute it with shapes that are referenced but not the component's own concern.
+- **Reusability**: Sub-types extracted to their own module can be imported by sibling components and tests; trapped inside a component file, they cannot.
+- **Diff hygiene**: Editing a sub-interface should not produce noise in the component diff.
+
+## Examples
+
+### Incorrect
+
+```tsx
+interface StoreCardProps {
+  address: StoreCardAddressProps;
+  image: StoreCardImageProps;
+  name: string;
+}
+
+interface StoreCardAddressProps {
+  label: string;
+  mapUrl: string;
+}
+
+interface StoreCardImageProps {
+  alt: string;
+  src: string;
+}
+
+type StoreCardKind = "phone" | "whatsapp";
+
+const StoreCard = (props: Readonly<StoreCardProps>) => <div />;
+```
+
+### Correct
+
+```tsx
+import type { StoreCardAddressProps } from "./store-card-address.types";
+import type { StoreCardImageProps } from "./store-card-image.types";
+
+interface StoreCardProps {
+  address: StoreCardAddressProps;
+  image: StoreCardImageProps;
+  name: string;
+}
+
+const StoreCard = (props: Readonly<StoreCardProps>) => <div />;
+```
+
+```ts
+// store-card-address.types.ts
+export interface StoreCardAddressProps {
+  label: string;
+  mapUrl: string;
+}
+```
+
+## What This Rule Checks
+
+The rule walks the program body and collects:
+
+- **Components** — top-level PascalCase `function` declarations and PascalCase `const X = (...) => ...` or `const X = function(...) {}` initializers, including ones wrapped in `export` / `export default`.
+- **Main types** — for each component, the type referenced by its first parameter's annotation, after unwrapping `Readonly<T>`, `Required<T>`, `Partial<T>`, `PropsWithChildren<T>`, and `NoInfer<T>`.
+- **Top-level type declarations** — `interface` and `type` declarations at the top level (including ones wrapped in `export`).
+
+Any top-level type declaration whose name is not in the set of main types is flagged. The rule does not fire when the file has no component.
+
+## When Not To Use It
+
+If your project deliberately co-locates sub-types and helper types with their consuming component, or if you keep the component and its supporting types in a single file by convention.
+
+## Related Rules
+
+- [enforce-props-suffix](ENFORCE_PROPS_SUFFIX.md)
+- [prefer-interface-for-component-props](PREFER_INTERFACE_FOR_COMPONENT_PROPS.md)
+- [prefer-interface-over-inline-types](PREFER_INTERFACE_OVER_INLINE_TYPES.md)

--- a/src/__tests__/rules.test.ts
+++ b/src/__tests__/rules.test.ts
@@ -72,8 +72,8 @@ describe("ESLint Plugin Rules", () => {
     expect(typeof rules["no-env-fallback"].create).toBe("function");
   });
 
-  it("should have exactly 59 rules", () => {
-    expect(Object.keys(rules)).toHaveLength(59);
+  it("should have exactly 63 rules", () => {
+    expect(Object.keys(rules)).toHaveLength(63);
   });
 
   it("should have correct rule names", () => {
@@ -137,6 +137,10 @@ describe("ESLint Plugin Rules", () => {
     expect(ruleNames).toContain("no-inline-type-import");
     expect(ruleNames).toContain("no-ghost-wrapper");
     expect(ruleNames).toContain("no-redundant-fragment");
+    expect(ruleNames).toContain("jsx-no-data-array");
+    expect(ruleNames).toContain("jsx-no-data-object");
+    expect(ruleNames).toContain("jsx-no-sub-interface");
+    expect(ruleNames).toContain("enforce-render-naming");
   });
 
   it("should have prefer-interface-over-inline-types rule", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,14 +7,18 @@ import enforceHookNaming from "./rules/enforce-hook-naming";
 import enforcePropertyCase from "./rules/enforce-property-case";
 import enforcePropsSuffix from "./rules/enforce-props-suffix";
 import enforceReadonlyComponentProps from "./rules/enforce-readonly-component-props";
+import enforceRenderNaming from "./rules/enforce-render-naming";
 import enforceServiceNaming from "./rules/enforce-service-naming";
 import enforceSortedDestructuring from "./rules/enforce-sorted-destructuring";
 import enforceTypeDeclarationOrder from "./rules/enforce-type-declaration-order";
 import indexExportOnly from "./rules/index-export-only";
 import jsxNewlineBetweenElements from "./rules/jsx-newline-between-elements";
+import jsxNoDataArray from "./rules/jsx-no-data-array";
+import jsxNoDataObject from "./rules/jsx-no-data-object";
 import jsxNoInlineObjectProp from "./rules/jsx-no-inline-object-prop";
 import jsxNoNewlineSingleLineElements from "./rules/jsx-no-newline-single-line-elements";
 import jsxNoNonComponentFunction from "./rules/jsx-no-non-component-function";
+import jsxNoSubInterface from "./rules/jsx-no-sub-interface";
 import jsxNoTernaryNull from "./rules/jsx-no-ternary-null";
 import jsxNoVariableInCallback from "./rules/jsx-no-variable-in-callback";
 import jsxRequireSuspense from "./rules/jsx-require-suspense";
@@ -75,14 +79,18 @@ const rules = {
   "enforce-property-case": enforcePropertyCase,
   "enforce-props-suffix": enforcePropsSuffix,
   "enforce-readonly-component-props": enforceReadonlyComponentProps,
+  "enforce-render-naming": enforceRenderNaming,
   "enforce-service-naming": enforceServiceNaming,
   "enforce-sorted-destructuring": enforceSortedDestructuring,
   "enforce-type-declaration-order": enforceTypeDeclarationOrder,
   "index-export-only": indexExportOnly,
   "jsx-newline-between-elements": jsxNewlineBetweenElements,
+  "jsx-no-data-array": jsxNoDataArray,
+  "jsx-no-data-object": jsxNoDataObject,
   "jsx-no-inline-object-prop": jsxNoInlineObjectProp,
   "jsx-no-newline-single-line-elements": jsxNoNewlineSingleLineElements,
   "jsx-no-non-component-function": jsxNoNonComponentFunction,
+  "jsx-no-sub-interface": jsxNoSubInterface,
   "jsx-no-ternary-null": jsxNoTernaryNull,
   "jsx-no-variable-in-callback": jsxNoVariableInCallback,
   "jsx-require-suspense": jsxRequireSuspense,
@@ -223,10 +231,14 @@ const baseRecommendedRules = {
 const jsxRules = {
   "nextfriday/enforce-props-suffix": "warn",
   "nextfriday/enforce-readonly-component-props": "warn",
+  "nextfriday/enforce-render-naming": "warn",
   "nextfriday/jsx-newline-between-elements": "warn",
+  "nextfriday/jsx-no-data-array": "warn",
+  "nextfriday/jsx-no-data-object": "warn",
   "nextfriday/jsx-no-inline-object-prop": "warn",
   "nextfriday/jsx-no-newline-single-line-elements": "warn",
   "nextfriday/jsx-no-non-component-function": "warn",
+  "nextfriday/jsx-no-sub-interface": "warn",
   "nextfriday/jsx-no-ternary-null": "warn",
   "nextfriday/jsx-no-variable-in-callback": "warn",
   "nextfriday/jsx-require-suspense": "warn",
@@ -245,10 +257,14 @@ const jsxRules = {
 const jsxRecommendedRules = {
   "nextfriday/enforce-props-suffix": "error",
   "nextfriday/enforce-readonly-component-props": "error",
+  "nextfriday/enforce-render-naming": "error",
   "nextfriday/jsx-newline-between-elements": "error",
+  "nextfriday/jsx-no-data-array": "error",
+  "nextfriday/jsx-no-data-object": "error",
   "nextfriday/jsx-no-inline-object-prop": "error",
   "nextfriday/jsx-no-newline-single-line-elements": "error",
   "nextfriday/jsx-no-non-component-function": "error",
+  "nextfriday/jsx-no-sub-interface": "error",
   "nextfriday/jsx-no-ternary-null": "error",
   "nextfriday/jsx-no-variable-in-callback": "error",
   "nextfriday/jsx-require-suspense": "error",

--- a/src/rules/__tests__/enforce-render-naming.test.ts
+++ b/src/rules/__tests__/enforce-render-naming.test.ts
@@ -1,0 +1,211 @@
+import { afterAll, describe, it } from "@jest/globals";
+import { RuleTester } from "@typescript-eslint/rule-tester";
+
+import rule from "../enforce-render-naming";
+
+RuleTester.afterAll = afterAll;
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parserOptions: {
+      ecmaFeatures: {
+        jsx: true,
+      },
+    },
+  },
+});
+
+ruleTester.run("enforce-render-naming", rule, {
+  valid: [
+    {
+      code: `
+        const Component = () => {
+          const renderHeader = <div />;
+          return renderHeader;
+        };
+      `,
+      filename: "Component.tsx",
+      name: "value-form JSX with render prefix",
+    },
+    {
+      code: `
+        const Component = () => {
+          const renderHeader = () => <div />;
+          return renderHeader();
+        };
+      `,
+      filename: "Component.tsx",
+      name: "function-form JSX with render prefix",
+    },
+    {
+      code: `
+        const Component = (props) => {
+          const renderCardElements = props.items.map((item) => <Card {...item} />);
+          return <div>{renderCardElements}</div>;
+        };
+      `,
+      filename: "Component.tsx",
+      name: "render prefix on .map result",
+    },
+    {
+      code: `
+        const Component = () => {
+          const count = 5;
+          const label = "hello";
+          return <div>{label}</div>;
+        };
+      `,
+      filename: "Component.tsx",
+      name: "non-JSX variables are not flagged",
+    },
+    {
+      code: `
+        const Component = () => {
+          const items = [1, 2, 3];
+          return <div>{items.length}</div>;
+        };
+      `,
+      filename: "Component.tsx",
+      name: "array of primitives is not JSX-producing",
+    },
+    {
+      code: `
+        function notAComponent() {
+          const header = <div />;
+          return header;
+        }
+      `,
+      filename: "Component.tsx",
+      name: "non-PascalCase function does not enforce naming",
+    },
+    {
+      code: `
+        const Component = () => {
+          const count = 5;
+          return count;
+        };
+      `,
+      filename: "Component.ts",
+      name: "non-jsx file is not checked",
+    },
+  ],
+  invalid: [
+    {
+      code: `
+        const Component = () => {
+          const header = <div />;
+          return header;
+        };
+      `,
+      filename: "Component.tsx",
+      errors: [{ messageId: "missingRenderPrefix", data: { name: "header", pascalName: "Header" } }],
+      name: "value-form JSX without render prefix",
+    },
+    {
+      code: `
+        const Component = () => {
+          const renderer = () => <div />;
+          return renderer();
+        };
+      `,
+      filename: "Component.tsx",
+      errors: [{ messageId: "missingRenderPrefix", data: { name: "renderer", pascalName: "Renderer" } }],
+      name: "renderer is not a render-prefix (no camelCase boundary)",
+    },
+    {
+      code: `
+        const Component = (props) => {
+          const cardElements = props.items.map((item) => <Card {...item} />);
+          return <div>{cardElements}</div>;
+        };
+      `,
+      filename: "Component.tsx",
+      errors: [{ messageId: "missingRenderPrefix", data: { name: "cardElements", pascalName: "CardElements" } }],
+      name: "missing render prefix on .map result",
+    },
+    {
+      code: `
+        const Component = (props) => {
+          const phoneEntries = props.phones.map((phone) => {
+            return <span>{phone}</span>;
+          });
+          return <div>{phoneEntries}</div>;
+        };
+      `,
+      filename: "Component.tsx",
+      errors: [{ messageId: "missingRenderPrefix", data: { name: "phoneEntries", pascalName: "PhoneEntries" } }],
+      name: "missing render prefix on .map with block return",
+    },
+    {
+      code: `
+        const Component = (props) => {
+          const fallback = props.condition ? <A /> : <B />;
+          return fallback;
+        };
+      `,
+      filename: "Component.tsx",
+      errors: [{ messageId: "missingRenderPrefix", data: { name: "fallback", pascalName: "Fallback" } }],
+      name: "missing render prefix on conditional JSX",
+    },
+    {
+      code: `
+        const Component = (props) => {
+          const banner = props.isVisible && <Banner />;
+          return banner;
+        };
+      `,
+      filename: "Component.tsx",
+      errors: [{ messageId: "missingRenderPrefix", data: { name: "banner", pascalName: "Banner" } }],
+      name: "missing render prefix on logical AND with JSX",
+    },
+    {
+      code: `
+        const Component = () => {
+          const header = () => <div />;
+          return header();
+        };
+      `,
+      filename: "Component.tsx",
+      errors: [{ messageId: "missingRenderPrefix", data: { name: "header", pascalName: "Header" } }],
+      name: "function-form JSX without render prefix",
+    },
+    {
+      code: `
+        function Component() {
+          const header = <div />;
+          return header;
+        }
+      `,
+      filename: "Component.tsx",
+      errors: [{ messageId: "missingRenderPrefix", data: { name: "header", pascalName: "Header" } }],
+      name: "function declaration component",
+    },
+    {
+      code: `
+        export default function Component() {
+          const header = <div />;
+          return header;
+        }
+      `,
+      filename: "Component.tsx",
+      errors: [{ messageId: "missingRenderPrefix", data: { name: "header", pascalName: "Header" } }],
+      name: "default-exported function declaration component",
+    },
+    {
+      code: `
+        const Component = () => {
+          if (true) {
+            const nestedHeader = <div />;
+            return nestedHeader;
+          }
+          return null;
+        };
+      `,
+      filename: "Component.tsx",
+      errors: [{ messageId: "missingRenderPrefix", data: { name: "nestedHeader", pascalName: "NestedHeader" } }],
+      name: "JSX variable inside nested block",
+    },
+  ],
+});

--- a/src/rules/__tests__/jsx-no-data-array.test.ts
+++ b/src/rules/__tests__/jsx-no-data-array.test.ts
@@ -1,0 +1,97 @@
+import { afterAll, describe, it } from "@jest/globals";
+import { RuleTester } from "@typescript-eslint/rule-tester";
+
+import rule from "../jsx-no-data-array";
+
+RuleTester.afterAll = afterAll;
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parserOptions: {
+      ecmaFeatures: {
+        jsx: true,
+      },
+    },
+  },
+});
+
+ruleTester.run("jsx-no-data-array", rule, {
+  valid: [
+    {
+      code: "const TIMEOUT_MS = 1000;",
+      filename: "Component.tsx",
+      name: "primitive constant",
+    },
+    {
+      code: 'const labels = ["Home", "About", "Contact"];',
+      filename: "Component.tsx",
+      name: "array of string primitives",
+    },
+    {
+      code: "const numbers = [1, 2, 3];",
+      filename: "Component.tsx",
+      name: "array of number primitives",
+    },
+    {
+      code: 'const ROUTES = { home: "/", about: "/about" };',
+      filename: "Component.tsx",
+      name: "flat map of primitives",
+    },
+    {
+      code: 'const stores = [{ name: "x" }, { name: "y" }];',
+      filename: "utils.ts",
+      name: "array of objects in non-jsx file is allowed",
+    },
+    {
+      code: 'const stores = [{ name: "x" }];',
+      filename: "data.ts",
+      name: "array of objects in plain ts file is allowed",
+    },
+  ],
+  invalid: [
+    {
+      code: 'const stores = [{ name: "Koh Samui" }];',
+      filename: "Component.tsx",
+      errors: [{ messageId: "noDataArray", data: { name: "stores" } }],
+      name: "array of single object literal in tsx",
+    },
+    {
+      code: 'const stores = [{ name: "x" }, { name: "y" }];',
+      filename: "Component.tsx",
+      errors: [{ messageId: "noDataArray", data: { name: "stores" } }],
+      name: "array of multiple object literals in tsx",
+    },
+    {
+      code: "const items: Item[] = [{ id: 1 }];",
+      filename: "Component.tsx",
+      errors: [{ messageId: "noDataArray", data: { name: "items" } }],
+      name: "typed array of object literals",
+    },
+    {
+      code: "const items = [{ id: 1 }] as const;",
+      filename: "Component.tsx",
+      errors: [{ messageId: "noDataArray", data: { name: "items" } }],
+      name: "as const assertion",
+    },
+    {
+      code: "const items = [{ id: 1 }] satisfies readonly { id: number }[];",
+      filename: "Component.tsx",
+      errors: [{ messageId: "noDataArray", data: { name: "items" } }],
+      name: "satisfies expression",
+    },
+    {
+      code: "export const items = [{ id: 1 }];",
+      filename: "Component.tsx",
+      errors: [{ messageId: "noDataArray", data: { name: "items" } }],
+      name: "exported array of object literals",
+    },
+    {
+      code: 'const stores = [{ name: "x" }];',
+      filename: "Component.jsx",
+      errors: [{ messageId: "noDataArray", data: { name: "stores" } }],
+      name: "jsx file is checked too",
+    },
+  ],
+});

--- a/src/rules/__tests__/jsx-no-data-object.test.ts
+++ b/src/rules/__tests__/jsx-no-data-object.test.ts
@@ -1,0 +1,97 @@
+import { afterAll, describe, it } from "@jest/globals";
+import { RuleTester } from "@typescript-eslint/rule-tester";
+
+import rule from "../jsx-no-data-object";
+
+RuleTester.afterAll = afterAll;
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parserOptions: {
+      ecmaFeatures: {
+        jsx: true,
+      },
+    },
+  },
+});
+
+ruleTester.run("jsx-no-data-object", rule, {
+  valid: [
+    {
+      code: "const TIMEOUT_MS = 1000;",
+      filename: "Component.tsx",
+      name: "primitive constant",
+    },
+    {
+      code: 'const ROUTES = { home: "/", about: "/about", contact: "/contact" };',
+      filename: "Component.tsx",
+      name: "flat object map of primitives",
+    },
+    {
+      code: 'const labels = ["Home", "About"];',
+      filename: "Component.tsx",
+      name: "flat array of primitives",
+    },
+    {
+      code: "const empty = {};",
+      filename: "Component.tsx",
+      name: "empty object",
+    },
+    {
+      code: 'const config = { a: 1, b: "x", c: true };',
+      filename: "Component.tsx",
+      name: "object of mixed primitives",
+    },
+    {
+      code: 'const config = { home: { url: "/" } };',
+      filename: "utils.ts",
+      name: "nested object in non-jsx file is allowed",
+    },
+  ],
+  invalid: [
+    {
+      code: 'const config = { home: { url: "/" } };',
+      filename: "Component.tsx",
+      errors: [{ messageId: "noDataObject", data: { name: "config" } }],
+      name: "nested object literal value",
+    },
+    {
+      code: "const config = { items: [{ id: 1 }] };",
+      filename: "Component.tsx",
+      errors: [{ messageId: "noDataObject", data: { name: "config" } }],
+      name: "array of objects as value",
+    },
+    {
+      code: "const config = { matrix: [[1, 2], [3, 4]] };",
+      filename: "Component.tsx",
+      errors: [{ messageId: "noDataObject", data: { name: "config" } }],
+      name: "nested array as value",
+    },
+    {
+      code: "const config = { a: { b: 1 } } as const;",
+      filename: "Component.tsx",
+      errors: [{ messageId: "noDataObject", data: { name: "config" } }],
+      name: "as const assertion",
+    },
+    {
+      code: "const config = { a: { b: 1 } } satisfies Record<string, unknown>;",
+      filename: "Component.tsx",
+      errors: [{ messageId: "noDataObject", data: { name: "config" } }],
+      name: "satisfies expression",
+    },
+    {
+      code: "export const config = { a: { b: 1 } };",
+      filename: "Component.tsx",
+      errors: [{ messageId: "noDataObject", data: { name: "config" } }],
+      name: "exported nested object",
+    },
+    {
+      code: "const config = { a: { b: 1 } };",
+      filename: "Component.jsx",
+      errors: [{ messageId: "noDataObject", data: { name: "config" } }],
+      name: "jsx file is checked too",
+    },
+  ],
+});

--- a/src/rules/__tests__/jsx-no-sub-interface.test.ts
+++ b/src/rules/__tests__/jsx-no-sub-interface.test.ts
@@ -1,0 +1,172 @@
+import { afterAll, describe, it } from "@jest/globals";
+import { RuleTester } from "@typescript-eslint/rule-tester";
+
+import rule from "../jsx-no-sub-interface";
+
+RuleTester.afterAll = afterAll;
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parserOptions: {
+      ecmaFeatures: {
+        jsx: true,
+      },
+    },
+  },
+});
+
+ruleTester.run("jsx-no-sub-interface", rule, {
+  valid: [
+    {
+      code: `
+        interface StoreCardProps { name: string }
+        const StoreCard = (props: Readonly<StoreCardProps>) => <div />;
+      `,
+      filename: "StoreCard.tsx",
+      name: "single main interface used by component",
+    },
+    {
+      code: `
+        interface StoreCardProps { name: string }
+        const StoreCard = (props: StoreCardProps) => <div />;
+      `,
+      filename: "StoreCard.tsx",
+      name: "main interface without Readonly wrapper",
+    },
+    {
+      code: `
+        type StoreCardProps = { name: string }
+        const StoreCard = (props: Readonly<StoreCardProps>) => <div />;
+      `,
+      filename: "StoreCard.tsx",
+      name: "main type alias used by component",
+    },
+    {
+      code: `
+        interface StoreCardProps { name: string }
+        export default function StoreCard(props: Readonly<StoreCardProps>) { return <div />; }
+      `,
+      filename: "StoreCard.tsx",
+      name: "default-exported function declaration component",
+    },
+    {
+      code: `
+        interface StoreCardProps { name: string }
+        export const StoreCard = (props: Readonly<StoreCardProps>) => <div />;
+      `,
+      filename: "StoreCard.tsx",
+      name: "named-exported component",
+    },
+    {
+      code: `
+        export interface StoreCardProps { name: string }
+        export const StoreCard = (props: Readonly<StoreCardProps>) => <div />;
+      `,
+      filename: "StoreCard.tsx",
+      name: "exported main interface",
+    },
+    {
+      code: `
+        interface CardProps { x: number }
+        interface HeaderProps { y: string }
+        const Card = (props: Readonly<CardProps>) => <div />;
+        const Header = (props: Readonly<HeaderProps>) => <div />;
+      `,
+      filename: "Card.tsx",
+      name: "multiple components each with their own main props",
+    },
+    {
+      code: `
+        interface StoreCardAddressProps { label: string; mapUrl: string }
+      `,
+      filename: "store-card-address.types.ts",
+      name: "non-jsx file is not checked",
+    },
+    {
+      code: `
+        interface Foo { x: number }
+        interface Bar { y: string }
+        export { Foo, Bar };
+      `,
+      filename: "types.tsx",
+      name: "tsx file with no component is not checked",
+    },
+  ],
+  invalid: [
+    {
+      code: `
+        interface StoreCardProps { address: StoreCardAddressProps }
+        interface StoreCardAddressProps { label: string }
+        const StoreCard = (props: Readonly<StoreCardProps>) => <div />;
+      `,
+      filename: "StoreCard.tsx",
+      errors: [{ messageId: "noSubInterface", data: { name: "StoreCardAddressProps" } }],
+      name: "sub-interface alongside main",
+    },
+    {
+      code: `
+        interface StoreCardProps { name: string }
+        interface StoreCardAddressProps { label: string }
+        interface StoreCardImageProps { src: string }
+        const StoreCard = (props: Readonly<StoreCardProps>) => <div />;
+      `,
+      filename: "StoreCard.tsx",
+      errors: [
+        { messageId: "noSubInterface", data: { name: "StoreCardAddressProps" } },
+        { messageId: "noSubInterface", data: { name: "StoreCardImageProps" } },
+      ],
+      name: "multiple sub-interfaces",
+    },
+    {
+      code: `
+        interface StoreCardProps { name: string }
+        type StoreCardKind = "phone" | "whatsapp";
+        const StoreCard = (props: Readonly<StoreCardProps>) => <div />;
+      `,
+      filename: "StoreCard.tsx",
+      errors: [{ messageId: "noSubInterface", data: { name: "StoreCardKind" } }],
+      name: "helper type alias alongside main interface",
+    },
+    {
+      code: `
+        type StoreCardProps = { name: string };
+        type StoreCardKind = "a" | "b";
+        const StoreCard = (props: Readonly<StoreCardProps>) => <div />;
+      `,
+      filename: "StoreCard.tsx",
+      errors: [{ messageId: "noSubInterface", data: { name: "StoreCardKind" } }],
+      name: "helper type alias alongside main type alias",
+    },
+    {
+      code: `
+        interface StoreCardProps { name: string }
+        interface StoreCardAddressProps { label: string }
+        export const StoreCard = (props: Readonly<StoreCardProps>) => <div />;
+      `,
+      filename: "StoreCard.tsx",
+      errors: [{ messageId: "noSubInterface", data: { name: "StoreCardAddressProps" } }],
+      name: "sub-interface alongside named-exported component",
+    },
+    {
+      code: `
+        interface SpinnerKind { variant: string }
+        const Spinner = () => <div />;
+      `,
+      filename: "Spinner.tsx",
+      errors: [{ messageId: "noSubInterface", data: { name: "SpinnerKind" } }],
+      name: "component without props still flags any top-level type",
+    },
+    {
+      code: `
+        export interface StoreCardProps { name: string }
+        export interface StoreCardAddressProps { label: string }
+        export const StoreCard = (props: Readonly<StoreCardProps>) => <div />;
+      `,
+      filename: "StoreCard.tsx",
+      errors: [{ messageId: "noSubInterface", data: { name: "StoreCardAddressProps" } }],
+      name: "exported sub-interface is still flagged",
+    },
+  ],
+});

--- a/src/rules/enforce-render-naming.ts
+++ b/src/rules/enforce-render-naming.ts
@@ -1,0 +1,205 @@
+import { AST_NODE_TYPES, ESLintUtils } from "@typescript-eslint/utils";
+
+import { getFileExtension } from "../utils";
+
+import type { TSESTree } from "@typescript-eslint/utils";
+
+const createRule = ESLintUtils.RuleCreator(
+  (name) =>
+    `https://github.com/next-friday/eslint-plugin-nextfriday/blob/main/docs/rules/${name.replaceAll("-", "_").toUpperCase()}.md`,
+);
+
+const ARRAY_RETURNING_METHODS = new Set(["map", "flatMap", "filter"]);
+
+function hasRenderPrefix(name: string): boolean {
+  if (!name.startsWith("render")) {
+    return false;
+  }
+  if (name.length === "render".length) {
+    return true;
+  }
+  const nextChar = name["render".length];
+  return nextChar === nextChar.toUpperCase() && nextChar !== nextChar.toLowerCase();
+}
+
+function functionBodyReturnsJsx(body: TSESTree.BlockStatement | TSESTree.Expression): boolean {
+  if (body.type === AST_NODE_TYPES.JSXElement || body.type === AST_NODE_TYPES.JSXFragment) {
+    return true;
+  }
+
+  if (body.type === AST_NODE_TYPES.ConditionalExpression) {
+    return isJsxProducingExpression(body.consequent) || isJsxProducingExpression(body.alternate);
+  }
+
+  if (body.type === AST_NODE_TYPES.LogicalExpression) {
+    return isJsxProducingExpression(body.right);
+  }
+
+  if (body.type !== AST_NODE_TYPES.BlockStatement) {
+    return false;
+  }
+
+  for (const statement of body.body) {
+    if (statement.type === AST_NODE_TYPES.ReturnStatement && statement.argument) {
+      if (isJsxProducingExpression(statement.argument)) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+function isJsxProducingExpression(node: TSESTree.Expression): boolean {
+  if (node.type === AST_NODE_TYPES.JSXElement || node.type === AST_NODE_TYPES.JSXFragment) {
+    return true;
+  }
+
+  if (node.type === AST_NODE_TYPES.ConditionalExpression) {
+    return isJsxProducingExpression(node.consequent) || isJsxProducingExpression(node.alternate);
+  }
+
+  if (node.type === AST_NODE_TYPES.LogicalExpression) {
+    return isJsxProducingExpression(node.right);
+  }
+
+  if (node.type === AST_NODE_TYPES.ArrayExpression) {
+    return node.elements.some((element) => {
+      if (!element || element.type === AST_NODE_TYPES.SpreadElement) {
+        return false;
+      }
+      return isJsxProducingExpression(element as TSESTree.Expression);
+    });
+  }
+
+  if (node.type === AST_NODE_TYPES.ArrowFunctionExpression || node.type === AST_NODE_TYPES.FunctionExpression) {
+    return functionBodyReturnsJsx(node.body);
+  }
+
+  if (node.type === AST_NODE_TYPES.CallExpression) {
+    if (
+      node.callee.type === AST_NODE_TYPES.MemberExpression &&
+      node.callee.property.type === AST_NODE_TYPES.Identifier &&
+      ARRAY_RETURNING_METHODS.has(node.callee.property.name)
+    ) {
+      const callback = node.arguments[0];
+      if (
+        callback &&
+        (callback.type === AST_NODE_TYPES.ArrowFunctionExpression ||
+          callback.type === AST_NODE_TYPES.FunctionExpression)
+      ) {
+        return functionBodyReturnsJsx(callback.body);
+      }
+    }
+  }
+
+  if (node.type === AST_NODE_TYPES.TSAsExpression || node.type === AST_NODE_TYPES.TSSatisfiesExpression) {
+    return isJsxProducingExpression(node.expression);
+  }
+
+  return false;
+}
+
+function isPascalCase(name: string): boolean {
+  return /^[A-Z]/.test(name);
+}
+
+function isComponentFunction(
+  node: TSESTree.ArrowFunctionExpression | TSESTree.FunctionDeclaration | TSESTree.FunctionExpression,
+): boolean {
+  if (node.type === AST_NODE_TYPES.FunctionDeclaration && node.id && isPascalCase(node.id.name)) {
+    return true;
+  }
+
+  const parent = node.parent;
+  if (
+    parent?.type === AST_NODE_TYPES.VariableDeclarator &&
+    parent.id.type === AST_NODE_TYPES.Identifier &&
+    isPascalCase(parent.id.name)
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
+const enforceRenderNaming = createRule({
+  name: "enforce-render-naming",
+  meta: {
+    type: "problem",
+    docs: {
+      description: "Enforce 'render' prefix for variables that hold or return JSX inside React components",
+    },
+    schema: [],
+    messages: {
+      missingRenderPrefix:
+        "Variable '{{ name }}' holds JSX-producing content inside a component. Rename it to 'render{{ pascalName }}' so the intent is explicit.",
+    },
+  },
+  defaultOptions: [],
+  create(context) {
+    const { filename } = context;
+    const extension = getFileExtension(filename);
+
+    if (extension !== "tsx" && extension !== "jsx") {
+      return {};
+    }
+
+    const componentStack: boolean[] = [];
+
+    function isInsideComponent(): boolean {
+      return componentStack.some((value) => value);
+    }
+
+    function pushFunction(
+      node: TSESTree.ArrowFunctionExpression | TSESTree.FunctionDeclaration | TSESTree.FunctionExpression,
+    ) {
+      componentStack.push(isComponentFunction(node));
+    }
+
+    function popFunction() {
+      componentStack.pop();
+    }
+
+    return {
+      ArrowFunctionExpression: pushFunction,
+      FunctionDeclaration: pushFunction,
+      FunctionExpression: pushFunction,
+      "ArrowFunctionExpression:exit": popFunction,
+      "FunctionDeclaration:exit": popFunction,
+      "FunctionExpression:exit": popFunction,
+      VariableDeclarator(node: TSESTree.VariableDeclarator) {
+        if (!isInsideComponent()) {
+          return;
+        }
+
+        if (node.id.type !== AST_NODE_TYPES.Identifier) {
+          return;
+        }
+
+        if (!node.init) {
+          return;
+        }
+
+        if (!isJsxProducingExpression(node.init)) {
+          return;
+        }
+
+        const name = node.id.name;
+        if (hasRenderPrefix(name)) {
+          return;
+        }
+
+        const pascalName = name.charAt(0).toUpperCase() + name.slice(1);
+
+        context.report({
+          node: node.id,
+          messageId: "missingRenderPrefix",
+          data: { name, pascalName },
+        });
+      },
+    };
+  },
+});
+
+export default enforceRenderNaming;

--- a/src/rules/jsx-no-data-array.ts
+++ b/src/rules/jsx-no-data-array.ts
@@ -1,0 +1,113 @@
+import { AST_NODE_TYPES, ESLintUtils } from "@typescript-eslint/utils";
+
+import { getFileExtension } from "../utils";
+
+import type { TSESTree } from "@typescript-eslint/utils";
+
+const createRule = ESLintUtils.RuleCreator(
+  (name) =>
+    `https://github.com/next-friday/eslint-plugin-nextfriday/blob/main/docs/rules/${name.replaceAll("-", "_").toUpperCase()}.md`,
+);
+
+function isObjectLikeElement(node: TSESTree.Expression | TSESTree.SpreadElement | null): boolean {
+  if (!node) {
+    return false;
+  }
+
+  if (node.type === AST_NODE_TYPES.ObjectExpression) {
+    return true;
+  }
+
+  if (node.type === AST_NODE_TYPES.TSAsExpression || node.type === AST_NODE_TYPES.TSSatisfiesExpression) {
+    return isObjectLikeElement(node.expression);
+  }
+
+  return false;
+}
+
+function getArrayInitializer(init: TSESTree.Expression | null): TSESTree.ArrayExpression | null {
+  if (!init) {
+    return null;
+  }
+
+  if (init.type === AST_NODE_TYPES.ArrayExpression) {
+    return init;
+  }
+
+  if (init.type === AST_NODE_TYPES.TSAsExpression || init.type === AST_NODE_TYPES.TSSatisfiesExpression) {
+    return getArrayInitializer(init.expression);
+  }
+
+  return null;
+}
+
+const jsxNoDataArray = createRule({
+  name: "jsx-no-data-array",
+  meta: {
+    type: "problem",
+    docs: {
+      description: "Disallow top-level arrays of object literals in .tsx/.jsx files (extract to a data file)",
+    },
+    schema: [],
+    messages: {
+      noDataArray:
+        "Top-level array of object literals belongs in a data file (e.g. *.data.ts), not a .tsx/.jsx component file. Extract '{{ name }}' to a sibling data module.",
+    },
+  },
+  defaultOptions: [],
+  create(context) {
+    const { filename } = context;
+    const extension = getFileExtension(filename);
+
+    if (extension !== "tsx" && extension !== "jsx") {
+      return {};
+    }
+
+    return {
+      "Program > VariableDeclaration > VariableDeclarator": function checkDeclarator(
+        node: TSESTree.VariableDeclarator,
+      ) {
+        const arrayInit = getArrayInitializer(node.init);
+        if (!arrayInit) {
+          return;
+        }
+
+        const hasObjectElement = arrayInit.elements.some((element) => isObjectLikeElement(element));
+        if (!hasObjectElement) {
+          return;
+        }
+
+        const name = node.id.type === AST_NODE_TYPES.Identifier ? node.id.name : "<destructured>";
+
+        context.report({
+          node,
+          messageId: "noDataArray",
+          data: { name },
+        });
+      },
+      "Program > ExportNamedDeclaration > VariableDeclaration > VariableDeclarator": function checkExportedDeclarator(
+        node: TSESTree.VariableDeclarator,
+      ) {
+        const arrayInit = getArrayInitializer(node.init);
+        if (!arrayInit) {
+          return;
+        }
+
+        const hasObjectElement = arrayInit.elements.some((element) => isObjectLikeElement(element));
+        if (!hasObjectElement) {
+          return;
+        }
+
+        const name = node.id.type === AST_NODE_TYPES.Identifier ? node.id.name : "<destructured>";
+
+        context.report({
+          node,
+          messageId: "noDataArray",
+          data: { name },
+        });
+      },
+    };
+  },
+});
+
+export default jsxNoDataArray;

--- a/src/rules/jsx-no-data-object.ts
+++ b/src/rules/jsx-no-data-object.ts
@@ -1,0 +1,120 @@
+import { AST_NODE_TYPES, ESLintUtils } from "@typescript-eslint/utils";
+
+import { getFileExtension } from "../utils";
+
+import type { TSESTree } from "@typescript-eslint/utils";
+
+const createRule = ESLintUtils.RuleCreator(
+  (name) =>
+    `https://github.com/next-friday/eslint-plugin-nextfriday/blob/main/docs/rules/${name.replaceAll("-", "_").toUpperCase()}.md`,
+);
+
+function unwrapAssertion(node: TSESTree.Expression | null): TSESTree.Expression | null {
+  if (!node) {
+    return null;
+  }
+
+  if (node.type === AST_NODE_TYPES.TSAsExpression || node.type === AST_NODE_TYPES.TSSatisfiesExpression) {
+    return unwrapAssertion(node.expression);
+  }
+
+  return node;
+}
+
+function isNestedValue(value: TSESTree.Expression | null): boolean {
+  const unwrapped = unwrapAssertion(value);
+  if (!unwrapped) {
+    return false;
+  }
+
+  if (unwrapped.type === AST_NODE_TYPES.ObjectExpression) {
+    return true;
+  }
+
+  if (unwrapped.type === AST_NODE_TYPES.ArrayExpression) {
+    return unwrapped.elements.some((element) => {
+      if (!element || element.type === AST_NODE_TYPES.SpreadElement) {
+        return false;
+      }
+      const inner = unwrapAssertion(element);
+      return inner?.type === AST_NODE_TYPES.ObjectExpression || inner?.type === AST_NODE_TYPES.ArrayExpression;
+    });
+  }
+
+  return false;
+}
+
+function hasNestedProperty(object: TSESTree.ObjectExpression): boolean {
+  return object.properties.some((property) => {
+    if (property.type !== AST_NODE_TYPES.Property) {
+      return false;
+    }
+    if (property.value.type === AST_NODE_TYPES.AssignmentPattern) {
+      return false;
+    }
+    return isNestedValue(property.value as TSESTree.Expression);
+  });
+}
+
+function getObjectInitializer(init: TSESTree.Expression | null): TSESTree.ObjectExpression | null {
+  const unwrapped = unwrapAssertion(init);
+  if (!unwrapped) {
+    return null;
+  }
+
+  if (unwrapped.type === AST_NODE_TYPES.ObjectExpression) {
+    return unwrapped;
+  }
+
+  return null;
+}
+
+const jsxNoDataObject = createRule({
+  name: "jsx-no-data-object",
+  meta: {
+    type: "problem",
+    docs: {
+      description: "Disallow top-level nested object literals in .tsx/.jsx files (extract to a data file)",
+    },
+    schema: [],
+    messages: {
+      noDataObject:
+        "Top-level nested object literal belongs in a data file (e.g. *.data.ts), not a .tsx/.jsx component file. Extract '{{ name }}' to a sibling data module.",
+    },
+  },
+  defaultOptions: [],
+  create(context) {
+    const { filename } = context;
+    const extension = getFileExtension(filename);
+
+    if (extension !== "tsx" && extension !== "jsx") {
+      return {};
+    }
+
+    function checkDeclarator(node: TSESTree.VariableDeclarator) {
+      const objectInit = getObjectInitializer(node.init);
+      if (!objectInit) {
+        return;
+      }
+
+      if (!hasNestedProperty(objectInit)) {
+        return;
+      }
+
+      const name = node.id.type === AST_NODE_TYPES.Identifier ? node.id.name : "<destructured>";
+
+      context.report({
+        node,
+        messageId: "noDataObject",
+        data: { name },
+      });
+    }
+
+    return {
+      "Program > VariableDeclaration > VariableDeclarator": checkDeclarator,
+      "Program > ExportNamedDeclaration > VariableDeclaration > VariableDeclarator": checkDeclarator,
+    };
+  },
+});
+
+export default jsxNoDataObject;

--- a/src/rules/jsx-no-sub-interface.ts
+++ b/src/rules/jsx-no-sub-interface.ts
@@ -1,0 +1,167 @@
+import { AST_NODE_TYPES, ESLintUtils } from "@typescript-eslint/utils";
+
+import { getFileExtension } from "../utils";
+
+import type { TSESTree } from "@typescript-eslint/utils";
+
+const createRule = ESLintUtils.RuleCreator(
+  (name) =>
+    `https://github.com/next-friday/eslint-plugin-nextfriday/blob/main/docs/rules/${name.replaceAll("-", "_").toUpperCase()}.md`,
+);
+
+const PROPS_WRAPPER_NAMES = new Set(["Readonly", "Required", "Partial", "PropsWithChildren", "NoInfer"]);
+
+function unwrapWrapperType(node: TSESTree.TypeNode): TSESTree.TypeNode {
+  if (
+    node.type === AST_NODE_TYPES.TSTypeReference &&
+    node.typeName.type === AST_NODE_TYPES.Identifier &&
+    PROPS_WRAPPER_NAMES.has(node.typeName.name) &&
+    node.typeArguments &&
+    node.typeArguments.params.length > 0
+  ) {
+    return unwrapWrapperType(node.typeArguments.params[0]);
+  }
+  return node;
+}
+
+function getMainTypeName(typeNode: TSESTree.TypeNode | undefined): string | null {
+  if (!typeNode) {
+    return null;
+  }
+  const unwrapped = unwrapWrapperType(typeNode);
+  if (unwrapped.type === AST_NODE_TYPES.TSTypeReference && unwrapped.typeName.type === AST_NODE_TYPES.Identifier) {
+    return unwrapped.typeName.name;
+  }
+  return null;
+}
+
+function getComponentMainTypeName(
+  node: TSESTree.ArrowFunctionExpression | TSESTree.FunctionDeclaration | TSESTree.FunctionExpression,
+): string | null {
+  const firstParam = node.params[0];
+  if (!firstParam) {
+    return null;
+  }
+
+  if ("typeAnnotation" in firstParam && firstParam.typeAnnotation) {
+    return getMainTypeName(firstParam.typeAnnotation.typeAnnotation);
+  }
+
+  return null;
+}
+
+function isPascalCase(name: string): boolean {
+  return /^[A-Z]/.test(name);
+}
+
+function getDeclarationFromExportWrapper(node: TSESTree.ProgramStatement): TSESTree.Node {
+  if (node.type === AST_NODE_TYPES.ExportNamedDeclaration && node.declaration) {
+    return node.declaration;
+  }
+  if (node.type === AST_NODE_TYPES.ExportDefaultDeclaration) {
+    return node.declaration;
+  }
+  return node;
+}
+
+const jsxNoSubInterface = createRule({
+  name: "jsx-no-sub-interface",
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow sub-interfaces and helper types in component files; keep only the main component props (extract the rest)",
+    },
+    schema: [],
+    messages: {
+      noSubInterface:
+        "Sub-interface or helper type '{{ name }}' should not live in a component file. Extract it to a sibling module (e.g., a *.types.ts file or its own component file).",
+    },
+  },
+  defaultOptions: [],
+  create(context) {
+    const { filename } = context;
+    const extension = getFileExtension(filename);
+
+    if (extension !== "tsx" && extension !== "jsx") {
+      return {};
+    }
+
+    return {
+      Program(programNode: TSESTree.Program) {
+        const mainTypes = new Set<string>();
+        const typeDeclarations: Array<{ name: string; node: TSESTree.Node }> = [];
+        let componentCount = 0;
+
+        for (const statement of programNode.body) {
+          const declaration = getDeclarationFromExportWrapper(statement);
+
+          if (
+            declaration.type === AST_NODE_TYPES.FunctionDeclaration &&
+            declaration.id &&
+            isPascalCase(declaration.id.name)
+          ) {
+            componentCount += 1;
+            const mainType = getComponentMainTypeName(declaration);
+            if (mainType) {
+              mainTypes.add(mainType);
+            }
+            continue;
+          }
+
+          if (declaration.type === AST_NODE_TYPES.VariableDeclaration) {
+            for (const declarator of declaration.declarations) {
+              if (declarator.id.type !== AST_NODE_TYPES.Identifier) {
+                continue;
+              }
+              if (!isPascalCase(declarator.id.name)) {
+                continue;
+              }
+              const init = declarator.init;
+              if (
+                init &&
+                (init.type === AST_NODE_TYPES.ArrowFunctionExpression ||
+                  init.type === AST_NODE_TYPES.FunctionExpression)
+              ) {
+                componentCount += 1;
+                const mainType = getComponentMainTypeName(init);
+                if (mainType) {
+                  mainTypes.add(mainType);
+                }
+              }
+            }
+            continue;
+          }
+
+          if (declaration.type === AST_NODE_TYPES.TSInterfaceDeclaration) {
+            typeDeclarations.push({ name: declaration.id.name, node: declaration });
+            continue;
+          }
+
+          if (declaration.type === AST_NODE_TYPES.TSTypeAliasDeclaration) {
+            typeDeclarations.push({ name: declaration.id.name, node: declaration });
+            continue;
+          }
+        }
+
+        if (componentCount === 0) {
+          return;
+        }
+
+        for (const declaration of typeDeclarations) {
+          if (mainTypes.has(declaration.name)) {
+            continue;
+          }
+
+          context.report({
+            node: declaration.node,
+            messageId: "noSubInterface",
+            data: { name: declaration.name },
+          });
+        }
+      },
+    };
+  },
+});
+
+export default jsxNoSubInterface;


### PR DESCRIPTION
## Summary

Add four JSX rules that target a single anti-pattern: `.tsx` / `.jsx` files acting as content / type / naming dumping grounds. The component file should describe one component's render — data, sub-types, and helper render-fragments belong elsewhere or under a clearer name.

- **`jsx-no-data-array`** — flag top-level `const` whose initializer is an array of object literals (incl. `as const` / `satisfies` / exported variants). Arrays of primitives unaffected.
- **`jsx-no-data-object`** — flag top-level `const` whose initializer is an object literal containing a nested object or nested array of objects. Flat maps of primitives unaffected.
- **`jsx-no-sub-interface`** — flag any top-level `interface` / `type` that is not the main props type for a component declared in the same file. The "main" type is determined by the first parameter type of a top-level PascalCase function/arrow component, with `Readonly<T>`, `Required<T>`, `Partial<T>`, `PropsWithChildren<T>`, `NoInfer<T>` unwrapped. Files with no component are not checked.
- **`enforce-render-naming`** — flag variables declared inside a top-level PascalCase component whose initializer holds or returns JSX, but whose name does not start with `render` followed by a camelCase boundary. Detected initializers: JSX literals, conditional / logical with JSX branch, arrays of JSX, arrow / function expressions returning JSX, `.map` / `.flatMap` / `.filter` callbacks returning JSX, and `as` / `satisfies` wrappers around any of the above. Both value form (`const renderHeader = <div />`) and function form (`const renderHeader = () => <div />`) are accepted.

All four ship in `react`, `react/recommended`, `nextjs`, `nextjs/recommended` at `warn` and `error` respectively. Total rule count: 59 → 63 (40 base + 23 JSX). None are auto-fixable — each surfaces a structural decision the author should make.

## Type of Change

- [x] New rule or rule enhancement
- [x] Documentation

## Test Plan

- 4 new rule tests, 56 new test cases total: \`jsx-no-data-array\` (13), \`jsx-no-data-object\` (13), \`jsx-no-sub-interface\` (16), \`enforce-render-naming\` (17 — incl. value-form + function-form, conditional / logical / map callbacks, function declarations, default exports, nested blocks)
- Updated \`src/__tests__/rules.test.ts\` (count 61 → 63 ⇒ 63, names list)
- Full suite: 1426/1426 pass
- \`pnpm typecheck\` clean
- \`pnpm eslint:check\` clean (plugin dogfoods its own rules)

## Related Issues

None