### PR TITLE
feat(rules): expand enforce-constant-case scope

### DIFF
--- a/.changeset/wicked-drinks-make.md
+++ b/.changeset/wicked-drinks-make.md
@@ -1,0 +1,9 @@
+---
+"eslint-plugin-nextfriday": patch
+---
+
+Expand `enforce-constant-case` to enforce SCREAMING_SNAKE_CASE on RegExp and bigint constants, and refine `new RegExp()` detection to skip dynamic arguments.
+
+- RegExp literals (`/foo/`) and `new RegExp("foo", "g")` (all args must be string literals) are now flagged when named in camelCase at global scope.
+- BigInt literals (`100n`, `-1n`) are now flagged consistently with number literals.
+- `new RegExp(userInput)` and other non-literal RegExp constructors are intentionally ignored — only statically-constructed patterns are treated as magic values.

--- a/docs/rules/ENFORCE_CONSTANT_CASE.md
+++ b/docs/rules/ENFORCE_CONSTANT_CASE.md
@@ -1,23 +1,25 @@
 # enforce-constant-case
 
-Enforce SCREAMING_SNAKE_CASE for global magic-number and magic-text constants.
+Enforce SCREAMING_SNAKE_CASE for global magic-number, magic-text, bigint, and RegExp constants.
 
 ## Rule Details
 
-This rule ensures that global-scope `const` declarations bound to a **magic number** or **magic text** literal use SCREAMING_SNAKE_CASE. The rule scope is intentionally narrow:
+This rule ensures that global-scope `const` declarations bound to a **magic literal** value use SCREAMING_SNAKE_CASE. The rule scope is intentionally narrow:
 
 - A magic text constant is a string literal: `const API_URL = "https://api.example.com"`
 - A magic number constant is a number literal (including a unary `-`/`+` over a numeric literal): `const PAGE_LIMIT = 10`, `const OFFSET = -1`
+- A bigint constant is a bigint literal (including a unary `-`/`+` over a bigint literal): `const BIG_LIMIT = 9007199254740993n`, `const NEGATIVE_BIG = -1n`
+- A RegExp constant is a regex literal, or a `new RegExp(...)` call whose arguments are **all** string literals: `const PHONE_REGEX = /^[0-9]+$/`, `const EMAIL_PATTERN = new RegExp("^.+@.+$", "g")`
 
-Anything else is **not** checked: booleans, RegExp, template literals (static or dynamic), arrays, objects, `as const` assertions, function calls, identifiers, member expressions, JSX. Use whatever name fits the value (`metadata`, `viewport`, `statusMap`, `phoneRegex`, `isEnabled`, etc.) — the rule will not flag it.
+Anything else is **not** checked: booleans, template literals (static or dynamic), arrays, objects, `as const` assertions, function calls, identifiers, member expressions, JSX, and `new RegExp(dynamicValue)` (where the pattern argument is non-literal). Use whatever name fits the value (`metadata`, `viewport`, `statusMap`, `isEnabled`, `dynamicPattern`, etc.) — the rule will not flag it.
 
 Only global scope (top-level of a file) is checked. Local scope constants inside functions are not checked by this rule.
 
 **Config files are exempt.** Files matching `*.config.{ts,mjs,cjs,js}`, `*.rc.*`, `*.setup.*`, `*.spec.*`, `*.test.*`, `.eslintrc*`, `.babelrc*`, and `.prettierrc*` skip this rule entirely. This avoids conflicts with framework conventions that require specific identifier names — e.g. Next.js expects `nextConfig` (not `NEXT_CONFIG`) in `next.config.ts`, Vite expects `config`, Tailwind expects `config`, etc.
 
-### Why magic numbers and magic text only?
+### Why only static literal values?
 
