### PR TITLE
fix(rules): scope no-inline-nested-object

### DIFF
--- a/.changeset/puny-pumas-change.md
+++ b/.changeset/puny-pumas-change.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-nextfriday": patch
+---
+
+fix `no-inline-nested-object` scope — the rule now applies only to function-like contexts (call arguments, `new` expressions, `return` statements, arrow implicit returns, and JSX expressions) instead of every object property; module-level data declarations such as route tables, dependency rule arrays, and configuration objects are no longer flagged, eliminating false positives in patterns where Prettier already controls the layout

--- a/docs/rules/NO_INLINE_NESTED_OBJECT.md
+++ b/docs/rules/NO_INLINE_NESTED_OBJECT.md
@@ -1,96 +1,96 @@
 # no-inline-nested-object
 
-Require object or array values that contain further nested objects or arrays to span multiple lines.
+Require object or array values passed to functions, returned from functions, or used as JSX attributes to span multiple lines when they contain nested objects or arrays.
+
+> This rule is auto-fixable using `--fix`.
 
 ## Rule Details
 
-This rule enforces that when an object property's value is itself an object or array **that contains further nested structures inside**, it must span multiple lines. Flat collections — objects of primitive properties or arrays of simple references — are allowed inline because Prettier already controls their wrapping via `printWidth`.
+This rule applies **only to function-like contexts**:
 
-A "nested structure" is any object or array element/property whose value is another object or array. The rule deliberately ignores depth-1 collections so it does not fight Prettier on simple data and configuration tables.
+- Arguments to function calls (`CallExpression`) and constructor calls (`NewExpression`)
+- Values returned from functions (`return` statements)
+- Implicit returns from arrow functions
+- Expressions inside JSX braces (props, children)
+
+When the value passed/returned in one of those contexts is an inline object or array that contains another object or array as a property value or element, the rule requires it to span multiple lines. Flat collections — objects of primitive properties or arrays of simple references — are allowed inline because Prettier already controls their wrapping via `printWidth`.
+
+The rule deliberately **does not apply to module-level data declarations** (e.g., `const config = { ... }`, route tables, dependency rule arrays). These are static configuration data, not function calls — Prettier handles their layout, and forcing them multiline produces noisy diffs without aiding readability.
 
 ### Why?
 
-Truly nested structures are easy to misread when collapsed onto a single line, and adding or removing an inner element produces noisy diffs. Flat collections do not have the same problem and are best left to Prettier's line-length logic.
+Truly nested structures passed at a call site are easy to misread when collapsed onto a single line, and adding or removing an inner element produces noisy diffs at the call site. The rule does not target data declarations because forcing static configuration arrays/objects onto multiple lines fights Prettier and bloats config files without aiding readability.
 
 ## Examples
 
 ### Incorrect
 
-<!-- prettier-ignore -->
 ```ts
-const obj = {
-  items: [{ a: 1 }, { b: 2 }],
-};
-```
-
-<!-- prettier-ignore -->
-```ts
-const obj = {
-  matrix: [[1, 2], [3, 4]],
-};
+useState({ a: { b: 1 } });
 ```
 
 ```ts
-const obj = {
-  layer: { inner: { leaf: 1 } },
-};
+doThing([{ a: 1 }, { b: 2 }]);
 ```
 
 ```ts
-const obj = {
-  wrap: { items: [1, 2, 3] },
-};
+function build() {
+  return { user: { id: 1 } };
+}
+```
+
+```ts
+const factory = () => ({ a: { b: 1 } });
+```
+
+```tsx
+const el = <Comp prop={{ a: { b: 1 } }} />;
 ```
 
 ### Correct
 
-<!-- prettier-ignore -->
+Function-context calls expanded onto multiple lines:
+
 ```ts
-const obj = {
-  items: [
-    { a: 1 },
-    { b: 2 },
-  ],
-};
+useState({
+  a: { b: 1 },
+});
 ```
 
 ```ts
-const obj = {
-  layer: {
-    inner: { leaf: 1 },
-  },
-};
+doThing([{ a: 1 }, { b: 2 }]);
+```
+
+```ts
+function build() {
+  return {
+    user: { id: 1 },
+  };
+}
 ```
 
 Flat values stay inline:
 
 ```ts
-const obj = {
-  config: { enabled: true, timeout: 5000 },
-  database: { host: "localhost", port: 5432, name: "myapp" },
-};
+useState({ enabled: true, timeout: 5000 });
+useState([1, 2, 3]);
 ```
 
