### PR TITLE
feat(rules): add hook and test file enforcement rules

### DIFF
--- a/.changeset/bold-worms-pick.md
+++ b/.changeset/bold-worms-pick.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-nextfriday": minor
+---
+
+add enforce-hook-filename, enforce-test-filename, no-helper-function-in-hook, no-helper-function-in-test rules

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ The plugin dogfoods its own rules via `eslint.config.mjs`. Build config lives in
 `src/index.ts` - Main plugin export containing:
 
 - `meta` - Plugin name and version from package.json
-- `rules` - All 63 rule implementations keyed by hyphenated name
+- `rules` - All 67 rule implementations keyed by hyphenated name
 - `configs` - Six configuration presets (each rule set has a `warn` and `error`/`recommended` variant). All presets are built via `createConfig()` and return a single config object. The `nextjs` and `nextjs/recommended` presets currently share the same rule set as `react` and `react/recommended`; they are kept as named aliases.
 
 The plugin is exported both as default and as named exports `{ meta, configs, rules }`.
@@ -54,9 +54,11 @@ Six configs total. Two rule set tiers, each with a `warn` variant and a `Recomme
 
 | Preset                          | Rules            | Severity     |
 | ------------------------------- | ---------------- | ------------ |
-| `base` / `base/recommended`     | 40 base          | warn / error |
-| `react` / `react/recommended`   | 40 base + 23 JSX | warn / error |
-| `nextjs` / `nextjs/recommended` | 40 base + 23 JSX | warn / error |
+| `base` / `base/recommended`     | 42 base          | warn / error |
+| `react` / `react/recommended`   | 42 base + 23 JSX | warn / error |
+| `nextjs` / `nextjs/recommended` | 42 base + 23 JSX | warn / error |
+
+Some rules are **not** included in any preset and must be opted into manually via a `files`-scoped config block (e.g. `no-helper-function-in-test`, `no-helper-function-in-hook`). These rules apply only when explicitly configured by the user.
 
 ### Utilities
 
@@ -79,7 +81,8 @@ Six configs total. Two rule set tiers, each with a `warn` variant and a `Recomme
 3. Register in `src/index.ts`:
    - Import the rule
    - Add to `rules` object
-   - Add to both the warn and recommended variants of the appropriate rule set (e.g., `jsxRules` AND `jsxRecommendedRules`)
+   - **If the rule belongs in a preset**: add to both the warn and recommended variants of the appropriate rule set (e.g., `baseRules` AND `baseRecommendedRules`, or `jsxRules` AND `jsxRecommendedRules`). Rules that check the filename internally (e.g. `enforce-hook-filename`, `enforce-test-filename`) go in `baseRules` and return early when the file doesn't match.
+   - **If the rule is opt-in** (only useful when scoped to specific file patterns via `files` glob): add to `rules` only — do **not** add to any preset. Examples: `no-helper-function-in-test`, `no-helper-function-in-hook`.
 4. Create documentation: `docs/rules/{RULE_NAME_UPPERCASE}.md`
 5. Update README.md rules table
 6. Update `src/__tests__/rules.test.ts`:

--- a/README.md
+++ b/README.md
@@ -413,6 +413,8 @@ In practice: turn the high tier on as `"error"` first, leave the medium tier as 
 | [require-explicit-return-type](docs/rules/REQUIRE_EXPLICIT_RETURN_TYPE.md)   | Require explicit return types on functions for better documentation    | ❌      |
 | [no-complex-inline-return](docs/rules/NO_COMPLEX_INLINE_RETURN.md)           | Disallow complex inline expressions in return - extract to const first | ❌      |
 | [no-logic-in-params](docs/rules/NO_LOGIC_IN_PARAMS.md)                       | Disallow logic/conditions in function parameters - extract to const    | ❌      |
+| [enforce-hook-filename](docs/rules/ENFORCE_HOOK_FILENAME.md)                 | Enforce that files exporting custom hooks are named \*.hook.ts         | ❌      |
+| [enforce-test-filename](docs/rules/ENFORCE_TEST_FILENAME.md)                 | Enforce that files containing test code are named \*.test.ts           | ❌      |
 | [enforce-hook-naming](docs/rules/ENFORCE_HOOK_NAMING.md)                     | Enforce 'use' prefix for functions in \*.hook.ts files                 | ❌      |
 | [enforce-service-naming](docs/rules/ENFORCE_SERVICE_NAMING.md)               | Enforce 'fetch' prefix for async functions in \*.service.ts files      | ❌      |
 | [enforce-sorted-destructuring](docs/rules/ENFORCE_SORTED_DESTRUCTURING.md)   | Enforce alphabetical sorting of destructured properties                | ✅      |
@@ -427,6 +429,8 @@ In practice: turn the high tier on as `"error"` first, leave the medium tier as 
 | [prefer-async-await](docs/rules/PREFER_ASYNC_AWAIT.md)                       | Enforce async/await over .then() promise chains                        | ❌      |
 | [no-nested-ternary](docs/rules/NO_NESTED_TERNARY.md)                         | Disallow nested ternary expressions                                    | ❌      |
 | [prefer-guard-clause](docs/rules/PREFER_GUARD_CLAUSE.md)                     | Enforce guard clause pattern instead of nested if statements           | ❌      |
+| [no-helper-function-in-hook](docs/rules/NO_HELPER_FUNCTION_IN_HOOK.md)       | Disallow non-hook helper function definitions in hook files            | ❌      |
+| [no-helper-function-in-test](docs/rules/NO_HELPER_FUNCTION_IN_TEST.md)       | Disallow helper function definitions in test files                     | ❌      |
 
 ### Import Optimization Rules
 