-Reserved framework export names commonly bind to objects (Next.js App Router exports `metadata`, `viewport`, `generateStaticParams`, `dynamic`, `revalidate`, `runtime`, `fetchCache`, `dynamicParams`, `preferredRegion`, `maxDuration`; React Server Components and others have similar patterns). Forcing SCREAMING_SNAKE_CASE on any static-shaped initializer would rename those exports and break framework integration. Restricting the rule to bare number and string literals keeps the convention where it adds value (avoiding magic constants scattered through code) without colliding with framework-owned names.
+Reserved framework export names commonly bind to objects (Next.js App Router exports `metadata`, `viewport`, `generateStaticParams`, `dynamic`, `revalidate`, `runtime`, `fetchCache`, `dynamicParams`, `preferredRegion`, `maxDuration`; React Server Components and others have similar patterns). Forcing SCREAMING_SNAKE_CASE on any static-shaped initializer would rename those exports and break framework integration. Restricting the rule to bare number, string, bigint, and statically-constructed RegExp values keeps the convention where it adds value (avoiding magic constants scattered through code) without colliding with framework-owned names or flagging dynamically-constructed patterns.
 
 ## Examples
 
@@ -29,6 +31,9 @@ const pageLimit = 10;
 const apiBaseUrl = "https://api.example.com";
 const negativeOne = -1;
 const default_theme = "dark";