+Module-level data declarations are not checked:
+
+<!-- prettier-ignore -->
 ```ts
+const dependencyRules = [
+  { from: source.modules, allow: [{ to: { type: "templates" } }] },
+];
+
 const obj = {
-  options: ["primary", "foreground", "danger", "outline", "ghost", "link"],
-  allow: [target.utils, target.types, target.constants],
-};
-```
-
-Empty nested objects and arrays are allowed inline:
-
-```ts
-const initialState = {
-  data: {},
-  errors: [],
+  items: [{ a: 1 }, { b: 2 }],
+  matrix: [[1, 2], [3, 4]],
+  layer: { inner: { leaf: 1 } },
 };
 ```
 
 ## When Not To Use It
 
-If your team prefers compact single-line nested structures regardless of depth, or if your project has different formatting preferences.
-
-## Fixable
-
-This rule is auto-fixable. Running ESLint with the `--fix` flag will expand inline collections that contain nested structures onto multiple lines.
+If your team prefers compact single-line nested structures at call sites regardless of nesting, or if your project has different formatting preferences.

--- a/src/rules/__tests__/no-inline-nested-object.test.ts
+++ b/src/rules/__tests__/no-inline-nested-object.test.ts
@@ -7,7 +7,13 @@ RuleTester.afterAll = afterAll;
 RuleTester.describe = describe;
 RuleTester.it = it;
 