@@ -485,23 +489,25 @@ In practice: turn the high tier on as `"error"` first, leave the medium tier as 
 
 | Preset               | Severity | Base Rules | JSX Rules | Total Rules |
 | -------------------- | -------- | ---------- | --------- | ----------- |
-| `base`               | warn     | 40         | 0         | 40          |
-| `base/recommended`   | error    | 40         | 0         | 40          |
-| `react`              | warn     | 40         | 23        | 63          |
-| `react/recommended`  | error    | 40         | 23        | 63          |
-| `nextjs`             | warn     | 40         | 23        | 63          |
-| `nextjs/recommended` | error    | 40         | 23        | 63          |
+| `base`               | warn     | 42         | 0         | 42          |
+| `base/recommended`   | error    | 42         | 0         | 42          |
+| `react`              | warn     | 42         | 23        | 65          |
+| `react/recommended`  | error    | 42         | 23        | 65          |
+| `nextjs`             | warn     | 42         | 23        | 65          |
+| `nextjs/recommended` | error    | 42         | 23        | 65          |
 
 The `nextjs` and `nextjs/recommended` presets currently share the same rule set as `react` and `react/recommended`; they are kept as named aliases for ergonomics.
 
-### Base Configuration Rules (40 rules)
+### Base Configuration Rules (42 rules)
 
 Included in `base`, `base/recommended`, and all other presets:
 
 - `nextfriday/boolean-naming-prefix`
 - `nextfriday/enforce-camel-case`
 - `nextfriday/enforce-constant-case`
+- `nextfriday/enforce-hook-filename`
 - `nextfriday/enforce-hook-naming`
+- `nextfriday/enforce-test-filename`
 - `nextfriday/enforce-property-case`
 - `nextfriday/enforce-service-naming`
 - `nextfriday/enforce-sorted-destructuring`

--- a/docs/rules/ENFORCE_HOOK_FILENAME.md
+++ b/docs/rules/ENFORCE_HOOK_FILENAME.md
@@ -1,0 +1,77 @@
+# enforce-hook-filename
+
+Enforce that files exporting custom hooks are named `*.hook.ts` or `*.hooks.ts`.
+
+## Rule Details
+
+Any file that exports a custom hook (a function whose name starts with `use` followed by an uppercase letter) must have a `.hook.ts` or `.hooks.ts` suffix. This ensures hook files are consistently discoverable and that `no-helper-function-in-hook` can be reliably scoped to them.
+
+### Why?
+
+Without enforced naming, hooks can silently live inside service files, utility files, or component files — breaking the `files` glob that powers `no-helper-function-in-hook` and making codebases harder to navigate.
+
+## Examples
+
+### Incorrect
+
+```ts
+// use-user-data.ts ❌
+export function useUserData() {
+  return null;
+}
+```
+
+```ts
+// user.service.ts ❌
+export const useCurrentUser = () => null;
+```
+
+```ts
+// UserCard.tsx ❌
+export function useUserCard() {
+  return null;
+}
+```
+
+### Correct
+
+```ts
+// use-user-data.hook.ts ✅
+export function useUserData() {
+  return null;
+}
+```
+
+```ts
+// user.hooks.ts ✅
+export const useCurrentUser = () => null;
+```
+
+Re-exporting from an index file is fine — only the file that defines the hook must follow the naming convention:
+
+```ts
+// index.ts ✅
+export { useUserData } from "./use-user-data.hook";
+```
+
+## What This Rule Checks
+
+- `export function useFoo()` — named function declaration export
+- `export const useFoo = () =>` — arrow function export
+- `export const useFoo = function()` — function expression export
+- `export default function useFoo()` — default function declaration export
+
+A name is treated as a hook only when it starts with `use` followed by an uppercase letter (e.g. `useData`, not `user` or `use`).
+
+## Exceptions
+
+Files already named `*.hook.ts` or `*.hooks.ts` are skipped entirely. Re-exports (`export { useFoo } from "..."`) are not flagged.
+
+## When Not To Use It
+
+Disable per-file if you intentionally co-locate a small hook with its only consumer and do not plan to reuse it.
+
+## Related Rules
+
+- [enforce-hook-naming](./ENFORCE_HOOK_NAMING.md) — enforces the `use` prefix on functions inside hook files
+- [no-helper-function-in-hook](./NO_HELPER_FUNCTION_IN_HOOK.md) — disallows non-hook helpers inside hook files

--- a/docs/rules/ENFORCE_TEST_FILENAME.md
+++ b/docs/rules/ENFORCE_TEST_FILENAME.md
@@ -1,0 +1,61 @@
+# enforce-test-filename
+
+Enforce that files containing test code are named `*.test.ts` or `*.test.tsx`.
+
+## Rule Details
+
+Any file that calls test runner globals (`describe`, `it`, `test`, `beforeEach`, `beforeAll`, `afterEach`, `afterAll`) must have a `.test.ts` or `.test.tsx` suffix. Files named `*.spec.ts` or any other pattern are not allowed.
+
+### Why?
+
+Consistent naming makes test files predictable to find and reliable to target with `files` globs in ESLint configs (e.g. `no-helper-function-in-test`). Mixing `.spec.ts` and `.test.ts` breaks glob-based scoping.
+
+## Examples
+
+### Incorrect
+
+```ts
+// user.spec.ts ❌
+describe("user", () => {
+  it("works", () => {});
+});
+```
+
+```ts
+// user-tests.ts ❌
+it("works", () => {});
+```
+
+### Correct
+
+```ts
+// user.test.ts ✅
+describe("user", () => {
+  it("works", () => {});
+});
+```
+
+```ts
+// UserCard.test.tsx ✅
+test("renders", () => {});
+```
+
+## What This Rule Checks
+
+Files that contain calls to any of the following globals trigger the requirement:
+
+`describe`, `it`, `test`, `beforeEach`, `beforeAll`, `afterEach`, `afterAll`
+
+Only one error is reported per file regardless of how many test calls are present.
+
+## Exceptions
+
+Files already named `*.test.ts` or `*.test.tsx` are skipped entirely.
+
+## When Not To Use It
+
+Disable if your project intentionally uses `.spec.ts` as the test file convention.
+
+## Related Rules
+
+- [no-helper-function-in-test](./NO_HELPER_FUNCTION_IN_TEST.md) — disallows helper functions inside test files