+const phoneRegex = /^[0-9]{10}$/;
+const emailPattern = new RegExp("^.+@.+$");
+const bigLimit = 9007199254740993n;
 ```
 
 ### Correct
@@ -39,12 +44,15 @@ const PAGE_LIMIT = 10;
 const API_BASE_URL = "https://api.example.com";
 const NEGATIVE_ONE = -1;
 const DEFAULT_THEME = "dark";
+const PHONE_REGEX = /^[0-9]{10}$/;
+const EMAIL_PATTERN = new RegExp("^.+@.+$", "g");
+const BIG_LIMIT = 9007199254740993n;
 
 const isProduction = true;
 const hasAccess = false;
 const featureEnabled = true;
 
-const phoneRegex = /^[0-9]{10}$/;
+const dynamicPattern = new RegExp(userInput);
 const template = `hello world`;
 const skeletonItems = [1, 2, 3, 4, 5];
 const mapStyle = { height: "320px", width: "100%" };

--- a/src/rules/__tests__/enforce-constant-case.test.ts
+++ b/src/rules/__tests__/enforce-constant-case.test.ts
@@ -57,8 +57,32 @@ describe("enforce-constant-case", () => {
         name: "should ignore static template literals",
       },
       {
-        code: `const phoneRegex = /^[0-9]{10}$/;`,
-        name: "should ignore RegExp literals",
+        code: `const PHONE_REGEX = /^[0-9]{10}$/;`,
+        name: "should allow SCREAMING_SNAKE_CASE RegExp literal",
+      },
+      {
+        code: `const EMAIL_PATTERN = new RegExp("^.+@.+$");`,
+        name: "should allow SCREAMING_SNAKE_CASE new RegExp() constructor",
+      },
+      {
+        code: `const EMAIL_PATTERN = new RegExp("^.+@.+$", "g");`,
+        name: "should allow SCREAMING_SNAKE_CASE new RegExp() with flags",
+      },
+      {
+        code: `const dynamicPattern = new RegExp(userInput);`,
+        name: "should ignore new RegExp() with dynamic argument",
+      },
+      {
+        code: `const dynamicPattern = new RegExp(getPattern(), "i");`,
+        name: "should ignore new RegExp() with function-call argument",
+      },
+      {
+        code: `const BIG_LIMIT = 9007199254740993n;`,
+        name: "should allow SCREAMING_SNAKE_CASE bigint constant",
+      },
+      {
+        code: `const NEGATIVE_BIG = -1n;`,
+        name: "should allow SCREAMING_SNAKE_CASE for negative bigint",
       },
       {
         code: `const skeletonItems = [1, 2, 3, 4, 5];`,
@@ -200,6 +224,46 @@ describe("enforce-constant-case", () => {
           {
             messageId: "noSnakeCase",
             data: { name: "default_theme", suggestion: "DEFAULT_THEME" },
+          },
+        ],
+      },
+      {
+        code: `const phoneRegex = /^[0-9]{10}$/;`,
+        name: "should disallow camelCase for global RegExp literal",
+        errors: [
+          {
+            messageId: "useScreamingSnakeCase",
+            data: { name: "phoneRegex", suggestion: "PHONE_REGEX" },
+          },
+        ],
+      },
+      {
+        code: `const emailPattern = new RegExp("^.+@.+$");`,
+        name: "should disallow camelCase for global new RegExp() constructor",
+        errors: [
+          {
+            messageId: "useScreamingSnakeCase",
+            data: { name: "emailPattern", suggestion: "EMAIL_PATTERN" },
+          },
+        ],
+      },
+      {
+        code: `const bigLimit = 9007199254740993n;`,
+        name: "should disallow camelCase for global bigint constant",
+        errors: [
+          {
+            messageId: "useScreamingSnakeCase",
+            data: { name: "bigLimit", suggestion: "BIG_LIMIT" },
+          },
+        ],
+      },
+      {
+        code: `const negativeBig = -1n;`,
+        name: "should disallow camelCase for global negative bigint",
+        errors: [
+          {
+            messageId: "useScreamingSnakeCase",
+            data: { name: "negativeBig", suggestion: "NEGATIVE_BIG" },
           },
         ],
       },

--- a/src/rules/enforce-constant-case.ts
+++ b/src/rules/enforce-constant-case.ts
@@ -20,16 +20,30 @@ const toScreamingSnakeCase = (str: string): string =>
 
 const isMagicLiteral = (init: TSESTree.Expression): boolean => {
   if (init.type === AST_NODE_TYPES.Literal) {
-    return typeof init.value === "string" || typeof init.value === "number";
+    return (
+      typeof init.value === "string" ||
+      typeof init.value === "number" ||
+      typeof init.value === "bigint" ||
+      "regex" in init
+    );
   }
 
   if (init.type === AST_NODE_TYPES.UnaryExpression) {
     const { argument, operator } = init;
+    if (operator !== "-" && operator !== "+") {
+      return false;
+    }
     return (
-      (operator === "-" || operator === "+") &&
       argument.type === AST_NODE_TYPES.Literal &&
-      typeof argument.value === "number"
+      (typeof argument.value === "number" || typeof argument.value === "bigint")
     );
+  }
+
+  if (init.type === AST_NODE_TYPES.NewExpression) {
+    if (init.callee.type !== AST_NODE_TYPES.Identifier || init.callee.name !== "RegExp") {
+      return false;
+    }
+    return init.arguments.every((arg) => arg.type === AST_NODE_TYPES.Literal && typeof arg.value === "string");
   }
 
   return false;
@@ -54,7 +68,7 @@ const enforceConstantCase = createRule({
   meta: {
     type: "suggestion",
     docs: {
-      description: "Enforce SCREAMING_SNAKE_CASE for global magic-number and magic-text constants",
+      description: "Enforce SCREAMING_SNAKE_CASE for global magic-number, magic-text, bigint, and RegExp constants",
     },
     messages: {
       useScreamingSnakeCase: "Constant '{{ name }}' should use SCREAMING_SNAKE_CASE. Rename to '{{ suggestion }}'.",


### PR DESCRIPTION
## Summary

- Add SCREAMING_SNAKE_CASE enforcement for RegExp constants (`/foo/` and `new RegExp("foo", "g")`) and bigint literals (`100n`, `-1n`) at global scope.
- Refine `new RegExp(...)` detection: only flag when every argument is a string literal — `new RegExp(userInput)` and other dynamic constructors are intentionally ignored.
- Update rule docs, examples, and add tests for RegExp / bigint / dynamic-RegExp cases.

## Type of Change

- [x] New rule or rule enhancement
- [x] Documentation

## Test Plan

- [x] `pnpm test src/rules/__tests__/enforce-constant-case.test.ts` — 47 cases pass
- [x] `pnpm test` — full suite (1278 tests) passes
- [x] `pnpm typecheck` — clean
- [x] `pnpm eslint:check` — clean
- [x] Reproduced user scenarios (top-level, JSX arrow component, class method) via local repro test before deleting it

## Notes

Next.js App Router segment exports (`dynamic`, `revalidate`, `runtime`, ...) are not allowlisted in rule logic — consumers scope the rule away from `app/**` and `pages/**` in their flat config when needed (documented in `docs/rules/ENFORCE_CONSTANT_CASE.md`).