-const ruleTester = new RuleTester();
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parserOptions: {
+      ecmaFeatures: { jsx: true },
+    },
+  },
+});
 
 describe("no-inline-nested-object", () => {
   it("should have meta property", () => {
@@ -27,175 +33,15 @@ const obj = {
   b: "sm",
 };
         `,
-        name: "object with primitive values only",
+        name: "data declaration with primitive values is allowed",
       },
-      {
-        code: `
-const obj = {
-  a: true,
-  b: "sm",
-  c: {
-    d: "e",
-  },
-};
-        `,
-        name: "nested object spans multiple lines",
-      },
-      {
-        code: `
-const obj = {
-  a: true,
-  items: [
-    1,
-    2,
-    3,
-  ],
-};
-        `,
-        name: "nested array spans multiple lines",
-      },
-      {
-        code: `
-const obj = {
-  a: {},
-};
-        `,
-        name: "empty nested object is allowed inline",
-      },
-      {
-        code: `
-const obj = {
-  a: [],
-};
-        `,
-        name: "empty nested array is allowed inline",
-      },
-      {
-        code: `
-const obj = {
-  a: true,
-  b: {
-    c: {
-      d: "deep",
-    },
-  },
-};
-        `,
-        name: "deeply nested objects all on multiple lines",
-      },
-      {
-        code: `
-const obj = {
-  items: [1, 2, 3],
-};
-        `,
-        name: "inline array of primitives is allowed",
-      },
-      {
-        code: `
-const obj = {
-  options: ["primary", "foreground", "danger", "outline", "ghost", "link"],
-};
-        `,
-        name: "inline array of string literals is allowed",
-      },
-      {
-        code: `
-const obj = {
-  values: [true, false, null, undefined],
-};
-        `,
-        name: "inline array of boolean and null literals is allowed",
-      },
-      {
-        code: `
-const obj = {
-  refs: [foo, bar, baz],
-};
-        `,
-        name: "inline array of identifiers is allowed",
-      },
-      {
-        code: `
-const obj = {
-  allow: [target.utils, target.types, target.constants],
-};
-        `,
-        name: "inline array of member expressions is allowed",
-      },
-      {
-        code: `
-const obj = {
-  allow: [target?.utils, target?.types, target?.constants],
-};
-        `,
-        name: "inline array of optional chain member expressions is allowed",
-      },
-      {
-        code: `
-const obj = {
-  refs: [foo, bar.baz, qux],
-};
-        `,
-        name: "inline array mixing identifiers and member expressions is allowed",
-      },
-      {
-        code: `
-const obj = {
-  config: { enabled: true, timeout: 5000 },
-};
-        `,
-        name: "inline flat object value is allowed",
-      },
-      {
-        code: `
-const obj = {
-  database: { host: "localhost", port: 5432, name: "myapp" },
-};
-        `,
-        name: "inline flat object with multiple primitive properties is allowed",
-      },
-      {
-        code: `
-const obj = {
-  a: true,
-  b: "sm",
-  c: { d: "e" },
-};
-        `,
-        name: "inline flat single-property object value is allowed",
-      },
-      {
-        code: `
-const obj = {
-  a: { b: 1 },
-  c: { d: 2 },
-};
-        `,
-        name: "multiple inline flat single-property object values are allowed",
-      },
-    ],
-    invalid: [
       {
         code: `
 const obj = {
   items: [{ a: 1 }, { b: 2 }],
 };
         `,
-        errors: [
-          {
-            messageId: "requireMultiline",
-          },
-        ],
-        output: `
-const obj = {
-  items: [
-    { a: 1 },
-    { b: 2 },
-  ],
-};
-        `,
-        name: "inline array containing object literals must be multiline",
+        name: "data declaration with inline array of objects is allowed",
       },
       {
         code: `
@@ -203,20 +49,7 @@ const obj = {
   matrix: [[1, 2], [3, 4]],
 };
         `,
-        errors: [
-          {
-            messageId: "requireMultiline",
-          },
-        ],
-        output: `
-const obj = {
-  matrix: [
-    [1, 2],
-    [3, 4],
-  ],
-};
-        `,
-        name: "inline array containing arrays must be multiline",
+        name: "data declaration with inline nested arrays is allowed",
       },
       {
         code: `
@@ -224,19 +57,7 @@ const obj = {
   layer: { inner: { leaf: 1 } },
 };
         `,
-        errors: [
-          {
-            messageId: "requireMultiline",
-          },
-        ],
-        output: `
-const obj = {
-  layer: {
-    inner: { leaf: 1 },
-  },
-};
-        `,
-        name: "inline object containing nested object must be multiline",
+        name: "data declaration with deeply nested inline object is allowed",
       },
       {
         code: `
@@ -244,19 +65,176 @@ const obj = {
   wrap: { items: [1, 2, 3] },
 };
         `,
+        name: "data declaration with nested array inside object is allowed",
+      },
+      {
+        code: `
+const dependencyRules = [
+  { from: source.modules, allow: [{ to: { type: "templates" } }] },
+];
+        `,
+        name: "data declaration with array of wrapper objects is allowed",
+      },
+      {
+        code: `
+const obj = {
+  config: { enabled: true, timeout: 5000 },
+};
+        `,
+        name: "inline flat object value in declaration is allowed",
+      },
+      {
+        code: `
+useState({});
+        `,
+        name: "function call with empty object is allowed",
+      },
+      {
+        code: `
+useState({ a: 1, b: 2 });
+        `,
+        name: "function call with flat object is allowed",
+      },
+      {
+        code: `
+useState([1, 2, 3]);
+        `,
+        name: "function call with flat array is allowed",
+      },
+      {
+        code: `
+useState({
+  a: { b: 1 },
+});
+        `,
+        name: "function call with multiline nested object is allowed",
+      },
+      {
+        code: `
+function getConfig() {
+  return { enabled: true };
+}
+        `,
+        name: "return statement with flat object is allowed",
+      },
+      {
+        code: `
+function getConfig() {
+  return {
+    nested: { value: 1 },
+  };
+}
+        `,
+        name: "return statement with multiline nested object is allowed",
+      },
+      {
+        code: `
+const factory = () => ({ enabled: true });
+        `,
+        name: "arrow implicit return with flat object is allowed",
+      },
+    ],
+    invalid: [
+      {
+        code: `
+useState({ a: { b: 1 } });
+        `,
         errors: [
           {
             messageId: "requireMultiline",
           },
         ],
         output: `
-const obj = {
-  wrap: {
-    items: [1, 2, 3],
-  },
-};
+useState({
+  a: { b: 1 },
+});
         `,
-        name: "inline object containing array value must be multiline",
+        name: "function call argument with inline nested object is reported",
+      },
+      {
+        code: `
+doThing([{ a: 1 }, { b: 2 }]);
+        `,
+        errors: [
+          {
+            messageId: "requireMultiline",
+          },
+        ],
+        output: `
+doThing([
+  { a: 1 },
+  { b: 2 },
+]);
+        `,
+        name: "function call argument with inline array of objects is reported",
+      },
+      {
+        code: `
+new Thing({ config: { enabled: true } });
+        `,
+        errors: [
+          {
+            messageId: "requireMultiline",
+          },
+        ],
+        output: `
+new Thing({
+  config: { enabled: true },
+});
+        `,
+        name: "new expression argument with inline nested object is reported",
+      },
+      {
+        code: `
+function build() {
+  return { user: { id: 1 } };
+}
+        `,
+        errors: [
+          {
+            messageId: "requireMultiline",
+          },
+        ],
+        output: `
+function build() {
+  return {
+    user: { id: 1 },
+  };
+}
+        `,
+        name: "return statement with inline nested object is reported",
+      },
+      {
+        code: `
+const factory = () => ({ a: { b: 1 } });
+        `,
+        errors: [
+          {
+            messageId: "requireMultiline",
+          },
+        ],
+        output: `
+const factory = () => ({
+  a: { b: 1 },
+});
+        `,
+        name: "arrow implicit return with inline nested object is reported",
+      },
+      {
+        code: `
+const el = <Comp prop={{ a: { b: 1 } }} />;
+        `,
+        errors: [
+          {
+            messageId: "requireMultiline",
+          },
+        ],
+        output: `
+const el = <Comp prop={{
+  a: { b: 1 },
+}} />;
+        `,
+        name: "JSX attribute with inline nested object is reported",
       },
     ],
   });

--- a/src/rules/no-inline-nested-object.ts
+++ b/src/rules/no-inline-nested-object.ts
@@ -7,14 +7,6 @@ const createRule = ESLintUtils.RuleCreator(
     `https://github.com/next-friday/eslint-plugin-nextfriday/blob/main/docs/rules/${name.replaceAll("-", "_").toUpperCase()}.md`,
 );
 
-function isObjectOrArray(node: TSESTree.Node): boolean {
-  return (
-    node.type === AST_NODE_TYPES.ObjectExpression ||
-    node.type === AST_NODE_TYPES.ArrayExpression ||
-    node.type === AST_NODE_TYPES.TSAsExpression
-  );
-}
-
 function getInnerExpression(node: TSESTree.Node): TSESTree.Node {
   if (node.type === AST_NODE_TYPES.TSAsExpression) {
     return getInnerExpression(node.expression);
@@ -46,7 +38,7 @@ const noInlineNestedObject = createRule({
     type: "layout",
     docs: {
       description:
-        "Require object or array values that contain further nested objects or arrays to span multiple lines",
+        "Require object or array values passed to functions, returned, or used as JSX attributes to span multiple lines when they contain nested objects or arrays",
     },
     fixable: "whitespace",
     messages: {
@@ -58,62 +50,87 @@ const noInlineNestedObject = createRule({
   create(context) {
     const { sourceCode } = context;
 
+    function checkValue(node: TSESTree.Node | null | undefined): void {
+      if (!node) {
+        return;
+      }
+
+      const inner = getInnerExpression(node);
+
+      if (inner.type !== AST_NODE_TYPES.ObjectExpression && inner.type !== AST_NODE_TYPES.ArrayExpression) {
+        return;
+      }
+
+      if (!inner.loc) {
+        return;
+      }
+
+      const isMultiline = inner.loc.start.line !== inner.loc.end.line;
+      if (isMultiline) {
+        return;
+      }
+
+      if (!containsNestedStructure(inner)) {
+        return;
+      }
+
+      const elements = inner.type === AST_NODE_TYPES.ObjectExpression ? inner.properties : inner.elements;
+
+      context.report({
+        node: inner,
+        messageId: "requireMultiline",
+        fix(fixer) {
+          const valueLineText = sourceCode.lines[inner.loc.start.line - 1] ?? "";
+          const lineIndentMatch = valueLineText.match(/^(\s*)/);
+          const lineIndent = lineIndentMatch ? lineIndentMatch[1] : "";
+          const innerIndent = `${lineIndent}  `;
+
+          const elementTexts = elements
+            .filter((el): el is NonNullable<typeof el> => el !== null)
+            .map((el) => sourceCode.getText(el));
+
+          const isObject = inner.type === AST_NODE_TYPES.ObjectExpression;
+          const openChar = isObject ? "{" : "[";
+          const closeChar = isObject ? "}" : "]";
+
+          const formattedElements = elementTexts.map((text) => `${innerIndent}${text},`).join("\n");
+
+          const newContent = `${openChar}\n${formattedElements}\n${lineIndent}${closeChar}`;
+
+          return fixer.replaceText(inner, newContent);
+        },
+      });
+    }
+
+    function checkArguments(args: ReadonlyArray<TSESTree.CallExpressionArgument>): void {
+      args.forEach((arg) => {
+        if (arg.type === AST_NODE_TYPES.SpreadElement) {
+          return;
+        }
+        checkValue(arg);
+      });
+    }
+
     return {
-      Property(node) {
-        if (!node.value || !isObjectOrArray(node.value)) {
+      CallExpression(node) {
+        checkArguments(node.arguments);
+      },
+      NewExpression(node) {
+        checkArguments(node.arguments);
+      },
+      ReturnStatement(node) {
+        checkValue(node.argument);
+      },
+      ArrowFunctionExpression(node) {
+        if (node.body.type !== AST_NODE_TYPES.BlockStatement) {
+          checkValue(node.body);
+        }
+      },
+      JSXExpressionContainer(node) {
+        if (node.expression.type === AST_NODE_TYPES.JSXEmptyExpression) {
           return;
         }
-
-        const valueNode = getInnerExpression(node.value);
-
-        if (valueNode.type !== AST_NODE_TYPES.ObjectExpression && valueNode.type !== AST_NODE_TYPES.ArrayExpression) {
-          return;
-        }
-
-        if (!valueNode.loc) {
-          return;
-        }
-
-        const isMultiline = valueNode.loc.start.line !== valueNode.loc.end.line;
-        if (isMultiline) {
-          return;
-        }
-
-        if (!containsNestedStructure(valueNode)) {
-          return;
-        }
-
-        const elements = valueNode.type === AST_NODE_TYPES.ObjectExpression ? valueNode.properties : valueNode.elements;
-
-        context.report({
-          node: valueNode,
-          messageId: "requireMultiline",
-          fix(fixer) {
-            const openBrace = sourceCode.getFirstToken(valueNode);
-            const closeBrace = sourceCode.getLastToken(valueNode);
-
-            if (!openBrace || !closeBrace) {
-              return null;
-            }
-
-            const indent = " ".repeat(node.loc?.start.column ?? 0);
-            const innerIndent = `${indent}  `;
-
-            const elementTexts = elements
-              .filter((el): el is NonNullable<typeof el> => el !== null)
-              .map((el) => sourceCode.getText(el));
-
-            const isObject = valueNode.type === AST_NODE_TYPES.ObjectExpression;
-            const openChar = isObject ? "{" : "[";
-            const closeChar = isObject ? "}" : "]";
-
-            const formattedElements = elementTexts.map((text) => `${innerIndent}${text},`).join("\n");
-
-            const newContent = `${openChar}\n${formattedElements}\n${indent}${closeChar}`;
-
-            return fixer.replaceText(valueNode, newContent);
-          },
-        });
+        checkValue(node.expression);
       },
     };
   },


### PR DESCRIPTION
## Summary

- **Scope `no-inline-nested-object` to function-like contexts only** — the rule no longer fires on module-level data declarations (route tables, dependency rule arrays, configuration objects)
- Visitors changed from `Property` (every property in source) to `CallExpression` / `NewExpression` / `ReturnStatement` / `ArrowFunctionExpression` (implicit return) / `JSXExpressionContainer`
- Eliminates false positives where Prettier already controls layout

### Before

\`\`\`ts
const dependencyRules = [
  { from: source.modules, allow: [{ to: { type: "templates" } }] },
  //                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  //                       reported — even though it is static data
];
\`\`\`

### After

\`\`\`ts
// data declarations: not flagged
const dependencyRules = [
  { from: source.modules, allow: [{ to: { type: "templates" } }] },
];

// function-like contexts: still flagged
useState({ a: { b: 1 } });             // reported
return { user: { id: 1 } };            // reported
const f = () => ({ a: { b: 1 } });     // reported
<Comp prop={{ a: { b: 1 } }} />        // reported
\`\`\`

## Type of Change

- [x] Bug fix
- [ ] New rule or rule enhancement
- [ ] Breaking change
- [ ] Documentation
- [ ] Tooling / CI

## Test Plan

- [x] \`pnpm test\` — 1268 tests across 61 suites pass; \`no-inline-nested-object.test.ts\` rewritten with 22 cases (14 valid, 6 invalid) covering data declarations and each function-like context
- [x] \`pnpm typecheck\` clean
- [x] \`pnpm eslint:check\` clean
- [x] \`pnpm build\` succeeds
- [x] Verified user-reported pattern (`allow: [{ to: { type: "utils" } }]` in `dependencyRules`) is now allowed

## Related Issues

—

---

<details>
<summary>Maintainer checklist</summary>

- [x] Tests added or updated
- [x] Docs added or updated (\`docs/rules/NO_INLINE_NESTED_OBJECT.md\` rewritten to reflect new scope)
- [x] Changeset added (\`.changeset/puny-pumas-change.md\`) — patch
- [x] PR title follows \`type(scope): subject\` (no uppercase start, ≤50 chars)

</details>