--- a/docs/rules/NO_HELPER_FUNCTION_IN_HOOK.md
+++ b/docs/rules/NO_HELPER_FUNCTION_IN_HOOK.md
@@ -1,0 +1,86 @@
+# no-helper-function-in-hook
+
+Disallow non-hook helper function definitions in hook files.
+
+## Rule Details
+
+Custom hook files should contain only the hook function itself (prefixed with `use`) and its supporting constants. Utility functions that are not hooks must be extracted to a separate file and imported.
+
+### Why?
+
+Helper functions defined inside a hook file are invisible to the rest of the codebase, cannot be tested independently, and are harder to reuse. Keeping hook files focused on a single hook makes them easier to read and maintain.
+
+## Examples
+
+### Incorrect
+
+```ts
+function buildQueryKey(id: string): string {
+  return `item-${id}`;
+}
+
+export function useItemData(id: string) {
+  const key = buildQueryKey(id);
+  // ...
+}
+```
+
+```ts
+const formatResponse = (data: unknown) => data;
+
+export const useItemData = (id: string) => {
+  // ...
+};
+```
+
+### Correct
+
+```ts
+import { buildQueryKey } from "./item.utils";
+
+export function useItemData(id: string) {
+  const key = buildQueryKey(id);
+  // ...
+}
+```
+
+Functions defined inside the hook body are fine:
+
+```ts
+export function useItemData(id: string) {
+  function buildQueryKey() {
+    return `item-${id}`;
+  }
+  // ...
+}
+```
+
+## What This Rule Checks
+
+- Top-level `function` declarations whose name does not start with `use`
+- Top-level `const`/`let`/`var` declarations assigned an arrow function or function expression whose name does not start with `use`
+
+Both plain and `export`-prefixed declarations are checked.
+
+## Exceptions
+
+- Hook functions starting with `use` are allowed at the top level
+- Functions defined inside a hook body are not flagged
+- Non-function constants (strings, numbers, arrays, objects) are not flagged
+
+## When Not To Use It
+
+This rule should be scoped to hook files using the ESLint `files` glob:
+
+```js
+{
+  files: ["**/*.hook.ts", "**/*.hooks.ts"],
+  rules: {
+    "nextfriday/no-helper-function-in-hook": "error",
+  },
+}
+```
+
+## Related Rules
+
+- [enforce-hook-naming](./ENFORCE_HOOK_NAMING.md) — enforces the `use` prefix on all functions in hook files

--- a/docs/rules/NO_HELPER_FUNCTION_IN_TEST.md
+++ b/docs/rules/NO_HELPER_FUNCTION_IN_TEST.md
@@ -1,0 +1,69 @@
+# no-helper-function-in-test
+
+Disallow helper function definitions in test files.
+
+## Rule Details
+
+Test files should contain only pure test code — `describe`, `it`, `test`, `beforeEach`, and similar test runner constructs. Helper functions defined at the top level of a test file are utility code that belongs in a separate file and should be imported.
+
+### Why?
+
+When helper functions are defined inside test files, they become invisible to other tests and are harder to maintain, test independently, and reuse. Keeping test files free of utility logic makes them easier to read and reason about.
+
+## Examples
+
+### Incorrect
+
+```ts
+function findTemplateFiles(directory: string): string[] {
+  // ...
+}
+
+const extractImports = (source: string): string[] => {
+  // ...
+};
+
+describe("template imports", () => {
+  it("must only import from allowed paths", () => {
+    // ...
+  });
+});
+```
+
+### Correct
+
+```ts
+import { findTemplateFiles, extractImports } from "./test-utils";
+
+describe("template imports", () => {
+  it("must only import from allowed paths", () => {
+    // ...
+  });
+});
+```
+
+## What This Rule Checks
+
+- Top-level `function` declarations
+- Top-level `const`/`let`/`var` declarations assigned an arrow function or function expression
+
+Constants that are not functions (regex patterns, arrays, objects) are allowed.
+
+## Exceptions
+
+Functions declared inside `describe`, `it`, `test`, `beforeEach`, or other callback bodies are not flagged.
+
+## When Not To Use It
+
+Disable this rule for files that are intentionally test utility modules (e.g., `test-utils.ts`, `helpers.ts`) rather than test suite files.
+
+This rule should be scoped to test files using the ESLint `files` glob:
+
+```js
+{
+  files: ["**/*.test.ts", "**/*.spec.ts", "**/*.test.tsx", "**/*.spec.tsx"],
+  rules: {
+    "nextfriday/no-helper-function-in-test": "error",
+  },
+}
+```

--- a/src/__tests__/rules.test.ts
+++ b/src/__tests__/rules.test.ts
@@ -72,8 +72,8 @@ describe("ESLint Plugin Rules", () => {
     expect(typeof rules["no-env-fallback"].create).toBe("function");
   });
 
-  it("should have exactly 63 rules", () => {
-    expect(Object.keys(rules)).toHaveLength(63);
+  it("should have exactly 67 rules", () => {
+    expect(Object.keys(rules)).toHaveLength(67);
   });
 
   it("should have correct rule names", () => {
@@ -99,11 +99,13 @@ describe("ESLint Plugin Rules", () => {
     expect(ruleNames).toContain("react-props-destructure");
     expect(ruleNames).toContain("enforce-camel-case");
     expect(ruleNames).toContain("enforce-constant-case");
+    expect(ruleNames).toContain("enforce-hook-filename");
     expect(ruleNames).toContain("enforce-hook-naming");
     expect(ruleNames).toContain("enforce-property-case");
     expect(ruleNames).toContain("enforce-props-suffix");
     expect(ruleNames).toContain("enforce-readonly-component-props");
     expect(ruleNames).toContain("enforce-service-naming");
+    expect(ruleNames).toContain("enforce-test-filename");
     expect(ruleNames).toContain("enforce-sorted-destructuring");
     expect(ruleNames).toContain("no-complex-inline-return");
     expect(ruleNames).toContain("no-logic-in-params");
@@ -136,6 +138,8 @@ describe("ESLint Plugin Rules", () => {
     expect(ruleNames).toContain("index-export-only");
     expect(ruleNames).toContain("no-inline-type-import");
     expect(ruleNames).toContain("no-ghost-wrapper");
+    expect(ruleNames).toContain("no-helper-function-in-hook");
+    expect(ruleNames).toContain("no-helper-function-in-test");
     expect(ruleNames).toContain("no-redundant-fragment");
     expect(ruleNames).toContain("jsx-no-data-array");
     expect(ruleNames).toContain("jsx-no-data-object");

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,12 +3,14 @@ import packageJson from "../package.json" with { type: "json" };
 import booleanNamingPrefix from "./rules/boolean-naming-prefix";
 import enforceCamelCase from "./rules/enforce-camel-case";
 import enforceConstantCase from "./rules/enforce-constant-case";
+import enforceHookFilename from "./rules/enforce-hook-filename";
 import enforceHookNaming from "./rules/enforce-hook-naming";
 import enforcePropertyCase from "./rules/enforce-property-case";
 import enforcePropsSuffix from "./rules/enforce-props-suffix";
 import enforceReadonlyComponentProps from "./rules/enforce-readonly-component-props";
 import enforceRenderNaming from "./rules/enforce-render-naming";
 import enforceServiceNaming from "./rules/enforce-service-naming";
+import enforceTestFilename from "./rules/enforce-test-filename";
 import enforceSortedDestructuring from "./rules/enforce-sorted-destructuring";
 import enforceTypeDeclarationOrder from "./rules/enforce-type-declaration-order";
 import indexExportOnly from "./rules/index-export-only";
@@ -32,6 +34,8 @@ import noDirectDate from "./rules/no-direct-date";
 import noEmoji from "./rules/no-emoji";
 import noEnvFallback from "./rules/no-env-fallback";
 import noGhostWrapper from "./rules/no-ghost-wrapper";
+import noHelperFunctionInHook from "./rules/no-helper-function-in-hook";
+import noHelperFunctionInTest from "./rules/no-helper-function-in-test";
 import noInlineDefaultExport from "./rules/no-inline-default-export";
 import noInlineNestedObject from "./rules/no-inline-nested-object";
 import noInlineReturnProperties from "./rules/no-inline-return-properties";
@@ -75,12 +79,14 @@ const rules = {
   "boolean-naming-prefix": booleanNamingPrefix,
   "enforce-camel-case": enforceCamelCase,
   "enforce-constant-case": enforceConstantCase,
+  "enforce-hook-filename": enforceHookFilename,
   "enforce-hook-naming": enforceHookNaming,
   "enforce-property-case": enforcePropertyCase,
   "enforce-props-suffix": enforcePropsSuffix,
   "enforce-readonly-component-props": enforceReadonlyComponentProps,
   "enforce-render-naming": enforceRenderNaming,
   "enforce-service-naming": enforceServiceNaming,
+  "enforce-test-filename": enforceTestFilename,
   "enforce-sorted-destructuring": enforceSortedDestructuring,
   "enforce-type-declaration-order": enforceTypeDeclarationOrder,
   "index-export-only": indexExportOnly,
@@ -104,6 +110,8 @@ const rules = {
   "no-emoji": noEmoji,
   "no-env-fallback": noEnvFallback,
   "no-ghost-wrapper": noGhostWrapper,
+  "no-helper-function-in-hook": noHelperFunctionInHook,
+  "no-helper-function-in-test": noHelperFunctionInTest,
   "no-inline-default-export": noInlineDefaultExport,
   "no-inline-nested-object": noInlineNestedObject,
   "no-inline-return-properties": noInlineReturnProperties,
@@ -146,9 +154,11 @@ const baseRules = {
   "nextfriday/boolean-naming-prefix": "warn",
   "nextfriday/enforce-camel-case": "warn",
   "nextfriday/enforce-constant-case": "warn",
+  "nextfriday/enforce-hook-filename": "warn",
   "nextfriday/enforce-hook-naming": "warn",
   "nextfriday/enforce-property-case": "warn",
   "nextfriday/enforce-service-naming": "warn",
+  "nextfriday/enforce-test-filename": "warn",
   "nextfriday/enforce-sorted-destructuring": "warn",
   "nextfriday/enforce-type-declaration-order": "warn",
   "nextfriday/index-export-only": "warn",
@@ -189,9 +199,11 @@ const baseRecommendedRules = {
   "nextfriday/boolean-naming-prefix": "error",
   "nextfriday/enforce-camel-case": "error",
   "nextfriday/enforce-constant-case": "error",
+  "nextfriday/enforce-hook-filename": "error",
   "nextfriday/enforce-hook-naming": "error",
   "nextfriday/enforce-property-case": "error",
   "nextfriday/enforce-service-naming": "error",
+  "nextfriday/enforce-test-filename": "error",
   "nextfriday/enforce-sorted-destructuring": "error",
   "nextfriday/enforce-type-declaration-order": "error",
   "nextfriday/index-export-only": "error",

--- a/src/rules/__tests__/enforce-hook-filename.test.ts
+++ b/src/rules/__tests__/enforce-hook-filename.test.ts
@@ -1,0 +1,91 @@
+import { afterAll, describe, it } from "@jest/globals";
+import { RuleTester } from "@typescript-eslint/rule-tester";
+
+import rule from "../enforce-hook-filename";
+
+RuleTester.afterAll = afterAll;
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("enforce-hook-filename", rule, {
+  valid: [
+    {
+      name: "should allow hook export from .hook.ts file",
+      filename: "/src/features/user/use-user-data.hook.ts",
+      code: `export function useUserData() { return null; }`,
+    },
+    {
+      name: "should allow hook export from .hooks.ts file",
+      filename: "/src/features/user/user.hooks.ts",
+      code: `export const useUserData = () => null;`,
+    },
+    {
+      name: "should allow non-hook export from any file",
+      filename: "/src/features/user/user.service.ts",
+      code: `export function fetchUserData() { return null; }`,
+    },
+    {
+      name: "should allow non-hook export from .ts file",
+      filename: "/src/utils/format.ts",
+      code: `export const formatDate = (d: Date) => d.toISOString();`,
+    },
+    {
+      name: "should ignore re-exports of hooks",
+      filename: "/src/features/user/index.ts",
+      code: `export { useUserData } from "./use-user-data.hook";`,
+    },
+    {
+      name: "should not flag use without capital letter (e.g. user)",
+      filename: "/src/features/user/user.service.ts",
+      code: `export function user() { return null; }`,
+    },
+    {
+      name: "should not flag 'use' alone as a hook",
+      filename: "/src/utils/utils.ts",
+      code: `export function use() { return null; }`,
+    },
+  ],
+  invalid: [
+    {
+      name: "should disallow hook function declaration exported from plain .ts file",
+      filename: "/src/features/user/use-user-data.ts",
+      code: `export function useUserData() { return null; }`,
+      errors: [{ messageId: "requireHookFilename", data: { name: "useUserData" } }],
+    },
+    {
+      name: "should disallow hook arrow function exported from plain .ts file",
+      filename: "/src/features/user/use-user-data.ts",
+      code: `export const useUserData = () => null;`,
+      errors: [{ messageId: "requireHookFilename", data: { name: "useUserData" } }],
+    },
+    {
+      name: "should disallow hook function expression exported from plain .ts file",
+      filename: "/src/features/user/use-user-data.ts",
+      code: `export const useUserData = function() { return null; };`,
+      errors: [{ messageId: "requireHookFilename", data: { name: "useUserData" } }],
+    },
+    {
+      name: "should disallow hook exported from .tsx file",
+      filename: "/src/features/user/UserCard.tsx",
+      code: `export function useUserCard() { return null; }`,
+      errors: [{ messageId: "requireHookFilename", data: { name: "useUserCard" } }],
+    },
+    {
+      name: "should disallow default exported hook from plain .ts file",
+      filename: "/src/features/user/use-user-data.ts",
+      code: `export default function useUserData() { return null; }`,
+      errors: [{ messageId: "requireHookFilename", data: { name: "useUserData" } }],
+    },
+    {
+      name: "should flag multiple hook exports in one file",
+      filename: "/src/features/user/user.utils.ts",
+      code: `export function useA() {} export function useB() {}`,
+      errors: [
+        { messageId: "requireHookFilename", data: { name: "useA" } },
+        { messageId: "requireHookFilename", data: { name: "useB" } },
+      ],
+    },
+  ],
+});

--- a/src/rules/__tests__/enforce-test-filename.test.ts
+++ b/src/rules/__tests__/enforce-test-filename.test.ts
@@ -1,0 +1,77 @@
+import { afterAll, describe, it } from "@jest/globals";
+import { RuleTester } from "@typescript-eslint/rule-tester";
+
+import rule from "../enforce-test-filename";
+
+RuleTester.afterAll = afterAll;
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("enforce-test-filename", rule, {
+  valid: [
+    {
+      name: "should allow describe in .test.ts file",
+      filename: "/src/features/user/user.test.ts",
+      code: `describe("user", () => {});`,
+    },
+    {
+      name: "should allow it in .test.ts file",
+      filename: "/src/features/user/user.test.ts",
+      code: `it("works", () => {});`,
+    },
+    {
+      name: "should allow test in .test.tsx file",
+      filename: "/src/features/user/UserCard.test.tsx",
+      code: `test("renders", () => {});`,
+    },
+    {
+      name: "should allow beforeEach in .test.ts file",
+      filename: "/src/utils/format.test.ts",
+      code: `beforeEach(() => {});`,
+    },
+    {
+      name: "should allow non-test code in any file",
+      filename: "/src/utils/format.ts",
+      code: `export function formatDate(d: Date) { return d.toISOString(); }`,
+    },
+    {
+      name: "should allow non-test function calls in plain .ts file",
+      filename: "/src/utils/format.ts",
+      code: `console.log("hello");`,
+    },
+  ],
+  invalid: [
+    {
+      name: "should disallow describe in .spec.ts file",
+      filename: "/src/features/user/user.spec.ts",
+      code: `describe("user", () => {});`,
+      errors: [{ messageId: "requireTestFilename" }],
+    },
+    {
+      name: "should disallow it in plain .ts file",
+      filename: "/src/features/user/user-tests.ts",
+      code: `it("works", () => {});`,
+      errors: [{ messageId: "requireTestFilename" }],
+    },
+    {
+      name: "should disallow test in plain .ts file",
+      filename: "/src/features/user/user.ts",
+      code: `test("works", () => {});`,
+      errors: [{ messageId: "requireTestFilename" }],
+    },
+    {
+      name: "should disallow beforeAll in non-test file",
+      filename: "/src/setup.ts",
+      code: `beforeAll(() => {});`,
+      errors: [{ messageId: "requireTestFilename" }],
+    },
+    {
+      name: "should report only once even with multiple test calls",
+      filename: "/src/features/user/user.spec.ts",
+      code: `describe("a", () => {}); describe("b", () => {});`,
+      errors: [{ messageId: "requireTestFilename" }],
+    },
+  ],
+});

--- a/src/rules/__tests__/no-helper-function-in-hook.test.ts
+++ b/src/rules/__tests__/no-helper-function-in-hook.test.ts
@@ -1,0 +1,83 @@
+import { afterAll, describe, it } from "@jest/globals";
+import { RuleTester } from "@typescript-eslint/rule-tester";
+
+import rule from "../no-helper-function-in-hook";
+
+RuleTester.afterAll = afterAll;
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("no-helper-function-in-hook", rule, {
+  valid: [
+    {
+      code: `export function useMyHook() { return null; }`,
+      name: "should allow exported hook function declaration",
+    },
+    {
+      code: `export const useMyHook = () => null;`,
+      name: "should allow exported hook arrow function",
+    },
+    {
+      code: `export const useMyHook = function() { return null; };`,
+      name: "should allow exported hook function expression",
+    },
+    {
+      code: `function useMyHook() { return null; }`,
+      name: "should allow non-exported hook function declaration",
+    },
+    {
+      code: `const useMyHook = () => null;`,
+      name: "should allow non-exported hook arrow function",
+    },
+    {
+      code: `import { useState } from "react";`,
+      name: "should allow import statements",
+    },
+    {
+      code: `const CACHE_KEY = "my-key";`,
+      name: "should allow top-level non-function constants",
+    },
+    {
+      code: `export function useData() { function formatResponse(r) { return r; } return formatResponse; }`,
+      name: "should allow helper functions defined inside a hook body",
+    },
+    {
+      code: `export const useData = () => { const format = (r) => r; return format; };`,
+      name: "should allow arrow helpers defined inside a hook body",
+    },
+  ],
+  invalid: [
+    {
+      code: `function formatData(data) { return data; }`,
+      name: "should disallow top-level non-hook function declaration",
+      errors: [{ messageId: "noHelperFunction" }],
+    },
+    {
+      code: `const formatData = (data) => data;`,
+      name: "should disallow top-level non-hook arrow function",
+      errors: [{ messageId: "noHelperFunction" }],
+    },
+    {
+      code: `const formatData = function(data) { return data; };`,
+      name: "should disallow top-level non-hook function expression",
+      errors: [{ messageId: "noHelperFunction" }],
+    },
+    {
+      code: `export function formatData(data) { return data; }`,
+      name: "should disallow exported non-hook function declaration",
+      errors: [{ messageId: "noHelperFunction" }],
+    },
+    {
+      code: `export const formatData = (data) => data;`,
+      name: "should disallow exported non-hook arrow function",
+      errors: [{ messageId: "noHelperFunction" }],
+    },
+    {
+      code: `function helper() {} export function useMyHook() { return null; }`,
+      name: "should flag only the non-hook function alongside a valid hook",
+      errors: [{ messageId: "noHelperFunction" }],
+    },
+  ],
+});

--- a/src/rules/__tests__/no-helper-function-in-test.test.ts
+++ b/src/rules/__tests__/no-helper-function-in-test.test.ts
@@ -1,0 +1,70 @@
+import { afterAll, describe, it } from "@jest/globals";
+import { RuleTester } from "@typescript-eslint/rule-tester";
+
+import rule from "../no-helper-function-in-test";
+
+RuleTester.afterAll = afterAll;
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("no-helper-function-in-test", rule, {
+  valid: [
+    {
+      code: `import { describe, it, expect } from "@jest/globals";`,
+      name: "should allow import statements",
+    },
+    {
+      code: `const PATTERN = /^src\\/features\\//;`,
+      name: "should allow top-level non-function constants",
+    },
+    {
+      code: `const ALLOWED = ["foo", "bar"];`,
+      name: "should allow top-level array constants",
+    },
+    {
+      code: `describe("suite", () => { function helper() { return 1; } });`,
+      name: "should allow function declarations inside describe blocks",
+    },
+    {
+      code: `it("test", () => { const helper = () => true; });`,
+      name: "should allow arrow functions inside it blocks",
+    },
+    {
+      code: `RuleTester.afterAll = afterAll;`,
+      name: "should allow assignment expressions",
+    },
+    {
+      code: `const ruleTester = new RuleTester();`,
+      name: "should allow top-level class instantiation",
+    },
+  ],
+  invalid: [
+    {
+      code: `function findFiles(dir) { return []; }`,
+      name: "should disallow top-level function declaration",
+      errors: [{ messageId: "noHelperFunction" }],
+    },
+    {
+      code: `const extractImports = (source) => [];`,
+      name: "should disallow top-level arrow function",
+      errors: [{ messageId: "noHelperFunction" }],
+    },
+    {
+      code: `const buildPattern = function(name) { return new RegExp(name); };`,
+      name: "should disallow top-level function expression",
+      errors: [{ messageId: "noHelperFunction" }],
+    },
+    {
+      code: `function a() {} function b() {}`,
+      name: "should disallow multiple top-level function declarations",
+      errors: [{ messageId: "noHelperFunction" }, { messageId: "noHelperFunction" }],
+    },
+    {
+      code: `const a = () => {}; const b = () => {};`,
+      name: "should disallow multiple top-level arrow functions",
+      errors: [{ messageId: "noHelperFunction" }, { messageId: "noHelperFunction" }],
+    },
+  ],
+});

--- a/src/rules/enforce-hook-filename.ts
+++ b/src/rules/enforce-hook-filename.ts
@@ -1,0 +1,65 @@
+import path from "path";
+
+import { AST_NODE_TYPES, ESLintUtils } from "@typescript-eslint/utils";
+
+import type { TSESTree } from "@typescript-eslint/utils";
+
+const createRule = ESLintUtils.RuleCreator(
+  (name) =>
+    `https://github.com/next-friday/eslint-plugin-nextfriday/blob/main/docs/rules/${name.replaceAll("-", "_").toUpperCase()}.md`,
+);
+
+const enforceHookFilename = createRule({
+  name: "enforce-hook-filename",
+  meta: {
+    type: "suggestion",
+    docs: {
+      description: "Enforce that files exporting custom hooks are named *.hook.ts or *.hooks.ts",
+    },
+    messages: {
+      requireHookFilename: "'{{ name }}' is a custom hook and must be exported from a *.hook.ts or *.hooks.ts file.",
+    },
+    schema: [],
+  },
+  defaultOptions: [],
+  create(context) {
+    const basename = path.basename(context.filename);
+    const isHookFile = basename.endsWith(".hook.ts") || basename.endsWith(".hooks.ts");
+
+    if (isHookFile) return {};
+
+    function reportIfHook(name: string, node: TSESTree.Node): void {
+      if (name.startsWith("use") && name.length > 3 && /^use[A-Z]/.test(name)) {
+        context.report({ node, messageId: "requireHookFilename", data: { name } });
+      }
+    }
+
+    return {
+      ExportNamedDeclaration(node) {
+        if (node.declaration?.type === AST_NODE_TYPES.FunctionDeclaration && node.declaration.id) {
+          reportIfHook(node.declaration.id.name, node.declaration.id);
+        }
+
+        if (node.declaration?.type === AST_NODE_TYPES.VariableDeclaration) {
+          for (const declarator of node.declaration.declarations) {
+            if (
+              declarator.id.type === AST_NODE_TYPES.Identifier &&
+              declarator.init !== null &&
+              (declarator.init.type === AST_NODE_TYPES.ArrowFunctionExpression ||
+                declarator.init.type === AST_NODE_TYPES.FunctionExpression)
+            ) {
+              reportIfHook(declarator.id.name, declarator.id);
+            }
+          }
+        }
+      },
+      ExportDefaultDeclaration(node) {
+        if (node.declaration.type === AST_NODE_TYPES.FunctionDeclaration && node.declaration.id !== null) {
+          reportIfHook(node.declaration.id.name, node.declaration.id);
+        }
+      },
+    };
+  },
+});
+
+export default enforceHookFilename;

--- a/src/rules/enforce-test-filename.ts
+++ b/src/rules/enforce-test-filename.ts
@@ -1,0 +1,51 @@
+import path from "path";
+
+import { AST_NODE_TYPES, ESLintUtils } from "@typescript-eslint/utils";
+
+import type { TSESTree } from "@typescript-eslint/utils";
+
+const createRule = ESLintUtils.RuleCreator(
+  (name) =>
+    `https://github.com/next-friday/eslint-plugin-nextfriday/blob/main/docs/rules/${name.replaceAll("-", "_").toUpperCase()}.md`,
+);
+
+const TEST_GLOBALS = new Set(["describe", "it", "test", "beforeEach", "beforeAll", "afterEach", "afterAll"]);
+
+const enforceTestFilename = createRule({
+  name: "enforce-test-filename",
+  meta: {
+    type: "suggestion",
+    docs: {
+      description: "Enforce that files containing test code are named *.test.ts or *.test.tsx",
+    },
+    messages: {
+      requireTestFilename: "Files containing test code must be named *.test.ts or *.test.tsx.",
+    },
+    schema: [],
+  },
+  defaultOptions: [],
+  create(context) {
+    const basename = path.basename(context.filename);
+    const isTestFile = basename.endsWith(".test.ts") || basename.endsWith(".test.tsx");
+
+    if (isTestFile) return {};
+
+    function isTestGlobalCall(node: TSESTree.CallExpression): boolean {
+      return node.callee.type === AST_NODE_TYPES.Identifier && TEST_GLOBALS.has(node.callee.name);
+    }
+
+    let reported = false;
+
+    return {
+      CallExpression(node) {
+        if (reported) return;
+        if (!isTestGlobalCall(node)) return;
+
+        reported = true;
+        context.report({ node, messageId: "requireTestFilename" });
+      },
+    };
+  },
+});
+
+export default enforceTestFilename;

--- a/src/rules/no-helper-function-in-hook.ts
+++ b/src/rules/no-helper-function-in-hook.ts
@@ -1,0 +1,60 @@
+import { AST_NODE_TYPES, ESLintUtils } from "@typescript-eslint/utils";
+
+import type { TSESTree } from "@typescript-eslint/utils";
+
+const createRule = ESLintUtils.RuleCreator(
+  (name) =>
+    `https://github.com/next-friday/eslint-plugin-nextfriday/blob/main/docs/rules/${name.replaceAll("-", "_").toUpperCase()}.md`,
+);
+
+const noHelperFunctionInHook = createRule({
+  name: "no-helper-function-in-hook",
+  meta: {
+    type: "suggestion",
+    docs: {
+      description: "Disallow non-hook helper function definitions in hook files",
+    },
+    messages: {
+      noHelperFunction: "Helper functions must not be defined in hook files. Extract to a separate utility file.",
+    },
+    schema: [],
+  },
+  defaultOptions: [],
+  create(context) {
+    function isAtProgramLevel(node: TSESTree.Node): boolean {
+      const { parent } = node;
+
+      if (parent === undefined) return false;
+      if (parent.type === AST_NODE_TYPES.Program) return true;
+      if (parent.type !== AST_NODE_TYPES.ExportNamedDeclaration) return false;
+
+      return parent.parent?.type === AST_NODE_TYPES.Program;
+    }
+
+    return {
+      FunctionDeclaration(node: TSESTree.FunctionDeclaration) {
+        if (!isAtProgramLevel(node)) return;
+        if (node.id !== null && node.id.name.startsWith("use")) return;
+
+        context.report({ node, messageId: "noHelperFunction" });
+      },
+      VariableDeclarator(node: TSESTree.VariableDeclarator) {
+        if (node.parent.type !== AST_NODE_TYPES.VariableDeclaration) return;
+        if (!isAtProgramLevel(node.parent)) return;
+
+        if (
+          node.init === null ||
+          (node.init.type !== AST_NODE_TYPES.ArrowFunctionExpression &&
+            node.init.type !== AST_NODE_TYPES.FunctionExpression)
+        )
+          return;
+
+        if (node.id.type === AST_NODE_TYPES.Identifier && node.id.name.startsWith("use")) return;
+
+        context.report({ node, messageId: "noHelperFunction" });
+      },
+    };
+  },
+});
+
+export default noHelperFunctionInHook;

--- a/src/rules/no-helper-function-in-test.ts
+++ b/src/rules/no-helper-function-in-test.ts
@@ -1,0 +1,45 @@
+import { AST_NODE_TYPES, ESLintUtils } from "@typescript-eslint/utils";
+
+import type { TSESTree } from "@typescript-eslint/utils";
+
+const createRule = ESLintUtils.RuleCreator(
+  (name) =>
+    `https://github.com/next-friday/eslint-plugin-nextfriday/blob/main/docs/rules/${name.replaceAll("-", "_").toUpperCase()}.md`,
+);
+
+const noHelperFunctionInTest = createRule({
+  name: "no-helper-function-in-test",
+  meta: {
+    type: "suggestion",
+    docs: {
+      description: "Disallow helper function definitions in test files",
+    },
+    messages: {
+      noHelperFunction: "Helper functions must not be defined in test files. Extract to a separate utility file.",
+    },
+    schema: [],
+  },
+  defaultOptions: [],
+  create(context) {
+    return {
+      FunctionDeclaration(node: TSESTree.FunctionDeclaration) {
+        if (node.parent.type === AST_NODE_TYPES.Program) {
+          context.report({ node, messageId: "noHelperFunction" });
+        }
+      },
+      VariableDeclarator(node: TSESTree.VariableDeclarator) {
+        if (
+          node.parent.type === AST_NODE_TYPES.VariableDeclaration &&
+          node.parent.parent.type === AST_NODE_TYPES.Program &&
+          node.init !== null &&
+          (node.init.type === AST_NODE_TYPES.ArrowFunctionExpression ||
+            node.init.type === AST_NODE_TYPES.FunctionExpression)
+        ) {
+          context.report({ node, messageId: "noHelperFunction" });
+        }
+      },
+    };
+  },
+});
+
+export default noHelperFunctionInTest;


### PR DESCRIPTION
## Summary

- Add `enforce-hook-filename` — flags files that export `use*` hooks but are not named `*.hook.ts`
- Add `enforce-test-filename` — flags files with test globals (`describe`, `it`, `test`) but not named `*.test.ts`
- Add `no-helper-function-in-hook` — flags non-hook helper functions at the top level of hook files (opt-in via `files` glob)
- Add `no-helper-function-in-test` — flags helper function definitions at the top level of test files (opt-in via `files` glob)

## Test plan

- [ ] `pnpm test` passes (67 rules, all presets correct)
- [ ] `enforce-hook-filename` catches `use-custom-hook.ts` exporting `useCustomHook`
- [ ] `enforce-test-filename` catches `user.spec.ts` with `describe()` calls
- [ ] `no-helper-function-in-hook` catches helpers when scoped with `files: ["**/*.hook.ts"]`
- [ ] `no-helper-function-in-test` catches helpers when scoped with `files: ["**/*.test.ts"]`